### PR TITLE
Remove extra form field from licences filter + refactor exporter licences list page

### DIFF
--- a/exporter/apply_for_a_licence/forms/open_general_licences.py
+++ b/exporter/apply_for_a_licence/forms/open_general_licences.py
@@ -196,7 +196,9 @@ def open_general_licence_submit_success_page(request, **kwargs):
         includes="includes/open-general-licence.html",
         additional_context={"licence": open_general_licence},
         links={
-            OpenGeneralLicenceRegistration.Links.VIEW_OGLS_LINK: reverse_lazy("licences:licences")
+            OpenGeneralLicenceRegistration.Links.VIEW_OGLS_LINK: reverse_lazy(
+                "licences:list-open-and-standard-licences"
+            )
             + "?licence_type=open_general_licences",
             OpenGeneralLicenceRegistration.Links.APPLY_AGAIN: reverse_lazy("apply_for_a_licence:start"),
             OpenGeneralLicenceRegistration.Links.RETURN_TO_DASHBOARD: reverse_lazy("core:home"),

--- a/exporter/core/services.py
+++ b/exporter/core/services.py
@@ -189,7 +189,7 @@ def get_control_list_entries(request, convert_to_options=False, converted_contro
         else:
             data = client.get(request, "/static/control-list-entries/?flatten=True")
 
-        for control_list_entry in data.json().get("control_list_entries"):
+        for control_list_entry in data.json().get("control_list_entries", []):
             converted_control_list_entries_cache.append(
                 Option(
                     key=control_list_entry["rating"],

--- a/exporter/licences/filters.py
+++ b/exporter/licences/filters.py
@@ -1,25 +1,66 @@
-from exporter.core.services import get_control_list_entries, get_countries
-from lite_content.lite_exporter_frontend.licences import LicencesList
-from lite_forms.components import TextInput, AutocompleteInput, Checkboxes, Option
+from exporter.apply_for_a_licence.enums import OpenGeneralExportLicenceTypes
+from lite_content.lite_exporter_frontend.licences import LicencesList, OpenGeneralLicencesList
+from lite_forms.components import (
+    FiltersBar,
+    TextInput,
+    HiddenField,
+    Select,
+    Checkboxes,
+    Option,
+    AutocompleteInput,
+)
 
 
-def licences_filters(request):
-    return [
-        TextInput(name="reference", title=LicencesList.Filters.REFERENCE,),
-        AutocompleteInput(
-            name="clc",
-            title=LicencesList.Filters.CLC,
-            options=get_control_list_entries(request, convert_to_options=True),
-        ),
-        AutocompleteInput(
-            name="country",
-            title=LicencesList.Filters.DESTINATION_COUNTRY,
-            options=get_countries(request, convert_to_options=True),
-        ),
-        TextInput(name="end_user", title=LicencesList.Filters.DESTINATION_NAME,),
-        Checkboxes(
-            name="active_only",
-            options=[Option(key=True, value=LicencesList.Filters.ACTIVE)],
-            classes=["govuk-checkboxes--small"],
-        ),
-    ]
+def get_licences_filters(licence_type, control_list_entries, countries):
+    return FiltersBar(
+        [
+            TextInput(name="reference", title=LicencesList.Filters.REFERENCE,),
+            AutocompleteInput(name="clc", title=LicencesList.Filters.CLC, options=control_list_entries,),
+            AutocompleteInput(name="country", title=LicencesList.Filters.DESTINATION_COUNTRY, options=countries,),
+            TextInput(name="end_user", title=LicencesList.Filters.DESTINATION_NAME,),
+            Checkboxes(
+                name="active_only",
+                options=[Option(key=True, value=LicencesList.Filters.ACTIVE)],
+                classes=["govuk-checkboxes--small"],
+            ),
+            HiddenField(name="licence_type", value=licence_type),
+        ]
+    )
+
+
+def get_no_licence_required_filters(licence_type, control_list_entries, countries):
+    return FiltersBar(
+        [
+            TextInput(name="reference", title=LicencesList.Filters.REFERENCE,),
+            AutocompleteInput(name="clc", title=LicencesList.Filters.CLC, options=control_list_entries,),
+            AutocompleteInput(name="country", title=LicencesList.Filters.DESTINATION_COUNTRY, options=countries,),
+            TextInput(name="end_user", title=LicencesList.Filters.DESTINATION_NAME,),
+            HiddenField(name="licence_type", value=licence_type),
+        ]
+    )
+
+
+def get_open_general_licences_filters(licence_type, control_list_entries, countries, sites):
+    return FiltersBar(
+        [
+            TextInput(name="name", title=OpenGeneralLicencesList.Filters.NAME),
+            Select(
+                name="case_type",
+                title=OpenGeneralLicencesList.Filters.TYPE,
+                options=OpenGeneralExportLicenceTypes.as_options(),
+            ),
+            AutocompleteInput(
+                name="control_list_entry",
+                title=OpenGeneralLicencesList.Filters.CONTROL_LIST_ENTRY,
+                options=control_list_entries,
+            ),
+            AutocompleteInput(name="country", title=OpenGeneralLicencesList.Filters.COUNTRY, options=countries),
+            Select(name="site", title=OpenGeneralLicencesList.Filters.SITE, options=sites,),
+            Checkboxes(
+                name="active_only",
+                options=[Option(key=True, value=OpenGeneralLicencesList.Filters.ONLY_SHOW_ACTIVE)],
+                classes=["govuk-checkboxes--small"],
+            ),
+            HiddenField(name="licence_type", value=licence_type),
+        ]
+    )

--- a/exporter/licences/urls.py
+++ b/exporter/licences/urls.py
@@ -4,6 +4,9 @@ from exporter.licences import views
 
 app_name = "licences"
 urlpatterns = [
-    path("", views.Licences.as_view(), name="licences"),
+    path("", views.ListOpenAndStandardLicences.as_view(), name="list-open-and-standard-licences"),
+    path("no-licence-required/", views.ListNoLicenceRequired.as_view(), name="list-no-licence-required"),
+    path("clearances/", views.ListClearances.as_view(), name="list-clearances"),
+    path("open-general-licences/", views.ListOpenGeneralLicences.as_view(), name="list-open-general-licences"),
     path("<uuid:pk>/", views.Licence.as_view(), name="licence"),
 ]

--- a/exporter/licences/views.py
+++ b/exporter/licences/views.py
@@ -2,12 +2,13 @@ from http import HTTPStatus
 
 from django.http import Http404
 from django.shortcuts import render
+from django.template.response import TemplateResponse
 from django.views.generic import TemplateView
+from django.urls import reverse_lazy
 
-from exporter.apply_for_a_licence.enums import OpenGeneralExportLicenceTypes
 from exporter.core.objects import Tab
-from exporter.core.services import get_open_general_licences
-from exporter.licences.filters import licences_filters
+from exporter.core.services import get_open_general_licences, get_control_list_entries, get_countries
+from exporter.licences import filters
 from exporter.licences.helpers import (
     get_potential_ogl_control_list_entries,
     get_potential_ogl_countries,
@@ -15,100 +16,103 @@ from exporter.licences.helpers import (
 )
 from exporter.licences.services import get_licences, get_licence, get_nlr_letters
 from lite_content.lite_exporter_frontend.licences import LicencesList, LicencePage, OpenGeneralLicencesList
-from lite_forms.components import (
-    FiltersBar,
-    TextInput,
-    HiddenField,
-    Select,
-    Checkboxes,
-    Option,
-    AutocompleteInput,
-)
+
 from lite_forms.generators import error_page
 
 from core.auth.views import LoginRequiredMixin
 
 
-class Licences(LoginRequiredMixin, TemplateView):
-    type = None
-    data = None
-    filters = None
-    template = None
-    page = 1
+tabs = [
+    Tab(id="licences", name=LicencesList.Tabs.LICENCE, url=reverse_lazy("licences:list-open-and-standard-licences")),
+    Tab(
+        id="open_general_licences",
+        name=LicencesList.Tabs.OGLS,
+        url=reverse_lazy("licences:list-open-general-licences"),
+    ),
+    Tab(id="no_licence_required", name=LicencesList.Tabs.NLR, url=reverse_lazy("licences:list-no-licence-required"),),
+    Tab(id="clearances", name=LicencesList.Tabs.CLEARANCE, url=reverse_lazy("licences:list-clearances"),),
+]
 
-    def get_licences(self):
+
+class AbstractListView(LoginRequiredMixin, TemplateView):
+    @property
+    def params(self):
         params = self.request.GET.copy()
-        if "licence_type" in params:
-            params.pop("licence_type")
-        self.data = get_licences(
-            self.request, licence_type="licence" if self.type == "licences" else "clearance", **params
+        params.pop("licence_type", None)
+        return params
+
+    def get(self, *args, **kwargs):
+        self.page = int(self.request.GET.get("page", 1))
+        return super().get(*args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        return super().get_context_data(
+            selected_tab=self.object_name,
+            reference=self.request.GET.get("reference", ""),
+            name=self.request.GET.get("name", ""),
+            row_limit=3,
+            tabs=tabs,
+            **kwargs,
         )
-        self.filters = [
-            *licences_filters(self.request),
-            Checkboxes(
-                name="active_only",
-                options=[Option(key=True, value=LicencesList.Filters.ACTIVE)],
-                classes=["govuk-checkboxes--small"],
-            ),
-        ]
-        self.template = "licences"
 
-    def get_no_licence_required(self):
-        params = self.request.GET.copy()
-        params.pop("licence_type")
-        self.data = get_nlr_letters(self.request, **params)
-        self.filters = [*licences_filters(self.request)]
-        self.template = "nlrs"
+    @property
+    def control_list(self):
+        return get_control_list_entries(self.request, convert_to_options=True)
 
-    def get_open_general_licences(self):
-        params = self.request.GET.copy()
-        params.pop("licence_type")
-        self.data = get_open_general_licences(self.request, registered=True, **params)
-        control_list_entries = get_potential_ogl_control_list_entries(self.data)
-        countries = get_potential_ogl_countries(self.data)
-        sites = get_potential_ogl_sites(self.data)
-        self.filters = [
-            TextInput(name="name", title=OpenGeneralLicencesList.Filters.NAME),
-            Select(
-                name="case_type",
-                title=OpenGeneralLicencesList.Filters.TYPE,
-                options=OpenGeneralExportLicenceTypes.as_options(),
-            ),
-            AutocompleteInput(
-                name="control_list_entry",
-                title=OpenGeneralLicencesList.Filters.CONTROL_LIST_ENTRY,
-                options=control_list_entries,
-            ),
-            AutocompleteInput(name="country", title=OpenGeneralLicencesList.Filters.COUNTRY, options=countries),
-            Select(name="site", title=OpenGeneralLicencesList.Filters.SITE, options=sites,),
-            Checkboxes(
-                name="active_only",
-                options=[Option(key=True, value=OpenGeneralLicencesList.Filters.ONLY_SHOW_ACTIVE)],
-                classes=["govuk-checkboxes--small"],
-            ),
-        ]
-        self.template = "open-general-licences"
+    @property
+    def countries(self):
+        return get_countries(self.request, convert_to_options=True)
 
-    def get(self, request, **kwargs):
-        self.type = request.GET.get("licence_type", "licences")
-        self.page = int(request.GET.get("page", 1))
-        getattr(self, f"get_{self.type}", self.get_licences)()  # Set template properties
 
-        context = {
-            "data": self.data,
-            "filters": FiltersBar([*self.filters, HiddenField(name="licence_type", value=self.type)]),
-            "tabs": [
-                Tab("licences", LicencesList.Tabs.LICENCE, "?licence_type=licences"),
-                Tab("open_general_licences", LicencesList.Tabs.OGLS, "?licence_type=open_general_licences"),
-                Tab("no_licence_required", LicencesList.Tabs.NLR, "?licence_type=no_licence_required"),
-                Tab("clearances", LicencesList.Tabs.CLEARANCE, "?licence_type=clearances"),
-            ],
-            "selected_tab": self.type,
-            "reference": request.GET.get("reference", ""),
-            "name": request.GET.get("name", ""),
-            "row_limit": 3,
-        }
-        return render(request, f"licences/{self.template}.html", context)
+class ListOpenAndStandardLicences(AbstractListView):
+    template_name = "licences/licences.html"
+    object_name = "licences"
+
+    def get_context_data(self, **kwargs):
+        filter_bar = filters.get_licences_filters(
+            licence_type=self.object_name, control_list_entries=self.control_list, countries=self.countries
+        )
+        licences = get_licences(self.request, licence_type="licence")
+        return super().get_context_data(data=licences, filters=filter_bar, **kwargs)
+
+
+class ListClearances(AbstractListView):
+    template_name = "licences/licences.html"
+    object_name = "clearances"
+
+    def get_context_data(self, **kwargs):
+        filter_bar = filters.get_licences_filters(
+            licence_type=self.object_name, control_list_entries=self.control_list, countries=self.countries
+        )
+        clearances = get_licences(self.request, licence_type="clearance", **self.params)
+        return super().get_context_data(data=clearances, filters=filter_bar, **kwargs)
+
+
+class ListNoLicenceRequired(AbstractListView):
+    template_name = "licences/nlrs.html"
+    object_name = "no_licence_required"
+
+    def get_context_data(self, **kwargs):
+        letters = get_nlr_letters(self.request, **self.params)
+        filter_bar = filters.get_no_licence_required_filters(
+            licence_type=self.object_name, control_list_entries=self.control_list, countries=self.countries
+        )
+        return super().get_context_data(data=letters, filters=filter_bar, **kwargs)
+
+
+class ListOpenGeneralLicences(AbstractListView):
+    template_name = "licences/open-general-licences.html"
+    object_name = "open_general_licences"
+
+    def get_context_data(self, **kwargs):
+        licences = get_open_general_licences(self.request, registered=True, **self.params)
+        filter_bar = filters.get_open_general_licences_filters(
+            licence_type=self.object_name,
+            control_list_entries=get_potential_ogl_control_list_entries(licences),
+            countries=get_potential_ogl_countries(licences),
+            sites=get_potential_ogl_sites(licences),
+        )
+        return super().get_context_data(data=licences, filters=filter_bar, **kwargs)
 
 
 class Licence(LoginRequiredMixin, TemplateView):

--- a/exporter/licences/views.py
+++ b/exporter/licences/views.py
@@ -2,7 +2,6 @@ from http import HTTPStatus
 
 from django.http import Http404
 from django.shortcuts import render
-from django.template.response import TemplateResponse
 from django.views.generic import TemplateView
 from django.urls import reverse_lazy
 
@@ -15,7 +14,7 @@ from exporter.licences.helpers import (
     get_potential_ogl_sites,
 )
 from exporter.licences.services import get_licences, get_licence, get_nlr_letters
-from lite_content.lite_exporter_frontend.licences import LicencesList, LicencePage, OpenGeneralLicencesList
+from lite_content.lite_exporter_frontend.licences import LicencesList, LicencePage
 
 from lite_forms.generators import error_page
 

--- a/exporter/templates/core/hub.html
+++ b/exporter/templates/core/hub.html
@@ -64,7 +64,7 @@
 
 			{# View and manage licences tile #}
 			<div class="app-tile">
-				<a href="{% url 'licences:licences' %}" class="app-tile__heading" id="link-licences">
+				<a href="{% url 'licences:list-open-and-standard-licences' %}" class="app-tile__heading" id="link-licences">
 					{% lcs 'hub.Tiles.VIEW_AND_MANAGE_LICENCES' %}
 				</a>
 				<p class="app-tile__body">{% lcs 'hub.Tiles.Licences.DESCRIPTION' %}</p>

--- a/exporter/templates/licences/nlrs.html
+++ b/exporter/templates/licences/nlrs.html
@@ -35,7 +35,7 @@
 							<span class="govuk-table__header" aria-hidden="true">
 								{% lcs "licences.LicencesList.Table.APPLICATION_COLUMN" %}
 							</span>
-							<a href="{% url 'applications:application' licence.case_id %}?return_to={% url 'licences:licences' %}" class="govuk-link govuk-link--no-visited-state">{{ licence.case_reference }}</a>
+							<a href="{% url 'applications:application' licence.case_id %}?return_to={% url 'licences:list-open-and-standard-licences' %}" class="govuk-link govuk-link--no-visited-state">{{ licence.case_reference }}</a>
 						</td>
 						<td class="govuk-table__cell">
 							<span class="govuk-table__header" aria-hidden="true">

--- a/unit_tests/caseworker/conftest.py
+++ b/unit_tests/caseworker/conftest.py
@@ -636,7 +636,7 @@ def mock_case_statuses(requests_mock):
     yield data
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def authorized_client(client: Client, settings):
     """
     returns a factory to make a authorized client for a mock_gov_user,

--- a/unit_tests/exporter/conftest.py
+++ b/unit_tests/exporter/conftest.py
@@ -1,0 +1,84 @@
+import pytest
+
+from django.conf import settings
+from django.test import Client
+
+from core import client
+
+
+@pytest.fixture
+def mock_exporter_user(requests_mock):
+    url = client._build_absolute_uri("/users/authenticate/")
+    data = {
+        "user": {
+            "id": 123,
+            "email": "foo@example.com",
+            "first_name": "Foo",
+            "last_name": "Bar",
+            "status": "Active",
+            "token": "foo",
+            "lite_api_user_id": "d355428a-64cb-4347-853b-afcacee15d93",
+        }
+    }
+
+    requests_mock.get(url=url, json=data)
+    yield data
+
+
+@pytest.fixture
+def authorized_client(client: Client, settings):
+    """
+    returns a factory to make a authorized client for a mock_exporter_user,
+
+    the factory only expects the value of "user" inside the object returned by
+    the mock_exporter_user fixture
+    """
+
+    def _inner(user):
+        session = client.session
+        session["first_name"] = user["first_name"]
+        session["last_name"] = user["last_name"]
+        session["user_token"] = user["token"]
+        session["lite_api_user_id"] = user["lite_api_user_id"]
+        session[settings.TOKEN_SESSION_KEY] = {
+            "access_token": "mock_access_token",
+            "expires_in": 36000,
+            "token_type": "Bearer",
+            "scope": ["read", "write"],
+            "refresh_token": "mock_refresh_token",
+        }
+        session.save()
+        client.cookies[settings.SESSION_COOKIE_NAME] = session.session_key
+        return client
+
+    yield _inner
+
+
+@pytest.fixture
+def mock_control_list_entries(requests_mock):
+    url = client._build_absolute_uri("/static/control-list-entries/?flatten=True")
+    # in relity there are around 3000 CLCs
+    data = {
+        "control_list_entries": [
+            {"rating": "ML1", "text": "Smooth-bore weapons with a calibre of less than 20mm, other firearms..."},
+            {"rating": "ML1a", "text": "Rifles and combination guns, handguns, machine, sub-machine and volley guns"},
+        ]
+    }
+    requests_mock.get(url=url, json=data)
+    yield data
+
+
+@pytest.fixture
+def mock_countries(requests_mock):
+    url = client._build_absolute_uri("/static/countries/")
+    # in relity there are around 275 countries
+    data = {
+        "countries": [
+            {"id": "AE-AZ", "name": "Abu Dhabi", "type": "gov.uk Territory", "is_eu": False},
+            {"id": "AF", "name": "Afghanistan", "type": "gov.uk Country", "is_eu": False},
+            {"id": "AE-AJ", "name": "Ajman", "type": "gov.uk Territory", "is_eu": False},
+        ]
+    }
+
+    requests_mock.get(url=url, json=data)
+    yield data

--- a/unit_tests/exporter/licences/test_views.py
+++ b/unit_tests/exporter/licences/test_views.py
@@ -1,0 +1,180 @@
+import pytest
+
+from django.urls import reverse
+
+from core.client import _build_absolute_uri
+
+
+@pytest.fixture
+def data_list_no_licence_required():
+    return [
+        {
+            "count": 1,
+            "total_pages": 1,
+            "results": [
+                {
+                    "id": "66297b19-8753-4f37-8b6d-833b8f28727b",
+                    "name": "rich-b82a61ea-3611-4504-9477-70e75-3b1ab.pdf",
+                    "case_id": "f6911b67-c7ca-4e56-a11e-bf8194e9c6af",
+                    "case_reference": "GBSIEL/2020/0003427/P",
+                    "goods": [
+                        {
+                            "description": "Lentils",
+                            "control_list_entries": [
+                                {
+                                    "rating": "ML1a",
+                                    "text": "Rifles and combination guns, handguns, machine, sub-machine and volley...",
+                                }
+                            ],
+                        }
+                    ],
+                    "destinations": [
+                        {"party_name": "Tim Time", "country_name": "Ukraine"},
+                        {"party_name": "Foo Bar", "country_name": "United Kingdom"},
+                        {"party_name": "Dr. Bar Baz", "country_name": "United Kingdom"},
+                        {"party_name": "April May", "country_name": "United Kingdom"},
+                    ],
+                    "advice_type": "no_licence_required",
+                }
+            ],
+        }
+    ]
+
+
+@pytest.fixture
+def data_list_open_general_licences():
+    return [
+        {
+            "id": "3c3c01eb-1b49-4e50-a25d-1d1a0f263a74",
+            "name": "aggregate out-of-the-box experiences",
+            "description": "Talk standard evening happen blue information color population. Fly direction oil type team night.",
+            "url": "https://www.gov.uk/government/publications/open-general-export-licence-military-goods-government-or-nato-end-use--6",
+            "case_type": {
+                "id": "00000000-0000-0000-0000-000000000002",
+                "reference": {"key": "ogel", "value": "Open General Export Licence"},
+                "type": {"key": "registration", "value": "Registration"},
+                "sub_type": {"key": "open", "value": "Open Licence"},
+            },
+            "countries": [{"id": "GB", "name": "United Kingdom", "type": "gov.uk Country", "is_eu": True}],
+            "control_list_entries": [
+                {
+                    "rating": "ML1a",
+                    "text": "Rifles and combination guns, handguns, machine, sub-machine and volley guns",
+                }
+            ],
+            "registration_required": True,
+            "status": {"key": "active", "value": "Active"},
+            "registrations": [],
+            "created_at": "2020-08-18T20:42:27.985942+01:00",
+            "updated_at": "2020-08-18T20:42:27.985942+01:00",
+        }
+    ]
+
+
+@pytest.fixture
+def data_list_licences():
+    return {
+        "count": 1,
+        "total_pages": 1,
+        "results": [
+            {
+                "id": "8379b6ba-06eb-4e0a-9331-c3adc650d4d0",
+                "reference_code": "GBSIEL/2020/0002409/T",
+                "status": {"key": "issued", "value": "Issued"},
+                "application": {
+                    "id": "02e181f4-a35c-441e-afee-cd9fe5fde26b",
+                    "name": "25/09 - application 2",
+                    "destinations": [
+                        {
+                            "name": "Jim",
+                            "address": "Jim",
+                            "country": {"id": "TN", "name": "Tunisia", "type": "gov.uk Country", "is_eu": False},
+                        }
+                    ],
+                    "documents": [
+                        {
+                            "advice_type": {"key": "approve", "value": "Approve"},
+                            "id": "be7d9a9a-c66c-4dec-88dc-462ec836d538",
+                        }
+                    ],
+                },
+                "goods": [
+                    {
+                        "good_on_application_id": "3bcfd636-da6b-4458-a812-f78af77cc8ba",
+                        "usage": 0.0,
+                        "description": "Example product",
+                        "units": {"key": "MTR", "value": "Metre(s)"},
+                        "applied_for_quantity": 1.0,
+                        "applied_for_value": 1.0,
+                        "licenced_quantity": 1.0,
+                        "licenced_value": 1.0,
+                        "applied_for_value_per_item": 1.0,
+                        "licenced_value_per_item": 1.0,
+                        "control_list_entries": [],
+                        "advice": {"type": {"key": "approve", "value": "Approve"}, "text": "", "proviso": None},
+                    }
+                ],
+            }
+        ],
+    }
+
+
+@pytest.fixture(autouse=True)
+def mock_list_licences(requests_mock, data_list_licences):
+    url = _build_absolute_uri("/licences/?page=1")
+    return requests_mock.get(url=url, json=data_list_licences)
+
+
+@pytest.fixture(autouse=True)
+def mock_list_no_licence_required(data_list_no_licence_required, requests_mock):
+    url = _build_absolute_uri("/licences/nlrs/?page=1")
+    return requests_mock.get(url=url, json=data_list_no_licence_required)
+
+
+@pytest.fixture(autouse=True)
+def mock_list_open_general_licences(data_list_open_general_licences, requests_mock):
+    url = _build_absolute_uri(
+        "/open-general-licences/?convert_to_options=False&registered=True&disable_pagination=True"
+    )
+    return requests_mock.get(url=url, json=data_list_open_general_licences)
+
+
+@pytest.fixture
+def client(authorized_client, mock_exporter_user, mock_control_list_entries, mock_countries):
+    return authorized_client(mock_exporter_user["user"])
+
+
+def test_open_and_standard_licences(client, data_list_licences):
+    expected_filters = ["reference", "clc", "country", "end_user", "active_only", "licence_type"]
+
+    response = client.get(reverse("licences:list-open-and-standard-licences"))
+    assert response.status_code == 200
+    assert response.context_data["data"] == data_list_licences
+    assert [item.name for item in response.context_data["filters"].filters] == expected_filters
+
+
+def test_open_general_licences(client, data_list_open_general_licences):
+    expected_filters = ["name", "case_type", "control_list_entry", "country", "site", "active_only", "licence_type"]
+
+    response = client.get(reverse("licences:list-open-general-licences"))
+    assert response.status_code == 200
+    assert response.context_data["data"] == data_list_open_general_licences
+    assert [item.name for item in response.context_data["filters"].filters] == expected_filters
+
+
+def test_no_licenece_required(client, data_list_no_licence_required):
+    expected_filters = ["reference", "clc", "country", "end_user", "licence_type"]
+
+    response = client.get(reverse("licences:list-no-licence-required"))
+    assert response.status_code == 200
+    assert response.context_data["data"] == data_list_no_licence_required
+    assert [item.name for item in response.context_data["filters"].filters] == expected_filters
+
+
+def test_clearances(client, data_list_licences):
+    expected_filters = ["reference", "clc", "country", "end_user", "active_only", "licence_type"]
+
+    response = client.get(reverse("licences:list-clearances"))
+    assert response.status_code == 200
+    assert response.context_data["data"] == data_list_licences
+    assert [item.name for item in response.context_data["filters"].filters] == expected_filters


### PR DESCRIPTION
the licences view was four views mushed into one. I've seperated them.
![licences](https://user-images.githubusercontent.com/5485798/94584197-3b58bd80-0276-11eb-8438-7410bf091eec.gif)
