### PR TITLE
LTD-136: Fix parsing of datetime in template tags

### DIFF
--- a/core/builtins/custom_tags.py
+++ b/core/builtins/custom_tags.py
@@ -7,16 +7,16 @@ import re
 from collections import Counter, OrderedDict
 from html import escape
 
+from dateutil.parser import parse
 from dateutil.relativedelta import relativedelta
 
 from django import template
+from django.conf import settings
 from django.template.defaultfilters import stringfilter, safe, capfirst
-from django.templatetags.tz import do_timezone
+from django.templatetags.tz import localtime
 from django.utils.safestring import mark_safe
 
-from django.conf import settings
 from exporter.conf.constants import (
-    ISO8601_FMT,
     DATE_FORMAT,
     CASE_SECTIONS,
     PAGE_DATE_FORMAT,
@@ -97,7 +97,7 @@ def pluralize_lcs(items, string):
 @stringfilter
 def str_date(value):
     try:
-        return_value = do_timezone(datetime.datetime.strptime(value, ISO8601_FMT), "Europe/London")
+        return_value = localtime(parse(value))
         return (
             return_value.strftime("%-I:%M")
             + return_value.strftime("%p").lower()
@@ -112,8 +112,7 @@ def str_date(value):
 @stringfilter
 def str_date_only(value):
     if value != "None":
-        date_str = do_timezone(datetime.datetime.strptime(value, DATE_FORMAT), "Europe/London")
-        return date_str.strftime("%d %B %Y")
+        return localtime(parse(value)).strftime("%d %B %Y")
 
 
 @register.filter

--- a/exporter/core/helpers.py
+++ b/exporter/core/helpers.py
@@ -1,13 +1,12 @@
-import datetime
+from dateutil.parser import parse
 from html import escape
 from typing import List
 
 from django.template.defaultfilters import safe
-from django.templatetags.tz import do_timezone
+from django.templatetags.tz import localtime
 from django.utils.safestring import mark_safe
 
 from exporter.conf import decorators
-from exporter.conf.constants import ISO8601_FMT
 from core.builtins.custom_tags import default_na
 from exporter.organisation.roles.services import get_user_permissions
 
@@ -34,8 +33,7 @@ def str_to_bool(v, invert_none=False):
 
 
 def str_date_only(value):
-    return_value = do_timezone(datetime.datetime.strptime(value, ISO8601_FMT), "Europe/London")
-    return return_value.strftime("%d %B %Y")
+    return localtime(parse(value)).strftime("%d %B %Y")
 
 
 def generate_notification_string(notifications, case_types):


### PR DESCRIPTION
## Change description

The datetimes use current timezone by default (always aware) and the format
is failing to parse this resulting is no time displayed in UI.