### PR TITLE
LTD-305: Attach documents to ECJU query response

### DIFF
--- a/caseworker/cases/forms/respond_to_good_query.py
+++ b/caseworker/cases/forms/respond_to_good_query.py
@@ -76,7 +76,7 @@ def respond_to_clc_query_form(request, queue_pk, case):
                 ],
             ),
             DetailComponent(
-                title=CLCReviewGoods.COMMENT, components=[TextArea(name="comment", extras={"max_length": 500,}),],
+                title=PVGradingForm.COMMENT, components=[TextArea(name="comment", extras={"max_length": 500,},),],
             ),
         ],
         default_button_name=CLCReviewGoods.SUBMIT_BUTTON,
@@ -123,10 +123,20 @@ def respond_to_grading_query_form(request, queue_pk, case):
                 classes=["app-pv-grading-inputs"],
             ),
             DetailComponent(
-                title=PVGradingForm.COMMENT, components=[TextArea(name="comment", extras={"max_length": 500,}),],
+                title=PVGradingForm.COMMENT,
+                components=[
+                    TextArea(
+                        name="comment",
+                        extras={
+                            "max_length": 500,
+                        },
+                    ),
+                ],
             ),
         ],
         default_button_name=PVGradingForm.SUBMIT_BUTTON,
-        back_link=BackLink(url=reverse_lazy("cases:case", kwargs={"queue_pk": queue_pk, "pk": case["id"]}),),
+        back_link=BackLink(
+            url=reverse_lazy("cases:case", kwargs={"queue_pk": queue_pk, "pk": case["id"]}),
+        ),
         container="case",
     )

--- a/caseworker/cases/forms/respond_to_good_query.py
+++ b/caseworker/cases/forms/respond_to_good_query.py
@@ -76,11 +76,21 @@ def respond_to_clc_query_form(request, queue_pk, case):
                 ],
             ),
             DetailComponent(
-                title=PVGradingForm.COMMENT, components=[TextArea(name="comment", extras={"max_length": 500,},),],
+                title=PVGradingForm.COMMENT,
+                components=[
+                    TextArea(
+                        name="comment",
+                        extras={
+                            "max_length": 500,
+                        },
+                    ),
+                ],
             ),
         ],
         default_button_name=CLCReviewGoods.SUBMIT_BUTTON,
-        back_link=BackLink(url=reverse_lazy("cases:case", kwargs={"queue_pk": queue_pk, "pk": case["id"]}),),
+        back_link=BackLink(
+            url=reverse_lazy("cases:case", kwargs={"queue_pk": queue_pk, "pk": case["id"]}),
+        ),
         container="case",
     )
 

--- a/caseworker/templates/case/tabs/ecju-queries.html
+++ b/caseworker/templates/case/tabs/ecju-queries.html
@@ -67,6 +67,9 @@
 								<div class="app-documents__item-details">
 									<a {% if document.safe == True %}href="{% url 'cases:document' queue_pk=queue.id  pk=case.id file_pk=document.id %}"
 										{% endif %} class="govuk-link--no-visited-state">{{ document.name }}</a>
+									{% if document.description %}
+									<p class="govuk-body">{{ document.description }}</p>
+									{% endif %}
 								</div>
 							</li>
 						{% endfor %}

--- a/caseworker/templates/case/tabs/ecju-queries.html
+++ b/caseworker/templates/case/tabs/ecju-queries.html
@@ -1,3 +1,5 @@
+{% load svg %}
+
 <div class="lite-buttons-row">
 	{% make_list queue.id case.id as button_params %}
 	{% govuk_link_button id='new-query' text='cases.EcjuQueries.AddQuery.ADD_BUTTON_LABEL' url='cases:new_ecju_query' url_param=button_params query_params="?query_type=ecju_query"%}
@@ -52,6 +54,24 @@
 					<div class="app-ecju-query__text" data-max-length="300">
 						{{ ecju_query.response }}
 					</div>
+					{% if ecju_query.documents %}
+						{% for document in ecju_query.documents %}
+							<br>
+							<li class="app-documents__item govuk-!-margin-top-2">
+								<div class="app-documents__item-preview">
+									{% svg 'document' %}
+									<span>
+										{{ document.name|file_type }}
+									</span>
+								</div>
+								<div class="app-documents__item-details">
+									<a {% if document.safe == True %}href="{% url 'cases:document' queue_pk=queue.id  pk=case.id file_pk=document.id %}"
+										{% endif %} class="govuk-link--no-visited-state">{{ document.name }}</a>
+								</div>
+							</li>
+						{% endfor %}
+					{% endif %}
+
 					<p class="app-ecju-query__date">
 						<span class="govuk-visually-hidden">{% lcs 'cases.EcjuQueries.CREATED_AT' %} </span>{{ ecju_query.responded_at|str_date }}
 					</p>

--- a/core/assets/javascripts/query-response.js
+++ b/core/assets/javascripts/query-response.js
@@ -1,0 +1,18 @@
+const MIN_LENGTH = 1;
+const VISIBLE_LENGTH = 1000;
+const MAX_LENGTH = 2200;
+
+$("#response").on("input propertychange paste", function() {
+	if ($(this).val().length > VISIBLE_LENGTH) {
+		$("#response-length-warning").text("You have " + (MAX_LENGTH - $(this).val().length) + " character" + pluralize(MAX_LENGTH - $(this).val().length) + " remaining");
+	} else {
+		$("#response-length-warning").text("You can enter up to " + MAX_LENGTH + " characters");
+	}
+
+	if ($(this).val().length > MAX_LENGTH) {
+		$("#response-length-warning").text("You have " + ($(this).val().length - MAX_LENGTH) + " character" + pluralize($(this).val().length - MAX_LENGTH) + " too many");
+		$("#response-text-container").addClass("govuk-form-group--error");
+	} else {
+		$("#response-text-container").removeClass("govuk-form-group--error");
+	}
+});

--- a/exporter/applications/views/goods.py
+++ b/exporter/applications/views/goods.py
@@ -130,7 +130,7 @@ class CheckDocumentGrading(LoginRequiredMixin, SingleFormView):
     def init(self, request, **kwargs):
         self.draft_pk = kwargs["pk"]
         self.object_pk = kwargs["good_pk"]
-        self.form = document_grading_form(request, self.object_pk)
+        self.form = document_grading_form(request, reverse_lazy("goods:good", kwargs={"pk": self.object_pk}))
         self.action = post_good_document_sensitivity
 
     def get_success_url(self):

--- a/exporter/ecju_queries/forms.py
+++ b/exporter/ecju_queries/forms.py
@@ -1,6 +1,19 @@
-from lite_forms.components import Form, HTMLBlock, TextArea, HiddenField, BackLink
+from lite_forms.components import (
+    Form,
+    HTMLBlock,
+    TextArea,
+    HiddenField,
+    BackLink,
+    RadioButtons,
+    Select,
+    Option,
+    Label,
+    Button,
+    FileUpload,
+)
 from lite_forms.generators import confirm_form
 from lite_content.lite_exporter_frontend import ecju_queries
+from exporter.ecju_queries.services import get_ecju_query_document_missing_reasons
 
 
 def respond_to_query_form(back_link, ecju_query):
@@ -16,11 +29,16 @@ def respond_to_query_form(back_link, ecju_query):
                 name="response",
                 title=ecju_queries.Forms.RespondForm.RESPONSE,
                 description="",
-                extras={"max_length": 2200,},
+                extras={
+                    "max_length": 2200,
+                },
             ),
             HiddenField(name="form_name", value="respond_to_query"),
         ],
-        back_link=BackLink(ecju_queries.Forms.RespondForm.BACK_LINK, back_link,),
+        back_link=BackLink(
+            ecju_queries.Forms.RespondForm.BACK_LINK,
+            back_link,
+        ),
     )
 
 
@@ -34,4 +52,54 @@ def ecju_query_respond_confirmation_form(edit_response_url):
         back_link_text=ecju_queries.Forms.ConfirmResponseForm.BACK_LINK,
         back_url=edit_response_url,
         submit_button_text=ecju_queries.Forms.ConfirmResponseForm.SUBMIT_BTN,
+    )
+
+
+def document_grading_form(request, back_link):
+    select_options = get_ecju_query_document_missing_reasons(request)[0]["reasons"]
+    doc_sensitivity_form = ecju_queries.SupportingDocumentSensitivityForm
+
+    return Form(
+        title=doc_sensitivity_form.TITLE,
+        description=doc_sensitivity_form.DESCRIPTION,
+        questions=[
+            RadioButtons(
+                name="has_document_to_upload",
+                options=[
+                    Option(key="yes", value=doc_sensitivity_form.Options.YES),
+                    Option(
+                        key="no",
+                        value=doc_sensitivity_form.Options.NO,
+                        components=[
+                            Label(text=doc_sensitivity_form.ECJU_HELPLINE),
+                            Select(
+                                name="missing_document_reason",
+                                title=doc_sensitivity_form.LABEL,
+                                options=select_options,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+        back_link=BackLink(doc_sensitivity_form.BACK_BUTTON, back_link),
+        default_button_name=doc_sensitivity_form.SUBMIT_BUTTON,
+    )
+
+
+def upload_documents_form(back_link):
+    return Form(
+        title=ecju_queries.UploadDocumentForm.TITLE,
+        description=ecju_queries.UploadDocumentForm.DESCRIPTION,
+        questions=[
+            FileUpload(),
+            TextArea(
+                title=ecju_queries.UploadDocumentForm.Description.TITLE,
+                optional=True,
+                name="description",
+                extras={"max_length": 280},
+            ),
+        ],
+        buttons=[Button(ecju_queries.UploadDocumentForm.BUTTON, "submit")],
+        back_link=back_link,
     )

--- a/exporter/ecju_queries/forms.py
+++ b/exporter/ecju_queries/forms.py
@@ -4,16 +4,11 @@ from lite_forms.components import (
     TextArea,
     HiddenField,
     BackLink,
-    RadioButtons,
-    Select,
-    Option,
-    Label,
     Button,
     FileUpload,
 )
 from lite_forms.generators import confirm_form
 from lite_content.lite_exporter_frontend import ecju_queries
-from exporter.ecju_queries.services import get_ecju_query_document_missing_reasons
 
 
 def respond_to_query_form(back_link, ecju_query):
@@ -29,16 +24,11 @@ def respond_to_query_form(back_link, ecju_query):
                 name="response",
                 title=ecju_queries.Forms.RespondForm.RESPONSE,
                 description="",
-                extras={
-                    "max_length": 2200,
-                },
+                extras={"max_length": 2200},
             ),
             HiddenField(name="form_name", value="respond_to_query"),
         ],
-        back_link=BackLink(
-            ecju_queries.Forms.RespondForm.BACK_LINK,
-            back_link,
-        ),
+        back_link=BackLink(ecju_queries.Forms.RespondForm.BACK_LINK, back_link),
     )
 
 
@@ -52,38 +42,6 @@ def ecju_query_respond_confirmation_form(edit_response_url):
         back_link_text=ecju_queries.Forms.ConfirmResponseForm.BACK_LINK,
         back_url=edit_response_url,
         submit_button_text=ecju_queries.Forms.ConfirmResponseForm.SUBMIT_BTN,
-    )
-
-
-def document_grading_form(request, back_link):
-    select_options = get_ecju_query_document_missing_reasons(request)[0]["reasons"]
-    doc_sensitivity_form = ecju_queries.SupportingDocumentSensitivityForm
-
-    return Form(
-        title=doc_sensitivity_form.TITLE,
-        description=doc_sensitivity_form.DESCRIPTION,
-        questions=[
-            RadioButtons(
-                name="has_document_to_upload",
-                options=[
-                    Option(key="yes", value=doc_sensitivity_form.Options.YES),
-                    Option(
-                        key="no",
-                        value=doc_sensitivity_form.Options.NO,
-                        components=[
-                            Label(text=doc_sensitivity_form.ECJU_HELPLINE),
-                            Select(
-                                name="missing_document_reason",
-                                title=doc_sensitivity_form.LABEL,
-                                options=select_options,
-                            ),
-                        ],
-                    ),
-                ],
-            ),
-        ],
-        back_link=BackLink(doc_sensitivity_form.BACK_BUTTON, back_link),
-        default_button_name=doc_sensitivity_form.SUBMIT_BUTTON,
     )
 
 

--- a/exporter/ecju_queries/services.py
+++ b/exporter/ecju_queries/services.py
@@ -1,5 +1,4 @@
 from core import client
-from http import HTTPStatus
 
 
 def get_ecju_query(request, pk, query_pk):
@@ -43,9 +42,6 @@ def post_ecju_query_document_sensitivity(request, pk, query_pk, json):
 
 
 def post_ecju_query_document(request, pk, query_pk, json):
-    if "description" not in json:
-        json["description"] = ""
-    json = [json]
-
-    data = client.post(request, f"/cases/{pk}/ecju-queries/{query_pk}/document/", json)
-    return data.json(), data.status_code
+    response = client.post(request, f"/cases/{pk}/ecju-queries/{query_pk}/document/", json)
+    response.raise_for_status()
+    return response.json(), response.status_code

--- a/exporter/ecju_queries/services.py
+++ b/exporter/ecju_queries/services.py
@@ -30,17 +30,6 @@ def delete_ecju_query_document(request, pk, query_pk, doc_pk):
     return response.json(), response.status_code
 
 
-def get_ecju_query_document_missing_reasons(request):
-    response = client.get(request, "/static/missing-document-reasons/ecju-query")
-    response.raise_for_status()
-    return response.json(), response.status_code
-
-
-def post_ecju_query_document_sensitivity(request, pk, query_pk, json):
-    response = client.post(request, f"/cases/{pk}/ecju-queries/{query_pk}/document-sensitivity/", json)
-    return response.json(), response.status_code
-
-
 def post_ecju_query_document(request, pk, query_pk, json):
     response = client.post(request, f"/cases/{pk}/ecju-queries/{query_pk}/document/", json)
     response.raise_for_status()

--- a/exporter/ecju_queries/services.py
+++ b/exporter/ecju_queries/services.py
@@ -20,5 +20,13 @@ def get_ecju_query_document_missing_reasons(request):
 
 def post_ecju_query_document_sensitivity(request, pk, query_pk, json):
     response = client.post(request, f"/cases/{pk}/ecju-queries/{query_pk}/document-sensitivity/", json)
-    response.raise_for_status()
     return response.json(), response.status_code
+
+
+def post_ecju_query_document(request, pk, query_pk, json):
+    if "description" not in json:
+        json["description"] = ""
+    json = [json]
+
+    data = client.post(request, f"/cases/{pk}/ecju-queries/{query_pk}/document/", json)
+    return data.json(), data.status_code

--- a/exporter/ecju_queries/services.py
+++ b/exporter/ecju_queries/services.py
@@ -1,4 +1,5 @@
 from core import client
+from http import HTTPStatus
 
 
 def get_ecju_query(request, pk, query_pk):
@@ -11,7 +12,19 @@ def put_ecju_query(request, pk, query_pk, json):
     return data.json(), data.status_code
 
 
-# Document Sensitivity
+# Document
+def get_ecju_query_document(request, pk, query_pk, doc_pk):
+    response = client.get(request, f"/cases/{pk}/ecju-queries/{query_pk}/document/{doc_pk}/")
+    response.raise_for_status()
+    return response.json().get("document")
+
+
+def get_ecju_query_documents(request, pk, query_pk):
+    response = client.get(request, f"/cases/{pk}/ecju-queries/{query_pk}/document/")
+    response.raise_for_status()
+    return response.json().get("documents")
+
+
 def get_ecju_query_document_missing_reasons(request):
     response = client.get(request, "/static/missing-document-reasons/ecju-query")
     response.raise_for_status()

--- a/exporter/ecju_queries/services.py
+++ b/exporter/ecju_queries/services.py
@@ -25,6 +25,12 @@ def get_ecju_query_documents(request, pk, query_pk):
     return response.json().get("documents")
 
 
+def delete_ecju_query_document(request, pk, query_pk, doc_pk):
+    response = client.delete(request, f"/cases/{pk}/ecju-queries/{query_pk}/document/{doc_pk}/")
+    response.raise_for_status()
+    return response.json(), response.status_code
+
+
 def get_ecju_query_document_missing_reasons(request):
     response = client.get(request, "/static/missing-document-reasons/ecju-query")
     response.raise_for_status()

--- a/exporter/ecju_queries/services.py
+++ b/exporter/ecju_queries/services.py
@@ -9,3 +9,16 @@ def get_ecju_query(request, pk, query_pk):
 def put_ecju_query(request, pk, query_pk, json):
     data = client.put(request, f"/cases/{pk}/ecju-queries/{query_pk}/", json)
     return data.json(), data.status_code
+
+
+# Document Sensitivity
+def get_ecju_query_document_missing_reasons(request):
+    response = client.get(request, "/static/missing-document-reasons/ecju-query")
+    response.raise_for_status()
+    return response.json(), response.status_code
+
+
+def post_ecju_query_document_sensitivity(request, pk, query_pk, json):
+    response = client.post(request, f"/cases/{pk}/ecju-queries/{query_pk}/document-sensitivity/", json)
+    response.raise_for_status()
+    return response.json(), response.status_code

--- a/exporter/ecju_queries/urls.py
+++ b/exporter/ecju_queries/urls.py
@@ -21,4 +21,14 @@ urlpatterns = [
         views.UploadDocuments.as_view(),
         name="upload_document",
     ),
+    path(
+        "<uuid:query_pk>/<str:object_type>/<uuid:case_pk>/document/<uuid:doc_pk>",
+        views.QueryDocument.as_view(),
+        name="query-document",
+    ),
+    path(
+        "<uuid:query_pk>/<str:object_type>/<uuid:case_pk>/document/<uuid:doc_pk>/delete/",
+        views.QueryDocumentDelete.as_view(),
+        name="query-document-delete",
+    ),
 ]

--- a/exporter/ecju_queries/urls.py
+++ b/exporter/ecju_queries/urls.py
@@ -13,13 +13,8 @@ urlpatterns = [
     ),
     path(
         "<uuid:query_pk>/<str:object_type>/<uuid:extra_pk>/case/<uuid:case_pk>/add-document/",
-        views.CheckDocumentGrading.as_view(),
-        name="add_supporting_document",
-    ),
-    path(
-        "<uuid:query_pk>/<str:object_type>/<uuid:extra_pk>/case/<uuid:case_pk>/upload-document/",
         views.UploadDocuments.as_view(),
-        name="upload_document",
+        name="add_supporting_document",
     ),
     path(
         "<uuid:query_pk>/<str:object_type>/<uuid:case_pk>/document/<uuid:doc_pk>",
@@ -27,7 +22,7 @@ urlpatterns = [
         name="query-document",
     ),
     path(
-        "<uuid:query_pk>/<str:object_type>/<uuid:case_pk>/document/<uuid:doc_pk>/delete/",
+        "<uuid:query_pk>/<str:object_type>/<uuid:extra_pk>/case/<uuid:case_pk>/document/<uuid:doc_pk>/delete/",
         views.QueryDocumentDelete.as_view(),
         name="query-document-delete",
     ),

--- a/exporter/ecju_queries/urls.py
+++ b/exporter/ecju_queries/urls.py
@@ -17,7 +17,7 @@ urlpatterns = [
         name="add_supporting_document",
     ),
     path(
-        "<uuid:query_pk>/<str:object_type>/<uuid:case_pk>/upload-document/",
+        "<uuid:query_pk>/<str:object_type>/<uuid:extra_pk>/case/<uuid:case_pk>/upload-document/",
         views.UploadDocuments.as_view(),
         name="upload_document",
     ),

--- a/exporter/ecju_queries/urls.py
+++ b/exporter/ecju_queries/urls.py
@@ -12,7 +12,7 @@ urlpatterns = [
         name="respond_to_query_extra",
     ),
     path(
-        "<uuid:query_pk>/<str:object_type>/<uuid:case_pk>/add-document/",
+        "<uuid:query_pk>/<str:object_type>/<uuid:extra_pk>/case/<uuid:case_pk>/add-document/",
         views.CheckDocumentGrading.as_view(),
         name="add_supporting_document",
     ),

--- a/exporter/ecju_queries/urls.py
+++ b/exporter/ecju_queries/urls.py
@@ -11,4 +11,14 @@ urlpatterns = [
         views.RespondToQuery.as_view(),
         name="respond_to_query_extra",
     ),
+    path(
+        "<uuid:query_pk>/<str:object_type>/<uuid:case_pk>/add-document/",
+        views.CheckDocumentGrading.as_view(),
+        name="add_supporting_document",
+    ),
+    path(
+        "<uuid:query_pk>/<str:object_type>/<uuid:case_pk>/upload-document/",
+        views.UploadDocuments.as_view(),
+        name="upload_document",
+    ),
 ]

--- a/exporter/ecju_queries/views.py
+++ b/exporter/ecju_queries/views.py
@@ -27,7 +27,6 @@ from exporter.goods.services import get_good
 from lite_content.lite_exporter_frontend import strings, ecju_queries
 from lite_forms.components import HiddenField, BackLink
 from lite_forms.generators import form_page, error_page
-from lite_forms.views import SingleFormView
 
 from core.auth.views import LoginRequiredMixin
 

--- a/exporter/goods/forms.py
+++ b/exporter/goods/forms.py
@@ -362,7 +362,7 @@ def edit_good_detail_form(request, good_id):
     )
 
 
-def document_grading_form(request, good_id):
+def document_grading_form(request, back_link):
     select_options = get_document_missing_reasons(request)[0]["reasons"]
 
     return Form(
@@ -388,7 +388,7 @@ def document_grading_form(request, good_id):
                 ],
             ),
         ],
-        back_link=BackLink(DocumentSensitivityForm.BACK_BUTTON, reverse_lazy("goods:good", kwargs={"pk": good_id})),
+        back_link=BackLink(DocumentSensitivityForm.BACK_BUTTON, back_link),
         default_button_name=DocumentSensitivityForm.SUBMIT_BUTTON,
     )
 

--- a/exporter/goods/views.py
+++ b/exporter/goods/views.py
@@ -563,7 +563,7 @@ class DeleteGood(LoginRequiredMixin, TemplateView):
 class CheckDocumentGrading(LoginRequiredMixin, SingleFormView):
     def init(self, request, **kwargs):
         self.object_pk = kwargs["pk"]
-        self.form = document_grading_form(request, self.object_pk)
+        self.form = document_grading_form(request, reverse_lazy("goods:good", kwargs={"pk": self.object_pk}))
         self.action = post_good_document_sensitivity
 
     def get_success_url(self):

--- a/exporter/templates/ecju-queries/query-document-delete.html
+++ b/exporter/templates/ecju-queries/query-document-delete.html
@@ -52,7 +52,7 @@
 <div class="buttons-row">
     <form method="post" action="{% url 'ecju_queries:query-document-delete' query_pk object_type case_pk doc_pk %}">
         {% csrf_token %}
-        <button type="submit"
+        <button type="submit" value="submit"
             class="govuk-button govuk-button--warning govuk-!-margin-right-2">{% lcs "ecju_queries.SupportingDocumentDeletePage.BUTTON" %}</button>
     </form>
 </div>

--- a/exporter/templates/ecju-queries/query-document-delete.html
+++ b/exporter/templates/ecju-queries/query-document-delete.html
@@ -3,8 +3,15 @@
 {% load svg %}
 
 {% block back_link %}
-<a href="{% url 'ecju_queries:respond_to_query' query_pk object_type case_pk %}" id="back-link"
-    class="govuk-back-link">{% lcs "ecju_queries.SupportingDocumentDeletePage.BACK" %}</a>
+
+{% if object_type == "compliance-visit" or object_type == "good" %}
+<a href="{% url 'ecju_queries:respond_to_query_extra' query_pk=query_pk object_type=object_type extra_pk=extra_pk case_pk=case_pk %}"
+    id="back-link" class="govuk-back-link">{% lcs "ecju_queries.SupportingDocumentDeletePage.BACK" %}</a>
+{% else %}
+<a href="{% url 'ecju_queries:respond_to_query' query_pk=query_pk object_type=object_type case_pk=case_pk %}"
+    id="back-link" class="govuk-back-link">{% lcs "ecju_queries.SupportingDocumentDeletePage.BACK" %}</a>
+{% endif %}
+
 {% endblock %}
 
 {% block body %}
@@ -50,7 +57,8 @@
 </div>
 
 <div class="buttons-row">
-    <form method="post" action="{% url 'ecju_queries:query-document-delete' query_pk object_type case_pk doc_pk %}">
+    <form method="post"
+        action="{% url 'ecju_queries:query-document-delete' query_pk object_type extra_pk case_pk doc_pk %}">
         {% csrf_token %}
         <button type="submit" value="submit"
             class="govuk-button govuk-button--warning govuk-!-margin-right-2">{% lcs "ecju_queries.SupportingDocumentDeletePage.BUTTON" %}</button>

--- a/exporter/templates/ecju-queries/query-document-delete.html
+++ b/exporter/templates/ecju-queries/query-document-delete.html
@@ -1,0 +1,59 @@
+{% extends 'layouts/base.html' %}
+
+{% load svg %}
+
+{% block back_link %}
+<a href="{% url 'ecju_queries:respond_to_query' query_pk object_type case_pk %}" id="back-link"
+    class="govuk-back-link">{% lcs "ecju_queries.SupportingDocumentDeletePage.BACK" %}</a>
+{% endblock %}
+
+{% block body %}
+<div class="lite-app-bar">
+    <div class="lite-app-bar__content">
+        <h1 class="govuk-heading-l">{% block title %}{{ title }}{% endblock %}</h1>
+        <dl class="govuk-summary-list" id="good-details">
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    {% lcs "ecju_queries.SupportingDocumentDeletePage.DOCUMENT_NAME" %}
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    {{ document.name }}
+                </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    {% lcs "ecju_queries.SupportingDocumentDeletePage.DOCUMENT_CREATED_AT" %}
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    {{ document.created_at|str_date }}
+                </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    {% lcs "ecju_queries.SupportingDocumentDeletePage.DOCUMENT_CREATED_BY" %}
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    {{ document.user.first_name }} {{ document.user.last_name }}
+                </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    {% lcs "ecju_queries.SupportingDocumentDeletePage.DOCUMENT_DESCRIPTION" %}
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    {{ document.description|default_na|slice:"0:40" }}
+                    {% if document.description|length > 40 %}...{% endif %}
+                </dd>
+            </div>
+        </dl>
+    </div>
+</div>
+
+<div class="buttons-row">
+    <form method="post" action="{% url 'ecju_queries:query-document-delete' query_pk object_type case_pk doc_pk %}">
+        {% csrf_token %}
+        <button type="submit"
+            class="govuk-button govuk-button--warning govuk-!-margin-right-2">{% lcs "ecju_queries.SupportingDocumentDeletePage.BUTTON" %}</button>
+    </form>
+</div>
+{% endblock %}

--- a/exporter/templates/ecju-queries/respond_to_query.html
+++ b/exporter/templates/ecju-queries/respond_to_query.html
@@ -47,7 +47,8 @@
         {% endif %}
         <textarea id="response" name="response" rows="10"
             class="govuk-textarea govuk-js-character-count">{{ response }}</textarea>
-        <p class="govuk-caption-m" id="response-length-warning" class="govuk-hint govuk-character-count__message" aria-live="polite">You can enter upto 2200 characters</p>
+        <p class="govuk-caption-m" id="response-length-warning" class="govuk-hint govuk-character-count__message"
+            aria-live="polite">You can enter upto 2200 characters</p>
     </div>
 
     <div class="lite-app-bar">
@@ -56,7 +57,7 @@
         </div>
         <div class="lite-app-bar__controls">
             <button type="submit" value="add_document" name="respond_to_query"
-            class="govuk-button govuk-!-margin-right-2">{% lcs "ecju_queries.DocumentsList.AttachDocuments.BUTTON" %}</button>
+                class="govuk-button govuk-!-margin-right-2">{% lcs "ecju_queries.DocumentsList.AttachDocuments.BUTTON" %}</button>
         </div>
     </div>
 
@@ -86,29 +87,28 @@
                 <p class="govuk-label">{% lcs 'Goods.Documents.PROCESSING' %}</p>
                 {% endif %}
                 {% if not ecju_query.response %}
-                <a href="{% url 'ecju_queries:query-document-delete' query_pk=ecju_query.id object_type=object_type case_pk=case_id doc_pk=document.id %}"
-                    class="govuk-link govuk-!-font-size-16 govuk-!-margin-top-2">
-                    {% lcs "ecju_queries.DocumentsList.Documents.DELETE" %}
-                </a>
+                    {% if object_type == "compliance-visit" or object_type == "good" %}
+                        <a href="{% url 'ecju_queries:query-document-delete' query_pk=ecju_query.id object_type=object_type extra_pk=extra_id case_pk=case_id doc_pk=document.id %}"
+                            class="govuk-link govuk-!-font-size-16 govuk-!-margin-top-2">
+                            {% lcs "ecju_queries.DocumentsList.Documents.DELETE" %}
+                        </a>
+                    {% else %}
+                        <a href="{% url 'ecju_queries:query-document-delete' query_pk=ecju_query.id object_type=object_type extra_pk=case_id case_pk=case_id doc_pk=document.id %}"
+                        class="govuk-link govuk-!-font-size-16 govuk-!-margin-top-2">
+                        {% lcs "ecju_queries.DocumentsList.Documents.DELETE" %}
+                        </a>
+                    {% endif %}
                 {% endif %}
             </div>
         </li>
         {% endfor %}
     </ol>
-    {% elif ecju_query.missing_document_reason.key %}
-    <div class="lite-information-text">
-        <span class="lite-information-text__icon" aria-hidden="true">!</span>
-        <p class="lite-information-text__text">
-            <span class="govuk-visually-hidden">{% lcs "generic.NoticeComponent.INFORMATION" %}</span>
-            No document attached: {{ ecju_query.missing_document_reason.value }}
-        </p>
-    </div>
     {% else %}
     {% include "includes/notice.html" with text="ecju_queries.DocumentsList.Documents.NO_DOCUMENT_ATTACHED" %}
     {% endif %}
     <div class="buttons-row govuk-!-margin-top-8">
         <button type="submit" value="submit" name="respond_to_query"
-            class="govuk-button govuk-!-margin-right-2">{% lcs "ecju_queries.Forms.RespondForm.SAVE" %}</button>
+            class="govuk-button govuk-!-margin-right-2">{% lcs "ecju_queries.Forms.RespondForm.SEND" %}</button>
     </div>
 </form>
 

--- a/exporter/templates/ecju-queries/respond_to_query.html
+++ b/exporter/templates/ecju-queries/respond_to_query.html
@@ -27,7 +27,7 @@
     {% endfor %}
 </div>
 {% endif %}
-<form method="post" name="respond_to_query" {% if object_type == "compliance-visit" %}
+<form method="post" name="respond_to_query" {% if object_type == "compliance-visit" or object_type == "good" %}
     action="{% url 'ecju_queries:respond_to_query_extra' query_pk=ecju_query.id object_type=object_type extra_pk=extra_id case_pk=case_id %}"
     {% else %}
     action="{% url 'ecju_queries:respond_to_query' query_pk=ecju_query.id object_type=object_type case_pk=case_id %}"
@@ -55,15 +55,8 @@
             <h2 class="govuk-heading-m">{% lcs "ecju_queries.DocumentsList.Documents.TITLE" %}</h2>
         </div>
         <div class="lite-app-bar__controls">
-            {% if object_type == "compliance-visit" %}
-            {% url 'ecju_queries:add_supporting_document' ecju_query.id object_type extra_id case_id as url %}
-            {% else %}
-            {% url 'ecju_queries:add_supporting_document' ecju_query.id object_type case_id case_id as url %}
-            {% endif %}
-            <a role="button" type="submit" draggable="false" class="govuk-button govuk-button--secondary"
-                href={{ url }}>
-                {% lcs "ecju_queries.DocumentsList.AttachDocuments.BUTTON" %}
-            </a>
+            <button type="submit" value="add_document" name="respond_to_query"
+            class="govuk-button govuk-!-margin-right-2">{% lcs "ecju_queries.DocumentsList.AttachDocuments.BUTTON" %}</button>
         </div>
     </div>
 

--- a/exporter/templates/ecju-queries/respond_to_query.html
+++ b/exporter/templates/ecju-queries/respond_to_query.html
@@ -8,63 +8,106 @@
 </a>
 {% endblock %}
 
+
 {% block body %}
-<h1 class="govuk-heading-xl">Respond to query</h1>
-<div class="app-ecju-query__text">
-    {{ ecju_query.question }}
-</div><br><br>
-<p>Your response</p>
-<textarea id="ecju-query-response-text" name="response" cols="80"
-    class="govuk-textarea govuk-js-character-count"></textarea>
-<p class="govuk-caption-m">You can enter upto 2200 characters</p>
-
-<div class="lite-app-bar">
-    <div class="lite-app-bar__content">
-        <h2 class="govuk-heading-m">{% lcs "ecju_queries.DocumentsList.Documents.TITLE" %}</h2>
+{% if errors %}
+<div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1">
+    <h2 class="govuk-error-summary__title" id="error-summary-title">
+        There is a problem
+    </h2>
+    {% for field,error_msg in errors.items %}
+    <div class="govuk-error-summary__body">
+        <ul class="govuk-list govuk-error-summary__list">
+            <li>
+                <a href="#{{ field }}">{{ error_msg }}</a>
+            </li>
+        </ul>
     </div>
-    <div class="lite-app-bar__controls">
-        {% url 'ecju_queries:add_supporting_document' ecju_query.id object_type case_id as url %}
-        <a role="button" draggable="false" class="govuk-button govuk-button--secondary" href={{ url }}>
-            {% lcs "ecju_queries.DocumentsList.AttachDocuments.BUTTON" %}
-        </a>
-    </div>
-</div>
-
-{% if documents %}
-<ol class="app-documents__list">
-    {% for document in documents %}
-    <li class="app-documents__item">
-        <div class="app-documents__item-preview">
-            {% svg 'document' %}
-            <span>
-                {{ document.name|file_type }}
-            </span>
-        </div>
-        <div class="app-documents__item-details">
-            <a {% if document.safe == True %}href="{% url 'ecju_queries:query-document' query_pk=ecju_query.id object_type=object_type case_pk=case_id doc_pk=document.id %}"
-                {% endif %} class="govuk-link--no-visited-state">{{ document.name }}</a>
-            <p class="govuk-hint">Uploaded by {{ document.user.first_name }} {{ document.user.last_name }} at
-                {{ document.created_at|str_date }}</p>
-            {% if document.description %}
-            <p class="govuk-body">
-                {{ document.description }}
-            </p>
-            {% endif %}
-            {% if document.safe == False %}
-            <p class="govuk-label">{% lcs 'Goods.Documents.VIRUS_INFECTED' %}</p>
-            {% elif not document.safe %}
-            <p class="govuk-label">{% lcs 'Goods.Documents.PROCESSING' %}</p>
-            {% endif %}
-            {% if not ecju_query.response %}
-            <a href="{% url 'ecju_queries:query-document-delete' query_pk=ecju_query.id object_type=object_type case_pk=case_id doc_pk=document.id %}"
-                class="govuk-link govuk-!-font-size-16 govuk-!-margin-top-2">
-                {% lcs "ecju_queries.DocumentsList.Documents.DELETE" %}
-            </a>
-            {% endif %}
-        </div>
-    </li>
     {% endfor %}
-</ol>
+</div>
 {% endif %}
+<form method="post" name="respond_to_query"
+    action="{% url 'ecju_queries:respond_to_query' query_pk=ecju_query.id object_type=object_type case_pk=case_id %}">
+    {% csrf_token %}
+    <h1 class="govuk-heading-xl">Respond to query</h1>
+    <div class="app-ecju-query__text">
+        {{ ecju_query.question }}
+    </div><br><br>
+
+    <div class="govuk-form-group {% if errors %} govuk-form-group--error {% endif %}">
+        <label class="govuk-label" for="response">Your response</label>
+        {% if errors %}
+        <span id="error-response" class="govuk-error-message">
+            <span class="govuk-visually-hidden">Error:</span> {{ errors.response }}
+        </span>
+        {% endif %}
+        <textarea id="ecju-query-response-text" name="response" cols="80"
+            class="govuk-textarea govuk-js-character-count">{{ response }}</textarea>
+        <p class="govuk-caption-m">You can enter upto 2200 characters</p>
+    </div>
+
+    <div class="lite-app-bar">
+        <div class="lite-app-bar__content">
+            <h2 class="govuk-heading-m">{% lcs "ecju_queries.DocumentsList.Documents.TITLE" %}</h2>
+        </div>
+        <div class="lite-app-bar__controls">
+            {% url 'ecju_queries:add_supporting_document' ecju_query.id object_type case_id as url %}
+            <a role="button" draggable="false" class="govuk-button govuk-button--secondary" href={{ url }}>
+                {% lcs "ecju_queries.DocumentsList.AttachDocuments.BUTTON" %}
+            </a>
+        </div>
+    </div>
+
+    {% if documents %}
+    <ol class="app-documents__list">
+        {% for document in documents %}
+        <li class="app-documents__item">
+            <div class="app-documents__item-preview">
+                {% svg 'document' %}
+                <span>
+                    {{ document.name|file_type }}
+                </span>
+            </div>
+            <div class="app-documents__item-details">
+                <a {% if document.safe == True %}href="{% url 'ecju_queries:query-document' query_pk=ecju_query.id object_type=object_type case_pk=case_id doc_pk=document.id %}"
+                    {% endif %} class="govuk-link--no-visited-state">{{ document.name }}</a>
+                <p class="govuk-hint">Uploaded by {{ document.user.first_name }} {{ document.user.last_name }} at
+                    {{ document.created_at|str_date }}</p>
+                {% if document.description %}
+                <p class="govuk-body">
+                    {{ document.description }}
+                </p>
+                {% endif %}
+                {% if document.safe == False %}
+                <p class="govuk-label">{% lcs 'Goods.Documents.VIRUS_INFECTED' %}</p>
+                {% elif not document.safe %}
+                <p class="govuk-label">{% lcs 'Goods.Documents.PROCESSING' %}</p>
+                {% endif %}
+                {% if not ecju_query.response %}
+                <a href="{% url 'ecju_queries:query-document-delete' query_pk=ecju_query.id object_type=object_type case_pk=case_id doc_pk=document.id %}"
+                    class="govuk-link govuk-!-font-size-16 govuk-!-margin-top-2">
+                    {% lcs "ecju_queries.DocumentsList.Documents.DELETE" %}
+                </a>
+                {% endif %}
+            </div>
+        </li>
+        {% endfor %}
+    </ol>
+    {% elif ecju_query.missing_document_reason.key %}
+    <div class="lite-information-text">
+        <span class="lite-information-text__icon" aria-hidden="true">!</span>
+        <p class="lite-information-text__text">
+            <span class="govuk-visually-hidden">{% lcs "generic.NoticeComponent.INFORMATION" %}</span>
+            No document attached: {{ ecju_query.missing_document_reason.value }}
+        </p>
+    </div>
+    {% else %}
+    {% include "includes/notice.html" with text="ecju_queries.DocumentsList.Documents.NO_DOCUMENT_ATTACHED" %}
+    {% endif %}
+    <div class="buttons-row govuk-!-margin-top-8">
+        <button type="submit" name="respond_to_query"
+            class="govuk-button govuk-!-margin-right-2">{% lcs "ecju_queries.Forms.RespondForm.SAVE" %}</button>
+    </div>
+</form>
 
 {% endblock %}

--- a/exporter/templates/ecju-queries/respond_to_query.html
+++ b/exporter/templates/ecju-queries/respond_to_query.html
@@ -11,107 +11,113 @@
 
 
 {% block body %}
-{% if errors %}
-<div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1">
-    <h2 class="govuk-error-summary__title" id="error-summary-title">
-        There is a problem
-    </h2>
-    {% for field,error_msg in errors.items %}
-    <div class="govuk-error-summary__body">
-        <ul class="govuk-list govuk-error-summary__list">
-            <li>
-                <a href="#{{ field }}">{{ error_msg }}</a>
-            </li>
-        </ul>
-    </div>
-    {% endfor %}
-</div>
-{% endif %}
-<form method="post" name="respond_to_query" {% if object_type == "compliance-visit" or object_type == "good" %}
-    action="{% url 'ecju_queries:respond_to_query_extra' query_pk=ecju_query.id object_type=object_type extra_pk=extra_id case_pk=case_id %}"
-    {% else %}
-    action="{% url 'ecju_queries:respond_to_query' query_pk=ecju_query.id object_type=object_type case_pk=case_id %}"
-    {% endif %}>
-    {% csrf_token %}
-    <h1 class="govuk-heading-xl">Respond to query</h1>
-    <div class="app-ecju-query__text">
-        {{ ecju_query.question }}
-    </div><br><br>
-
-    <div id="response-text-container" class="govuk-form-group {% if errors %} govuk-form-group--error {% endif %}">
-        <label class="govuk-label" for="response">Your response</label>
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
         {% if errors %}
-        <span id="error-response" class="govuk-error-message">
-            <span class="govuk-visually-hidden">Error:</span> {{ errors.response }}
-        </span>
-        {% endif %}
-        <textarea id="response" name="response" rows="10"
-            class="govuk-textarea govuk-js-character-count">{{ response }}</textarea>
-        <p class="govuk-caption-m" id="response-length-warning" class="govuk-hint govuk-character-count__message"
-            aria-live="polite">You can enter upto 2200 characters</p>
-    </div>
-
-    <div class="lite-app-bar">
-        <div class="lite-app-bar__content">
-            <h2 class="govuk-heading-m">{% lcs "ecju_queries.DocumentsList.Documents.TITLE" %}</h2>
-        </div>
-        <div class="lite-app-bar__controls">
-            <button type="submit" value="add_document" name="respond_to_query"
-                class="govuk-button govuk-!-margin-right-2">{% lcs "ecju_queries.DocumentsList.AttachDocuments.BUTTON" %}</button>
-        </div>
-    </div>
-
-    {% if documents %}
-    <ol class="app-documents__list">
-        {% for document in documents %}
-        <li class="app-documents__item">
-            <div class="app-documents__item-preview">
-                {% svg 'document' %}
-                <span>
-                    {{ document.name|file_type }}
-                </span>
+        <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1">
+            <h2 class="govuk-error-summary__title" id="error-summary-title">
+                There is a problem
+            </h2>
+            {% for field,error_msg in errors.items %}
+            <div class="govuk-error-summary__body">
+                <ul class="govuk-list govuk-error-summary__list">
+                    <li>
+                        <a href="#{{ field }}">{{ error_msg }}</a>
+                    </li>
+                </ul>
             </div>
-            <div class="app-documents__item-details">
-                <a {% if document.safe == True %}href="{% url 'ecju_queries:query-document' query_pk=ecju_query.id object_type=object_type case_pk=case_id doc_pk=document.id %}"
-                    {% endif %} class="govuk-link--no-visited-state">{{ document.name }}</a>
-                <p class="govuk-hint">Uploaded by {{ document.user.first_name }} {{ document.user.last_name }} at
-                    {{ document.created_at|str_date }}</p>
-                {% if document.description %}
-                <p class="govuk-body">
-                    {{ document.description }}
-                </p>
+            {% endfor %}
+        </div>
+        {% endif %}
+        <form method="post" name="respond_to_query" {% if object_type == "compliance-visit" or object_type == "good" %}
+            action="{% url 'ecju_queries:respond_to_query_extra' query_pk=ecju_query.id object_type=object_type extra_pk=extra_id case_pk=case_id %}"
+            {% else %}
+            action="{% url 'ecju_queries:respond_to_query' query_pk=ecju_query.id object_type=object_type case_pk=case_id %}"
+            {% endif %}>
+            {% csrf_token %}
+            <h1 class="govuk-heading-xl">Respond to query</h1>
+            <div class="app-ecju-query__text">
+                {{ ecju_query.question }}
+            </div><br><br>
+
+            <div id="response-text-container"
+                class="govuk-form-group {% if errors %} govuk-form-group--error {% endif %}">
+                <label class="govuk-label" for="response">Your response</label>
+                {% if errors %}
+                <span id="error-response" class="govuk-error-message">
+                    <span class="govuk-visually-hidden">Error:</span> {{ errors.response }}
+                </span>
                 {% endif %}
-                {% if document.safe == False %}
-                <p class="govuk-label">{% lcs 'Goods.Documents.VIRUS_INFECTED' %}</p>
-                {% elif not document.safe %}
-                <p class="govuk-label">{% lcs 'Goods.Documents.PROCESSING' %}</p>
-                {% endif %}
-                {% if not ecju_query.response %}
-                    {% if object_type == "compliance-visit" or object_type == "good" %}
+                <textarea id="response" name="response" rows="10"
+                    class="govuk-textarea govuk-js-character-count">{{ response }}</textarea>
+                <p class="govuk-caption-m" id="response-length-warning"
+                    class="govuk-hint govuk-character-count__message" aria-live="polite">You can enter upto 2200
+                    characters</p>
+            </div>
+
+            <div class="lite-app-bar">
+                <div class="lite-app-bar__content">
+                    <h2 class="govuk-heading-m">{% lcs "ecju_queries.DocumentsList.Documents.TITLE" %}</h2>
+                </div>
+                <div class="lite-app-bar__controls">
+                    <button type="submit" value="add_document" name="respond_to_query"
+                        class="govuk-button govuk-!-margin-right-2">{% lcs "ecju_queries.DocumentsList.AttachDocuments.BUTTON" %}</button>
+                </div>
+            </div>
+
+            {% if documents %}
+            <ol class="app-documents__list">
+                {% for document in documents %}
+                <li class="app-documents__item">
+                    <div class="app-documents__item-preview">
+                        {% svg 'document' %}
+                        <span>
+                            {{ document.name|file_type }}
+                        </span>
+                    </div>
+                    <div class="app-documents__item-details">
+                        <a {% if document.safe == True %}href="{% url 'ecju_queries:query-document' query_pk=ecju_query.id object_type=object_type case_pk=case_id doc_pk=document.id %}"
+                            {% endif %} class="govuk-link--no-visited-state">{{ document.name }}</a>
+                        <p class="govuk-hint">Uploaded by {{ document.user.first_name }} {{ document.user.last_name }}
+                            at
+                            {{ document.created_at|str_date }}</p>
+                        {% if document.description %}
+                        <p class="govuk-body">
+                            {{ document.description }}
+                        </p>
+                        {% endif %}
+                        {% if document.safe == False %}
+                        <p class="govuk-label">{% lcs 'Goods.Documents.VIRUS_INFECTED' %}</p>
+                        {% elif not document.safe %}
+                        <p class="govuk-label">{% lcs 'Goods.Documents.PROCESSING' %}</p>
+                        {% endif %}
+                        {% if not ecju_query.response %}
+                        {% if object_type == "compliance-visit" or object_type == "good" %}
                         <a href="{% url 'ecju_queries:query-document-delete' query_pk=ecju_query.id object_type=object_type extra_pk=extra_id case_pk=case_id doc_pk=document.id %}"
                             class="govuk-link govuk-!-font-size-16 govuk-!-margin-top-2">
                             {% lcs "ecju_queries.DocumentsList.Documents.DELETE" %}
                         </a>
-                    {% else %}
+                        {% else %}
                         <a href="{% url 'ecju_queries:query-document-delete' query_pk=ecju_query.id object_type=object_type extra_pk=case_id case_pk=case_id doc_pk=document.id %}"
-                        class="govuk-link govuk-!-font-size-16 govuk-!-margin-top-2">
-                        {% lcs "ecju_queries.DocumentsList.Documents.DELETE" %}
+                            class="govuk-link govuk-!-font-size-16 govuk-!-margin-top-2">
+                            {% lcs "ecju_queries.DocumentsList.Documents.DELETE" %}
                         </a>
-                    {% endif %}
-                {% endif %}
+                        {% endif %}
+                        {% endif %}
+                    </div>
+                </li>
+                {% endfor %}
+            </ol>
+            {% else %}
+            {% include "includes/notice.html" with text="ecju_queries.DocumentsList.Documents.NO_DOCUMENT_ATTACHED" %}
+            {% endif %}
+            <div class="buttons-row govuk-!-margin-top-8">
+                <button type="submit" value="submit" name="respond_to_query"
+                    class="govuk-button govuk-!-margin-right-2">{% lcs "ecju_queries.Forms.RespondForm.SEND" %}</button>
             </div>
-        </li>
-        {% endfor %}
-    </ol>
-    {% else %}
-    {% include "includes/notice.html" with text="ecju_queries.DocumentsList.Documents.NO_DOCUMENT_ATTACHED" %}
-    {% endif %}
-    <div class="buttons-row govuk-!-margin-top-8">
-        <button type="submit" value="submit" name="respond_to_query"
-            class="govuk-button govuk-!-margin-right-2">{% lcs "ecju_queries.Forms.RespondForm.SEND" %}</button>
+        </form>
     </div>
-</form>
-
+</div>
 <script src="{% static 'javascripts/helpers.js' %}"></script>
 <script src="{% static 'javascripts/pluralize.js' %}"></script>
 <script src="{% static 'javascripts/query-response.js' %}"></script>

--- a/exporter/templates/ecju-queries/respond_to_query.html
+++ b/exporter/templates/ecju-queries/respond_to_query.html
@@ -26,8 +26,11 @@
     {% endfor %}
 </div>
 {% endif %}
-<form method="post" name="respond_to_query"
-    action="{% url 'ecju_queries:respond_to_query' query_pk=ecju_query.id object_type=object_type case_pk=case_id %}">
+<form method="post" name="respond_to_query" {% if object_type == "compliance-visit" %}
+    action="{% url 'ecju_queries:respond_to_query_extra' query_pk=ecju_query.id object_type=object_type extra_pk=extra_id case_pk=case_id %}"
+    {% else %}
+    action="{% url 'ecju_queries:respond_to_query' query_pk=ecju_query.id object_type=object_type case_pk=case_id %}"
+    {% endif %}>
     {% csrf_token %}
     <h1 class="govuk-heading-xl">Respond to query</h1>
     <div class="app-ecju-query__text">
@@ -41,7 +44,7 @@
             <span class="govuk-visually-hidden">Error:</span> {{ errors.response }}
         </span>
         {% endif %}
-        <textarea id="ecju-query-response-text" name="response" cols="80"
+        <textarea id="response" name="response" cols="80"
             class="govuk-textarea govuk-js-character-count">{{ response }}</textarea>
         <p class="govuk-caption-m">You can enter upto 2200 characters</p>
     </div>
@@ -51,8 +54,13 @@
             <h2 class="govuk-heading-m">{% lcs "ecju_queries.DocumentsList.Documents.TITLE" %}</h2>
         </div>
         <div class="lite-app-bar__controls">
-            {% url 'ecju_queries:add_supporting_document' ecju_query.id object_type case_id as url %}
-            <a role="button" draggable="false" class="govuk-button govuk-button--secondary" href={{ url }}>
+            {% if object_type == "compliance-visit" %}
+            {% url 'ecju_queries:add_supporting_document' ecju_query.id object_type extra_id case_id as url %}
+            {% else %}
+            {% url 'ecju_queries:add_supporting_document' ecju_query.id object_type case_id case_id as url %}
+            {% endif %}
+            <a role="button" type="submit" draggable="false" class="govuk-button govuk-button--secondary"
+                href={{ url }}>
                 {% lcs "ecju_queries.DocumentsList.AttachDocuments.BUTTON" %}
             </a>
         </div>
@@ -105,7 +113,7 @@
     {% include "includes/notice.html" with text="ecju_queries.DocumentsList.Documents.NO_DOCUMENT_ATTACHED" %}
     {% endif %}
     <div class="buttons-row govuk-!-margin-top-8">
-        <button type="submit" name="respond_to_query"
+        <button type="submit" value="submit" name="respond_to_query"
             class="govuk-button govuk-!-margin-right-2">{% lcs "ecju_queries.Forms.RespondForm.SAVE" %}</button>
     </div>
 </form>

--- a/exporter/templates/ecju-queries/respond_to_query.html
+++ b/exporter/templates/ecju-queries/respond_to_query.html
@@ -1,0 +1,34 @@
+{% extends 'layouts/base.html' %}
+
+{% load svg %}
+
+{% block back_link %}
+<a href="{{back_link}}" id="back-link" class="govuk-back-link">
+    back to ecju queries
+</a>
+{% endblock %}
+
+{% block body %}
+<h1 class="govuk-heading-xl">Respond to query</h1>
+<div class="app-ecju-query__text">
+    {{ ecju_query.question }}
+</div><br><br>
+<p>Your response</p>
+<textarea id="ecju-query-response-text" name="response" cols="80"
+    class="govuk-textarea govuk-js-character-count"></textarea>
+<p class="govuk-caption-m">You can enter upto 2200 characters</p>
+
+<div class="lite-app-bar">
+    <div class="lite-app-bar__content">
+        <h2 class="govuk-heading-m">{% lcs "ecju_queries.DocumentsList.Documents.TITLE" %}</h2>
+    </div>
+    <div class="lite-app-bar__controls">
+        {% url 'ecju_queries:add_supporting_document' ecju_query.id object_type case_id as url %}
+        <a role="button" draggable="false" class="govuk-button govuk-button--secondary"
+            href={{ url }}>
+            {% lcs "ecju_queries.DocumentsList.AttachDocuments.BUTTON" %}
+        </a>
+    </div>
+</div>
+
+{% endblock %}

--- a/exporter/templates/ecju-queries/respond_to_query.html
+++ b/exporter/templates/ecju-queries/respond_to_query.html
@@ -24,11 +24,47 @@
     </div>
     <div class="lite-app-bar__controls">
         {% url 'ecju_queries:add_supporting_document' ecju_query.id object_type case_id as url %}
-        <a role="button" draggable="false" class="govuk-button govuk-button--secondary"
-            href={{ url }}>
+        <a role="button" draggable="false" class="govuk-button govuk-button--secondary" href={{ url }}>
             {% lcs "ecju_queries.DocumentsList.AttachDocuments.BUTTON" %}
         </a>
     </div>
 </div>
+
+{% if documents %}
+<ol class="app-documents__list">
+    {% for document in documents %}
+    <li class="app-documents__item">
+        <div class="app-documents__item-preview">
+            {% svg 'document' %}
+            <span>
+                {{ document.name|file_type }}
+            </span>
+        </div>
+        <div class="app-documents__item-details">
+            <a {% if document.safe == True %}href="{% url 'ecju_queries:query-document' query_pk=ecju_query.id object_type=object_type case_pk=case_id doc_pk=document.id %}"
+                {% endif %} class="govuk-link--no-visited-state">{{ document.name }}</a>
+            <p class="govuk-hint">Uploaded by {{ document.user.first_name }} {{ document.user.last_name }} at
+                {{ document.created_at|str_date }}</p>
+            {% if document.description %}
+            <p class="govuk-body">
+                {{ document.description }}
+            </p>
+            {% endif %}
+            {% if document.safe == False %}
+            <p class="govuk-label">{% lcs 'Goods.Documents.VIRUS_INFECTED' %}</p>
+            {% elif not document.safe %}
+            <p class="govuk-label">{% lcs 'Goods.Documents.PROCESSING' %}</p>
+            {% endif %}
+            {% if not ecju_query.response %}
+            <a href="{% url 'ecju_queries:query-document-delete' query_pk=ecju_query.id object_type=object_type case_pk=case_id doc_pk=document.id %}"
+                class="govuk-link govuk-!-font-size-16 govuk-!-margin-top-2">
+                {% lcs "ecju_queries.DocumentsList.Documents.DELETE" %}
+            </a>
+            {% endif %}
+        </div>
+    </li>
+    {% endfor %}
+</ol>
+{% endif %}
 
 {% endblock %}

--- a/exporter/templates/ecju-queries/respond_to_query.html
+++ b/exporter/templates/ecju-queries/respond_to_query.html
@@ -1,6 +1,7 @@
 {% extends 'layouts/base.html' %}
 
 {% load svg %}
+{% load static %}
 
 {% block back_link %}
 <a href="{{back_link}}" id="back-link" class="govuk-back-link">
@@ -37,16 +38,16 @@
         {{ ecju_query.question }}
     </div><br><br>
 
-    <div class="govuk-form-group {% if errors %} govuk-form-group--error {% endif %}">
+    <div id="response-text-container" class="govuk-form-group {% if errors %} govuk-form-group--error {% endif %}">
         <label class="govuk-label" for="response">Your response</label>
         {% if errors %}
         <span id="error-response" class="govuk-error-message">
             <span class="govuk-visually-hidden">Error:</span> {{ errors.response }}
         </span>
         {% endif %}
-        <textarea id="response" name="response" cols="80"
+        <textarea id="response" name="response" rows="10"
             class="govuk-textarea govuk-js-character-count">{{ response }}</textarea>
-        <p class="govuk-caption-m">You can enter upto 2200 characters</p>
+        <p class="govuk-caption-m" id="response-length-warning" class="govuk-hint govuk-character-count__message" aria-live="polite">You can enter upto 2200 characters</p>
     </div>
 
     <div class="lite-app-bar">
@@ -117,5 +118,9 @@
             class="govuk-button govuk-!-margin-right-2">{% lcs "ecju_queries.Forms.RespondForm.SAVE" %}</button>
     </div>
 </form>
+
+<script src="{% static 'javascripts/helpers.js' %}"></script>
+<script src="{% static 'javascripts/pluralize.js' %}"></script>
+<script src="{% static 'javascripts/query-response.js' %}"></script>
 
 {% endblock %}

--- a/exporter/templates/includes/ecju-queries.html
+++ b/exporter/templates/includes/ecju-queries.html
@@ -1,3 +1,5 @@
+{% load svg %}
+
 {% if open_queries %}
 	<h3 class="govuk-heading-m">Open queries</h3>
 	{% for ecju_query in open_queries %}
@@ -50,6 +52,23 @@
 				<div class="app-ecju-query__text">
 					{{ ecju_query.response }}
 				</div>
+				{% if ecju_query.documents %}
+					{% for document in ecju_query.documents %}
+						<br>
+						<li class="app-documents__item govuk-!-margin-top-2">
+							<div class="app-documents__item-preview">
+								{% svg 'document' %}
+								<span>
+									{{ document.name|file_type }}
+								</span>
+							</div>
+							<div class="app-documents__item-details">
+								<a {% if document.safe == True %}href="{% url 'ecju_queries:query-document' query_pk=ecju_query.id object_type=object_type case_pk=case_id doc_pk=document.id %}"
+									{% endif %} class="govuk-link--no-visited-state">{{ document.name }}</a>
+							</div>
+						</li>
+					{% endfor %}
+				{% endif %}
 				<p class="app-ecju-query__date">
 					<span class="govuk-visually-hidden">Responded at </span>{{ ecju_query.responded_at|str_date }}
 				</p>

--- a/exporter/templates/includes/ecju-queries.html
+++ b/exporter/templates/includes/ecju-queries.html
@@ -65,6 +65,9 @@
 							<div class="app-documents__item-details">
 								<a {% if document.safe == True %}href="{% url 'ecju_queries:query-document' query_pk=ecju_query.id object_type=object_type case_pk=case_id doc_pk=document.id %}"
 									{% endif %} class="govuk-link--no-visited-state">{{ document.name }}</a>
+								{% if document.description %}
+								<p class="govuk-body">{{ document.description }}</p>
+								{% endif %}
 							</div>
 						</li>
 					{% endfor %}

--- a/exporter/urls.py
+++ b/exporter/urls.py
@@ -22,7 +22,7 @@ urlpatterns += [
     path("goods/", include("exporter.goods.urls")),
     path("licences/", include("exporter.licences.urls")),
     path("organisation/", include("exporter.organisation.urls")),
-    path("ecju-queries/", include("exporter.ecju_queries.urls")),
+    path("ecju-queries/", include("exporter.ecju_queries.urls"), name="ecju-queries"),
     path("", include("exporter.hmrc.urls")),
 ]
 

--- a/lite_content/lite_exporter_frontend/ecju_queries.py
+++ b/lite_content/lite_exporter_frontend/ecju_queries.py
@@ -1,11 +1,13 @@
 from lite_content.lite_exporter_frontend import generic
 
+
 class Forms:
     class RespondForm:
         BACK_LINK = "Back to ecju queries"
         TITLE = "Respond to query"
         RESPONSE = "Your response"
         SAVE = "Save"
+        SEND = "Send"
 
     class ConfirmResponseForm:
         TITLE = "Confirm you want to send this response"
@@ -17,7 +19,7 @@ class Forms:
 
 class DocumentsList:
     class AttachDocuments:
-        BUTTON = "Add a document"
+        BUTTON = "Attach a document"
 
     class Documents:
         TITLE = "Documents"
@@ -47,13 +49,8 @@ class SupportingDocumentSensitivityForm:
 
 
 class UploadDocumentForm:
-    TITLE = "Upload a document"
-    DESCRIPTION = (
-        "Documentation could be specifications, datasheets, sales brochures, drawings "
-        "or anything else that fully details what the query is and what it's designed to do."
-        "\n\nDo not attach a document that’s above OFFICIAL-SENSITIVE. "
-        "\n\nThe file must be smaller than 50MB."
-    )
+    TITLE = "Attach a document"
+    DESCRIPTION = "Do not attach a document that's above OFFICIAL-SENSITIVE.\n\nThe file must be smaller than 50MB."
     BUTTON = "Save"
     BACK_FORM_LINK = "Back"
 

--- a/lite_content/lite_exporter_frontend/ecju_queries.py
+++ b/lite_content/lite_exporter_frontend/ecju_queries.py
@@ -1,3 +1,5 @@
+from lite_content.lite_exporter_frontend import generic
+
 class Forms:
     class RespondForm:
         BACK_LINK = "Back to ecju queries"
@@ -19,6 +21,7 @@ class DocumentsList:
     class Documents:
         TITLE = "Documents"
         NO_DOCUMENT_ATTACHED = "There are no documents."
+        DELETE = generic.Document.DELETE
 
 
 class SupportingDocumentSensitivityForm:

--- a/lite_content/lite_exporter_frontend/ecju_queries.py
+++ b/lite_content/lite_exporter_frontend/ecju_queries.py
@@ -58,3 +58,13 @@ class UploadDocumentForm:
 
     class Description:
         TITLE = "Description"
+
+
+class SupportingDocumentDeletePage:
+    TITLE = "Confirm you want to delete this document"
+    BACK = "Back to respond to query"
+    DOCUMENT_NAME = "Name"
+    DOCUMENT_CREATED_AT = "Created at"
+    DOCUMENT_CREATED_BY = "Created by"
+    DOCUMENT_DESCRIPTION = "Description"
+    BUTTON = "Delete document"

--- a/lite_content/lite_exporter_frontend/ecju_queries.py
+++ b/lite_content/lite_exporter_frontend/ecju_queries.py
@@ -26,10 +26,10 @@ class DocumentsList:
 
 
 class SupportingDocumentSensitivityForm:
-    TITLE = "Do you have a document for the product and is the document rated OFFICIAL-SENSITIVE or below?"
+    TITLE = "Do you have a document for the query and is the document rated OFFICIAL-SENSITIVE or below?"
     DESCRIPTION = (
         "Documentation should be specifications, datasheets, sales brochures, drawings or anything else that fully "
-        "details what the product is and what it's designed to do."
+        "details what the query is and what it's designed to do."
     )
     ECJU_HELPLINE = (
         "**<noscript>If the answer is No;</noscript>**\n\nContact ECJU to arrange a more secure way to send "
@@ -50,7 +50,7 @@ class UploadDocumentForm:
     TITLE = "Upload a document"
     DESCRIPTION = (
         "Documentation could be specifications, datasheets, sales brochures, drawings "
-        "or anything else that fully details what the product is and what it's designed to do."
+        "or anything else that fully details what the query is and what it's designed to do."
         "\n\nDo not attach a document that’s above OFFICIAL-SENSITIVE. "
         "\n\nThe file must be smaller than 50MB."
     )

--- a/lite_content/lite_exporter_frontend/ecju_queries.py
+++ b/lite_content/lite_exporter_frontend/ecju_queries.py
@@ -10,3 +10,48 @@ class Forms:
         NO_LABEL = "Cancel"
         BACK_LINK = "Back to edit response"
         SUBMIT_BTN = "Continue"
+
+
+class DocumentsList:
+    class AttachDocuments:
+        BUTTON = "Add a document"
+
+    class Documents:
+        TITLE = "Documents"
+        NO_DOCUMENT_ATTACHED = "There are no documents."
+
+
+class SupportingDocumentSensitivityForm:
+    TITLE = "Do you have a document for the product and is the document rated OFFICIAL-SENSITIVE or below?"
+    DESCRIPTION = (
+        "Documentation should be specifications, datasheets, sales brochures, drawings or anything else that fully "
+        "details what the product is and what it's designed to do."
+    )
+    ECJU_HELPLINE = (
+        "**<noscript>If the answer is No;</noscript>**\n\nContact ECJU to arrange a more secure way to send "
+        "this document.\n\n You can continue with the application "
+        "without attaching a document.\n\n**ECJU helpline**\n 020 7215 4594\n "
+        "[Find out about call charges](https://www.gov.uk/call-charges)"
+    )
+    SUBMIT_BUTTON = "Continue"
+    BACK_BUTTON = "Back to ecju queries"
+    LABEL = "Missing document reason"
+
+    class Options:
+        YES = "Yes"
+        NO = "No"
+
+
+class UploadDocumentForm:
+    TITLE = "Upload a document"
+    DESCRIPTION = (
+        "Documentation could be specifications, datasheets, sales brochures, drawings "
+        "or anything else that fully details what the product is and what it's designed to do."
+        "\n\nDo not attach a document that’s above OFFICIAL-SENSITIVE. "
+        "\n\nThe file must be smaller than 50MB."
+    )
+    BUTTON = "Save"
+    BACK_FORM_LINK = "Back to ecju queries"
+
+    class Description:
+        TITLE = "Description"

--- a/lite_content/lite_exporter_frontend/ecju_queries.py
+++ b/lite_content/lite_exporter_frontend/ecju_queries.py
@@ -5,6 +5,7 @@ class Forms:
         BACK_LINK = "Back to ecju queries"
         TITLE = "Respond to query"
         RESPONSE = "Your response"
+        SAVE = "Save"
 
     class ConfirmResponseForm:
         TITLE = "Confirm you want to send this response"

--- a/lite_content/lite_exporter_frontend/ecju_queries.py
+++ b/lite_content/lite_exporter_frontend/ecju_queries.py
@@ -34,7 +34,7 @@ class SupportingDocumentSensitivityForm:
         "[Find out about call charges](https://www.gov.uk/call-charges)"
     )
     SUBMIT_BUTTON = "Continue"
-    BACK_BUTTON = "Back to ecju queries"
+    BACK_BUTTON = "Back to respond to query"
     LABEL = "Missing document reason"
 
     class Options:
@@ -51,7 +51,7 @@ class UploadDocumentForm:
         "\n\nThe file must be smaller than 50MB."
     )
     BUTTON = "Save"
-    BACK_FORM_LINK = "Back to ecju queries"
+    BACK_FORM_LINK = "Back"
 
     class Description:
         TITLE = "Description"

--- a/tests_common/fixtures/apply_for_application.py
+++ b/tests_common/fixtures/apply_for_application.py
@@ -94,7 +94,7 @@ def apply_for_standard_application(api_test_client, context):
     timer.print_time("apply_for_standard_application")
 
 
-@fixture(scope="module")
+@fixture(scope="function")
 def add_an_ecju_query(api_test_client, context):
     api_test_client.api_client.auth_exporter_user(api_test_client.context["org_id"])
     api_test_client.ecju_queries.add_ecju_query(context.case_id)

--- a/ui_tests/exporter/conftest.py
+++ b/ui_tests/exporter/conftest.py
@@ -375,6 +375,17 @@ def respond_to_ecju_click(driver):  # noqa
     application_page.respond_to_ecju_query(0)
 
 
+@when(parsers.parse('I enter my response as "{response}"'))  # noqa
+def enter_query_response(driver, response):  # noqa
+    response_page = RespondToEcjuQueryPage(driver)
+    response_page.enter_form_response(response)
+
+
+@when(parsers.parse('I click "{button_value}"'))  # noqa
+def click_button(driver, button_value):  # noqa
+    functions.click_submit(driver, button_value=button_value)
+
+
 @when(parsers.parse('I enter "{response}" for ecju query and click submit'))  # noqa
 def respond_to_query(driver, response):  # noqa
     response_page = RespondToEcjuQueryPage(driver)
@@ -387,6 +398,21 @@ def determine_that_there_is_a_closed_query(driver):  # noqa
     application_page = ApplicationPage(driver)
     closed_queries = application_page.get_count_of_closed_ecju_queries()
     assert closed_queries > 0
+
+
+@when(parsers.parse('I upload file "{filename}" with description "{description}"'))  # noqa
+def upload_a_file_with_description(driver, filename, description):  # noqa
+    attach_document_page = AttachDocumentPage(driver)
+    file_path = get_file_upload_path(filename)
+    attach_document_page.choose_file(file_path)
+    attach_document_page.enter_description(description)
+    functions.click_submit(driver)
+
+
+@when(parsers.parse('I see the missing document reason text "{reason}"'))
+def get_missing_document_reason_text(driver, reason):
+    response_page = RespondToEcjuQueryPage(driver)
+    assert response_page.get_missing_document_reason_text() == reason
 
 
 @when(parsers.parse('I select "{value}" for submitting response and click submit'))  # noqa

--- a/ui_tests/exporter/conftest.py
+++ b/ui_tests/exporter/conftest.py
@@ -410,7 +410,7 @@ def upload_a_file_with_description(driver, filename, description):  # noqa
 
 
 @when(parsers.parse('I see the missing document reason text "{reason}"'))
-def get_missing_document_reason_text(driver, reason):
+def get_missing_document_reason(driver, reason): # noqa
     response_page = RespondToEcjuQueryPage(driver)
     assert response_page.get_missing_document_reason_text() == reason
 

--- a/ui_tests/exporter/conftest.py
+++ b/ui_tests/exporter/conftest.py
@@ -410,7 +410,7 @@ def upload_a_file_with_description(driver, filename, description):  # noqa
 
 
 @when(parsers.parse('I see the missing document reason text "{reason}"'))
-def get_missing_document_reason(driver, reason): # noqa
+def get_missing_document_reason(driver, reason):  # noqa
     response_page = RespondToEcjuQueryPage(driver)
     assert response_page.get_missing_document_reason_text() == reason
 

--- a/ui_tests/exporter/features/ecju_queries.feature
+++ b/ui_tests/exporter/features/ecju_queries.feature
@@ -35,10 +35,8 @@ So that I can quickly identify where action is required by me and respond to any
     And I click to respond to the ecju query
     And I enter my response as "Uploading requested documents"
     And I click "add_document"
-    And I select that I cannot attach a document
-    And I see ECJU helpline details
-    And I select a valid missing document reason
-    And I see the missing document reason text "No document attached: Document is above OFFICIAL-SENSITIVE"
+    And I click the back link
+    And I see the missing document reason text "There are no documents."
     And I click "submit"
     And I select "yes" for submitting response and click submit
     Then I see my ecju query is closed
@@ -51,11 +49,9 @@ So that I can quickly identify where action is required by me and respond to any
     And I click to respond to the ecju query
     And I enter my response as "Uploading requested documents"
     And I click "add_document"
-    And I confirm I can upload a document
     And I upload file "file_for_doc_upload_test_1.txt" with description "Supporting document for the query"
     And I see "1" documents ready to be included in the response
     And I click "add_document"
-    And I confirm I can upload a document
     And I upload file "file_for_doc_upload_test_1.txt" with description "Supporting document for the query"
     And I see "2" documents ready to be included in the response
     And I click "submit"
@@ -70,7 +66,6 @@ So that I can quickly identify where action is required by me and respond to any
     And I click to respond to the ecju query
     And I enter my response as "Uploading requested documents"
     And I click "add_document"
-    And I confirm I can upload a document
     And I upload file "file_for_doc_upload_test_1.txt" with description "Supporting document for the query"
     And I see "1" documents ready to be included in the response
     And I delete document "1" from the response

--- a/ui_tests/exporter/features/ecju_queries.feature
+++ b/ui_tests/exporter/features/ecju_queries.feature
@@ -26,3 +26,55 @@ So that I can quickly identify where action is required by me and respond to any
     And I enter "This is my edited response" for ecju query and click submit
     And I select "yes" for submitting response and click submit
     Then I see my ecju query is closed
+
+  @LTD_305_ecju_query_response_without_document @regression
+  Scenario: view an ecju query, provide response without uploading documents
+    Given I go to exporter homepage and choose Test Org
+    When I go to the recently created application with ecju query
+    And I click the ECJU Queries tab
+    And I click to respond to the ecju query
+    And I enter my response as "Uploading requested documents"
+    And I click "add_document"
+    And I select that I cannot attach a document
+    And I see ECJU helpline details
+    And I select a valid missing document reason
+    And I see the missing document reason text "No document attached: Document is above OFFICIAL-SENSITIVE"
+    And I click "submit"
+    And I select "yes" for submitting response and click submit
+    Then I see my ecju query is closed
+
+  @LTD_305_ecju_query_response_with_document @regression
+  Scenario: view an ecju query, provide response and upload documents
+    Given I go to exporter homepage and choose Test Org
+    When I go to the recently created application with ecju query
+    And I click the ECJU Queries tab
+    And I click to respond to the ecju query
+    And I enter my response as "Uploading requested documents"
+    And I click "add_document"
+    And I confirm I can upload a document
+    And I upload file "file_for_doc_upload_test_1.txt" with description "Supporting document for the query"
+    And I see "1" documents ready to be included in the response
+    And I click "add_document"
+    And I confirm I can upload a document
+    And I upload file "file_for_doc_upload_test_1.txt" with description "Supporting document for the query"
+    And I see "2" documents ready to be included in the response
+    And I click "submit"
+    And I select "yes" for submitting response and click submit
+    Then I see my ecju query is closed
+
+  @LTD_305_ecju_query_response_upload_and_delete_document @regression
+  Scenario: view an ecju query, provide response and upload and delete document
+    Given I go to exporter homepage and choose Test Org
+    When I go to the recently created application with ecju query
+    And I click the ECJU Queries tab
+    And I click to respond to the ecju query
+    And I enter my response as "Uploading requested documents"
+    And I click "add_document"
+    And I confirm I can upload a document
+    And I upload file "file_for_doc_upload_test_1.txt" with description "Supporting document for the query"
+    And I see "1" documents ready to be included in the response
+    And I delete document "1" from the response
+    And I see the missing document reason text "There are no documents."
+    And I click "submit"
+    And I select "yes" for submitting response and click submit
+    Then I see my ecju query is closed

--- a/ui_tests/exporter/pages/respond_to_ecju_query_page.py
+++ b/ui_tests/exporter/pages/respond_to_ecju_query_page.py
@@ -8,10 +8,7 @@ class RespondToEcjuQueryPage(BasePage):
     DOCUMENT_INFORMATION_TEXT = "lite-information-text__text"
     UPLOADED_DOCUMENT_ITEM_CLASS = "app-documents__item"
 
-    def enter_form_response(
-        self,
-        value,
-    ):
+    def enter_form_response(self, value):
         response_tb = self.driver.find_element_by_id(self.RESPONSE_FORM)
         response_tb.clear()
         response_tb.send_keys(value)

--- a/ui_tests/exporter/pages/respond_to_ecju_query_page.py
+++ b/ui_tests/exporter/pages/respond_to_ecju_query_page.py
@@ -1,12 +1,43 @@
+from selenium.webdriver.support.select import Select
+
 from ui_tests.exporter.pages.BasePage import BasePage
 
 
 class RespondToEcjuQueryPage(BasePage):
     RESPONSE_FORM = "response"  # ID
+    DOCUMENT_INFORMATION_TEXT = "lite-information-text__text"
+    UPLOADED_DOCUMENT_ITEM_CLASS = "app-documents__item"
 
     def enter_form_response(
-        self, value,
+        self,
+        value,
     ):
         response_tb = self.driver.find_element_by_id(self.RESPONSE_FORM)
         response_tb.clear()
         response_tb.send_keys(value)
+
+    def get_missing_document_reason_text(self):
+        element = self.driver.find_element_by_class_name(self.DOCUMENT_INFORMATION_TEXT)
+        return element.text.split("\n")[1].strip()
+
+    def get_uploaded_document_items(self):
+        return self.driver.find_elements_by_class_name(self.UPLOADED_DOCUMENT_ITEM_CLASS)
+
+    def get_uploaded_documents_delete_links(self):
+        return self.driver.find_elements_by_link_text("Delete")
+
+
+class DocumentGradingPage(BasePage):
+    DOCUMENT_AVAILABLE_FOR_UPLOAD = "has_document_to_upload-"
+    ECJU_HELPLINE_ID = "conditional-has_document_to_upload-no-conditional"
+    MISSING_DOCUMENT_REASON = "missing_document_reason"  # ID
+
+    def confirm_upload_document(self, option):
+        # The only options accepted here are 'yes', 'no'
+        self.driver.find_element_by_id(self.DOCUMENT_AVAILABLE_FOR_UPLOAD + option.lower()).click()
+
+    def get_ecju_help(self):
+        return self.driver.find_element_by_id(self.ECJU_HELPLINE_ID).is_displayed()
+
+    def select_valid_missing_document_reason(self):
+        Select(self.driver.find_element_by_id(self.MISSING_DOCUMENT_REASON)).select_by_index(2)

--- a/ui_tests/exporter/step_defs/test_ecju_queries.py
+++ b/ui_tests/exporter/step_defs/test_ecju_queries.py
@@ -1,4 +1,8 @@
-from pytest_bdd import when, scenarios
+from exporter.ecju_queries.services import get_ecju_query_documents
+from pytest_bdd import when, scenarios, then, parsers
+from tests_common import functions
+
+from ui_tests.exporter.pages.respond_to_ecju_query_page import RespondToEcjuQueryPage, DocumentGradingPage
 
 
 scenarios("../features/ecju_queries.feature", strict_gherkin=False)
@@ -12,3 +16,40 @@ def click_on_an_application(driver, exporter_url, context, apply_for_standard_ap
 @when("I click on an CLC query previously created")
 def click_on_clc_query(driver, exporter_url, context, add_goods_clc_query):
     driver.get(exporter_url.rstrip("/") + "/goods/" + context.goods_query_good_id)
+
+
+@when("I confirm I can upload a document")
+def confirm_can_upload_document(driver):
+    # Confirm you have a document that is not sensitive
+    DocumentGradingPage(driver).confirm_upload_document("yes")
+    functions.click_submit(driver)
+
+
+@when("I select that I cannot attach a document")
+def select_cannot_attach_a_document(driver):
+    DocumentGradingPage(driver).confirm_upload_document("no")
+
+
+@when("I see ECJU helpline details")
+def ecju_helpline(driver):
+    assert DocumentGradingPage(driver).get_ecju_help()
+
+
+@when("I select a valid missing document reason")
+def select_missing_document_reason(driver):
+    DocumentGradingPage(driver).select_valid_missing_document_reason()
+    functions.click_submit(driver)
+
+
+@when(parsers.parse('I see "{expected_count:d}" documents ready to be included in the response'))
+def verify_upload_document_count(driver, expected_count):
+    items = RespondToEcjuQueryPage(driver).get_uploaded_document_items()
+    assert len(items) == expected_count
+
+
+@when(parsers.parse('I delete document "{item_index:d}" from the response'))
+def delete_uploaded_document_and_submit(driver, item_index):
+    document = RespondToEcjuQueryPage(driver).get_uploaded_documents_delete_links()[item_index - 1]
+    driver.execute_script("arguments[0].scrollIntoView();", document)
+    driver.execute_script("arguments[0].click();", document)
+    functions.click_submit(driver)

--- a/ui_tests/exporter/step_defs/test_goods.py
+++ b/ui_tests/exporter/step_defs/test_goods.py
@@ -223,15 +223,6 @@ def click_add_from_organisation_button(driver):  # noqa
     GoodsListPage(driver).click_add_a_good()
 
 
-@when(parsers.parse('I upload file "{filename}" with description "{description}"'))  # noqa
-def upload_a_file_with_description(driver, filename, description):  # noqa
-    attach_document_page = AttachDocumentPage(driver)
-    file_path = get_file_upload_path(filename)
-    attach_document_page.choose_file(file_path)
-    attach_document_page.enter_description(description)
-    functions.click_submit(driver)
-
-
 @when(
     parsers.parse(
         'I raise a clc query control code "{control_code}" clc description "{clc_reason}" and pv grading reason "{pv_grading_reason}"'


### PR DESCRIPTION
## Change description

Changes to support document uploads when responding to an ECJU query or pre-visit questionnaire or Compliance action.
- create new templates, views as required
- Add new content strings
- Add browser tests

Updated query response page showing uploaded documents,
![ecju_query_response_updated](https://user-images.githubusercontent.com/2622464/98247938-2d304800-1f6c-11eb-8419-810673b7adb6.png)

Once the query is closed,
![closed_query_response](https://user-images.githubusercontent.com/2622464/98248752-45549700-1f6d-11eb-88ed-f165464eda9d.png)

