### PR TITLE
Bug: Change ?goods to ?good_ids in get param for review goods wizard

### DIFF
--- a/caseworker/cases/helpers/advice.py
+++ b/caseworker/cases/helpers/advice.py
@@ -40,7 +40,9 @@ def get_param_destinations(request, case: Case):
 
 
 def get_param_goods(request, case: Case):
-    selected_goods_ids = request.GET.getlist("goods", request.GET.getlist("goods_types"))
+    selected_goods_ids = request.GET.getlist(
+        "goods", request.GET.getlist("goods_types", request.GET.getlist("good_ids"))
+    )
     goods = case.data.get("goods", case.data.get("goods_types"))
     return_values = []
 

--- a/caseworker/cases/views/goods.py
+++ b/caseworker/cases/views/goods.py
@@ -99,7 +99,7 @@ class AbstractReviewGoodWizardView(SessionWizardView):
 
 
 class ReviewStandardApplicationGoodWizardView(AbstractReviewGoodWizardView):
-    object_name = "goods"
+    object_name = "good_ids"
     template_name = "case/review-good-standard.html"
 
     @property

--- a/caseworker/templates/case/slices/goods.html
+++ b/caseworker/templates/case/slices/goods.html
@@ -57,7 +57,7 @@
 						{% if not hide_checkboxes %}
 							<td class="govuk-table__cell govuk-table__cell--checkbox {% if show_advice %}lite-!-no-border{% endif %}">
 								<div>
-									<input class="govuk-checkboxes__input" type="checkbox" name="goods" value="{{ good.good.id }}" id="{{ good.id }}">
+									<input class="govuk-checkboxes__input" type="checkbox" name="good_ids" value="{{ good.good.id }}" id="{{ good.id }}">
 									<label class="govuk-label govuk-checkboxes__label" for="{{ good.good.id }}">{{ forloop.counter }}</label>
 								</div>
 							</td>

--- a/unit_tests/caseworker/cases/test_views.py
+++ b/unit_tests/caseworker/cases/test_views.py
@@ -118,11 +118,11 @@ def test_standard_review_goods(
     )
     url = reverse("cases:review_standard_application_goods", kwargs={"queue_pk": queue_pk, "pk": standard_case_pk})
 
-    response = authorized_client.get(f"{url}?goods={good_pk}")
+    response = authorized_client.get(f"{url}?good_ids={good_pk}")
 
     assert response.status_code == 200
 
-    response = authorized_client.post(f"{url}?goods={good_pk}", step_data)
+    response = authorized_client.post(f"{url}?good_ids={good_pk}", step_data)
 
     assert response.status_code == 302
     assert requests_mock_instance.call_count == 1


### PR DESCRIPTION
This query parameter was triggering the cloudfround WAF and causing requests to
be blocked.