### PR TITLE
LTD-434: Cannot add new product to draft application

### DIFF
--- a/exporter/applications/views/goods.py
+++ b/exporter/applications/views/goods.py
@@ -132,7 +132,7 @@ class CheckDocumentGrading(LoginRequiredMixin, SingleFormView):
     def init(self, request, **kwargs):
         self.draft_pk = kwargs["pk"]
         self.object_pk = kwargs["good_pk"]
-        self.form = document_grading_form(request, reverse_lazy("goods:good", kwargs={"pk": self.object_pk}))
+        self.form = document_grading_form(request, self.object_pk)
         self.action = post_good_document_sensitivity
 
     def get_success_url(self):

--- a/exporter/goods/views.py
+++ b/exporter/goods/views.py
@@ -138,7 +138,7 @@ class GoodsDetail(LoginRequiredMixin, TemplateView):
                 context["generated_documents"] = generated_documents["results"]
 
         if self.view_type == "application":
-            context["draft_pk"] = str(kwargs.get("draft_pk"))
+            context["draft_pk"] = str(kwargs.get("draft_pk", ""))
 
         if self.view_type == "case-notes":
             if self.good.get("case_id"):
@@ -199,7 +199,7 @@ class GoodSoftwareTechnology(LoginRequiredMixin, SingleFormView):
             self.application_id = str(kwargs["pk"])
         else:
             self.object_pk = str(kwargs["pk"])
-        self.draft_pk = kwargs.get("draft_pk")
+        self.draft_pk = str(kwargs.get("draft_pk", ""))
         self.data = get_good_details(request, self.object_pk)[0]
         self.form = software_technology_details_form(request, self.data.get("item_category"))
         self.action = edit_good_details
@@ -239,7 +239,7 @@ class GoodMilitaryUse(LoginRequiredMixin, SingleFormView):
             self.application_id = str(kwargs["pk"])
         else:
             self.object_pk = str(kwargs["pk"])
-        self.draft_pk = kwargs.get("draft_pk")
+        self.draft_pk = str(kwargs.get("draft_pk", ""))
         self.data = get_good_details(request, self.object_pk)[0]
         self.form = product_military_use_form(request)
         self.action = edit_good_details
@@ -297,7 +297,7 @@ class GoodComponent(LoginRequiredMixin, SingleFormView):
             self.application_id = str(kwargs["pk"])
         else:
             self.object_pk = str(kwargs["pk"])
-        self.draft_pk = kwargs.get("draft_pk")
+        self.draft_pk = str(kwargs.get("draft_pk", ""))
         self.data = get_good_details(request, self.object_pk)[0]
         self.form = product_component_form(request)
         self.action = edit_good_details
@@ -340,7 +340,7 @@ class GoodInformationSecurity(LoginRequiredMixin, SingleFormView):
             self.application_id = str(kwargs["pk"])
         else:
             self.object_pk = str(kwargs["pk"])
-        self.draft_pk = kwargs.get("draft_pk")
+        self.draft_pk = str(kwargs.get("draft_pk", ""))
         self.data = get_good_details(request, self.object_pk)[0]
         self.form = product_uses_information_security(request)
         self.action = edit_good_details
@@ -370,10 +370,10 @@ class GoodInformationSecurity(LoginRequiredMixin, SingleFormView):
 class RaiseGoodsQuery(LoginRequiredMixin, SingleFormView):
     def init(self, request, **kwargs):
         self.object_pk = str(kwargs["pk"])
-        self.draft_pk = kwargs.get("draft_pk")
+        self.draft_pk = str(kwargs.get("draft_pk", ""))
         good, _ = get_good(request, self.object_pk)
 
-        raise_a_clc_query = "unsure" == good["is_good_controlled"]["key"]
+        raise_a_clc_query = good["is_good_controlled"] is None
         raise_a_pv_query = "grading_required" == good["is_pv_graded"]["key"]
 
         self.form = raise_a_goods_query(self.object_pk, raise_a_clc_query, raise_a_pv_query)
@@ -398,7 +398,7 @@ class EditGood(LoginRequiredMixin, SingleFormView):
             self.application_id = str(kwargs["pk"])
         else:
             self.object_pk = str(kwargs["pk"])
-        self.draft_pk = kwargs.get("draft_pk")
+        self.draft_pk = str(kwargs.get("draft_pk", ""))
         self.data = get_good(request, self.object_pk)[0]
         self.form = edit_good_detail_form(request, self.object_pk)
         self.action = edit_good
@@ -434,7 +434,7 @@ class EditGrading(LoginRequiredMixin, SingleFormView):
             self.application_id = str(kwargs["pk"])
         else:
             self.object_pk = str(kwargs["pk"])
-        self.draft_pk = kwargs.get("draft_pk")
+        self.draft_pk = str(kwargs.get("draft_pk", ""))
         self.data = get_good(request, self.object_pk)[0]
         self.form = edit_grading_form(request, self.object_pk)
         self.action = edit_good_pv_grading
@@ -458,7 +458,7 @@ class EditGrading(LoginRequiredMixin, SingleFormView):
             )
         good = get_good(self.request, self.object_pk, full_detail=True)[0]
 
-        raise_a_clc_query = "unsure" == good["is_good_controlled"]["key"]
+        raise_a_clc_query = good["is_good_controlled"] is None
         raise_a_pv_query = "grading_required" == good["is_pv_graded"]["key"]
 
         if self.draft_pk:
@@ -484,7 +484,7 @@ class EditFirearmProductType(LoginRequiredMixin, SingleFormView):
             self.application_id = str(kwargs["pk"])
         else:
             self.object_pk = str(kwargs["pk"])
-        self.draft_pk = kwargs.get("draft_pk")
+        self.draft_pk = str(kwargs.get("draft_pk", ""))
         self.data = get_good_details(request, self.object_pk)[0]["firearm_details"]
         self.form = group_two_product_type_form()
         self.action = edit_good_firearm_details
@@ -518,7 +518,7 @@ class EditAmmunition(LoginRequiredMixin, SingleFormView):
             self.application_id = str(kwargs["pk"])
         else:
             self.object_pk = str(kwargs["pk"])
-        self.draft_pk = kwargs.get("draft_pk")
+        self.draft_pk = str(kwargs.get("draft_pk", ""))
         self.data = get_good_details(request, self.object_pk)[0]["firearm_details"]
         self.form = firearm_ammunition_details_form()
         self.action = edit_good_firearm_details
@@ -552,7 +552,7 @@ class EditFirearmActDetails(LoginRequiredMixin, SingleFormView):
             self.application_id = str(kwargs["pk"])
         else:
             self.object_pk = str(kwargs["pk"])
-        self.draft_pk = kwargs.get("draft_pk")
+        self.draft_pk = str(kwargs.get("draft_pk", ""))
         self.data = get_good_details(request, self.object_pk)[0]["firearm_details"]
         self.form = firearms_act_confirmation_form()
         self.action = edit_good_firearm_details
@@ -608,7 +608,7 @@ class EditIdentificationMarkings(LoginRequiredMixin, SingleFormView):
             self.application_id = str(kwargs["pk"])
         else:
             self.object_pk = str(kwargs["pk"])
-        self.draft_pk = kwargs.get("draft_pk")
+        self.draft_pk = str(kwargs.get("draft_pk", ""))
         self.data = get_good_details(request, self.object_pk)[0]["firearm_details"]
         self.form = identification_markings_form()
         self.action = edit_good_firearm_details
@@ -658,7 +658,7 @@ class CheckDocumentGrading(LoginRequiredMixin, SingleFormView):
 
         if self.request.POST.get("has_document_to_upload") == "no":
             good = self.get_validated_data()["good"]
-            raise_a_clc_query = "unsure" == good["is_good_controlled"]["key"]
+            raise_a_clc_query = good["is_good_controlled"] is None
             raise_a_pv_query = "grading_required" == good["is_pv_graded"]["key"]
 
             if self.draft_pk:
@@ -687,7 +687,7 @@ class AttachDocuments(LoginRequiredMixin, TemplateView):
         return_to_good_page = request.GET.get("goodpage", "no")
         good_id = str(kwargs["pk"])
         extra_data = {"good_id": good_id}
-        draft_pk = str(kwargs.get("draft_pk"))
+        draft_pk = str(kwargs.get("draft_pk", ""))
         if draft_pk:
             extra_data["draft_pk"] = draft_pk
         if return_to_good_page == "yes":
@@ -719,7 +719,7 @@ class AttachDocuments(LoginRequiredMixin, TemplateView):
         self.request.upload_handlers.insert(0, S3FileUploadHandler(request))
 
         good_id = str(kwargs["pk"])
-        draft_pk = str(kwargs.get("draft_pk"))
+        draft_pk = str(kwargs.get("draft_pk", ""))
         good, _ = get_good(request, good_id)
 
         data, error = add_document_data(request)
@@ -731,7 +731,7 @@ class AttachDocuments(LoginRequiredMixin, TemplateView):
         if status_code != HTTPStatus.CREATED:
             return error_page(request, data["errors"]["file"])
 
-        raise_a_clc_query = "unsure" == good["is_good_controlled"]["key"]
+        raise_a_clc_query = good["is_good_controlled"] is None
         raise_a_pv_query = "grading_required" == good["is_pv_graded"]["key"]
 
         if draft_pk:
@@ -765,7 +765,7 @@ class Document(LoginRequiredMixin, TemplateView):
 class DeleteDocument(LoginRequiredMixin, TemplateView):
     def get(self, request, **kwargs):
         good_id = str(kwargs["pk"])
-        draft_pk = str(kwargs.get("draft_pk"))
+        draft_pk = str(kwargs.get("draft_pk", ""))
         file_pk = str(kwargs["file_pk"])
 
         document = get_good_document(request, good_id, file_pk)
@@ -780,7 +780,7 @@ class DeleteDocument(LoginRequiredMixin, TemplateView):
 
     def post(self, request, **kwargs):
         good_id = str(kwargs["pk"])
-        draft_pk = str(kwargs.get("draft_pk"))
+        draft_pk = str(kwargs.get("draft_pk", ""))
         file_pk = str(kwargs["file_pk"])
 
         # Delete the file on the API

--- a/exporter/templates/goods/delete-document.html
+++ b/exporter/templates/goods/delete-document.html
@@ -58,7 +58,7 @@
 		<form method="post" action="{% url 'goods:delete_document' good_id document.id %}">
 	{% endif %}
 		{% csrf_token %}
-		<button type="submit" class="govuk-button govuk-button--warning govuk-!-margin-right-2">{% lcs "goods.DeleteGoodDocumentPage.BUTTON" %}</button>
+		<button type="submit" value="submit" class="govuk-button govuk-button--warning govuk-!-margin-right-2">{% lcs "goods.DeleteGoodDocumentPage.BUTTON" %}</button>
 	</form>
 </div>
 {% endblock %}

--- a/ui_tests/exporter/features/goods.feature
+++ b/ui_tests/exporter/features/goods.feature
@@ -10,16 +10,17 @@ Feature: I want to edit and remove goods on the goods list
     When I click on goods link
     And I click add a good button
     And I select product category "one" for a good
-    And I add a good with description "123 pistol" part number "321" controlled "Yes" control code "ML1a" and graded "yes"
+    And I add a good with description "123 pistol" part number "321" controlled "True" control code "ML1a" and graded "yes"
     And I add the goods grading with prefix "abc" grading "nato_restricted" suffix "def" issuing authority "NATO" reference "12345" Date of issue "10-05-2015"
     And I specify the "category 1" good details military use "yes_modified" component "yes_general" and information security "Yes"
     And I confirm I can upload a document
     And I upload file "file_for_doc_upload_test_1.txt" with description "This is a file I want to upload to show."
     And I get the goods ID
     Then I see good in goods list
-    When I edit the good to description "edited" part number "321" controlled "Yes" and control list entry "ML1a"
+    When I edit the good to description "edited" part number "321" controlled "True" and control list entry "ML1a"
     And I edit the "category 1" good details to military use "yes_designed" component "yes_designed" information security "No"
     Then I see my edited good details in the good page
+    And I delete document "1" from the good
     When I delete my good
     Then my good is no longer in the goods list
 
@@ -29,7 +30,7 @@ Feature: I want to edit and remove goods on the goods list
     When I click on goods link
     And I click add a good button
     And I select product category "one" for a good
-    And I add a good with description "Hand pistol" part number "321" controlled "Unsure" control code " " and graded "grading_required"
+    And I add a good with description "Hand pistol" part number "321" controlled "None" control code " " and graded "grading_required"
     And I specify the "category 1" good details military use "yes_designed" component "yes_modified" and information security "No"
     And I confirm I can upload a document
     And I upload file "file_for_doc_upload_test_1.txt" with description "This is a file I want to upload to show."
@@ -43,7 +44,7 @@ Feature: I want to edit and remove goods on the goods list
     When I click on goods link
     And I click add a good button
     And I select product category "one" for a good
-    And I add a good with description "Hand pistol" part number "321" controlled "Unsure" control code " " and graded "no"
+    And I add a good with description "Hand pistol" part number "321" controlled "None" control code " " and graded "no"
     And I specify the "category 1" good details military use "no" component "no" and information security "No"
     And I select that I cannot attach a document
     Then I see ECJU helpline details

--- a/ui_tests/exporter/pages/add_goods_page.py
+++ b/ui_tests/exporter/pages/add_goods_page.py
@@ -30,8 +30,8 @@ class AddGoodPage(BasePage):
         self.driver.find_element_by_id(self.DESCRIPTION).send_keys(description)
 
     def select_is_your_good_controlled(self, option):
-        # The only options accepted here are 'yes', 'no' and 'unsure'
-        self.driver.find_element_by_id(self.IS_CONTROLLED + option.lower()).click()
+        # The options accepted here are 'True', 'False' and 'None'
+        self.driver.find_element_by_id(self.IS_CONTROLLED + option).click()
 
     def select_is_your_good_graded(self, option):
         # The only options accepted here are 'yes', 'no' and 'grading_required'

--- a/ui_tests/exporter/pages/goods_page.py
+++ b/ui_tests/exporter/pages/goods_page.py
@@ -3,7 +3,7 @@ from ui_tests.exporter.pages.BasePage import BasePage
 
 class GoodsPage(BasePage):
 
-    LINK_EDIT_ID = "link-edit"
+    LINK_EDIT_ID = "link-edit-description"
     QUERY_TABLE_ID = "query_table"
     BUTTON_DELETE_GOOD_ID = "button-delete-good"
 
@@ -45,3 +45,6 @@ class GoodsPage(BasePage):
 
     def click_delete_button(self):
         self.driver.find_element_by_id(self.BUTTON_DELETE_GOOD_ID).click()
+
+    def get_uploaded_documents_delete_links(self):
+        return self.driver.find_elements_by_link_text("Delete")

--- a/ui_tests/exporter/step_defs/test_goods.py
+++ b/ui_tests/exporter/step_defs/test_goods.py
@@ -92,6 +92,14 @@ def delete_my_good_in_list(driver, context):
     functions.click_submit(driver)
 
 
+@then(parsers.parse('I delete document "{item_index:d}" from the good'))
+def delete_uploaded_document_from_good_and_submit(driver, item_index):
+    document = GoodsPage(driver).get_uploaded_documents_delete_links()[item_index - 1]
+    driver.execute_script("arguments[0].scrollIntoView();", document)
+    driver.execute_script("arguments[0].click();", document)
+    functions.click_submit(driver)
+
+
 @then("my good is no longer in the goods list")
 def good_is_no_longer_in_list(driver, context):
     assert context.good_description not in Shared(driver).get_text_of_gov_table()


### PR DESCRIPTION
## Change description
When `draft_pk` is missing in kwargs it returns `None` but it was being converted to string using `str(kwargs.get("draft_pk"))` which assigns the value `"None"` to it resulting in this bug.

Fixed the existing browser test and extended it to be able to test this.