### PR TITLE
Fix assertion on case finalise

### DIFF
--- a/caseworker/templates/components/goods-licence-reissue-list.html
+++ b/caseworker/templates/components/goods-licence-reissue-list.html
@@ -1,5 +1,7 @@
 {% load humanize %}
 
+{% load svg static %}
+
 <table class="govuk-table">
 	<thead class="govuk-table__head">
 		<tr class="govuk-table__row">

--- a/ui_tests/caseworker/step_defs/test_finalise_case.py
+++ b/ui_tests/caseworker/step_defs/test_finalise_case.py
@@ -44,9 +44,7 @@ def applied_for_goods_details(driver, context):
     page = GrantLicencePage(driver)
     good_on_app_id = context.goods[0]["id"]
     assert context.goods[0]["quantity"] == float(page.get_good_quantity(good_on_app_id))
-    assert round(float(context.goods[0]["value"]) * context.goods[0]["quantity"], 2) == float(
-        page.get_good_value(good_on_app_id)
-    )
+    assert float(context.goods[0]["value"]) == float(page.get_good_value(good_on_app_id))
     date_in_form = GrantLicencePage(driver).get_date_in_date_entry()
     today = date.today()
     assert today.day == int(date_in_form["day"])


### PR DESCRIPTION
The value is actually the total value, not the unit value.
API changes done to reflect that, this changes updates the test.

Another change is related to template error complaining about `javascript` block not being recognised.