### PR TITLE
LTD-398: Accurately categorise Firearms related products

### DIFF
--- a/caseworker/templates/case/product-on-case.html
+++ b/caseworker/templates/case/product-on-case.html
@@ -40,6 +40,25 @@
                             <th scope="row" class="govuk-table__header">Category</th>
                             <td class="govuk-table__cell">{{ good_on_application.good.item_category.value }}</td>
                         </tr>
+                        {% if good_on_application.good.firearm_details %}
+                            <tr class="govuk-table__row app-table__row">
+                                <th scope="row" class="govuk-table__header">Product type</th>
+                                <td class="govuk-table__cell">{{ good_on_application.good.firearm_details.type.value }}</td>
+                            </tr>
+                        {% else %}
+                            <tr class="govuk-table__row app-table__row">
+                                    <th scope="row" class="govuk-table__header">Product type</th>
+                                    <td class="govuk-table__cell">
+                                        {% if good_on_application.item_type %}
+                                            {{ good_on_application.item_type }}
+                                        {% elif good_on_application.other_item_type %}
+                                            {{ good_on_application.other_item_type }}
+                                        {% else %}
+                                            N/A
+                                        {% endif %}
+                                    </td>
+                                </tr>
+                        {% endif %}
                         <tr class="govuk-table__row app-table__row">
                             <th scope="row" class="govuk-table__header">Description</th>
                             <td class="govuk-table__cell">{{ good_on_application.good.description }}</td>
@@ -74,47 +93,87 @@
                                 {% endif %}
                             </td>
                         </tr>
-                        <tr class="govuk-table__row app-table__row">
-                            <th scope="row" class="govuk-table__header">Product type</th>
-                            <td class="govuk-table__cell">
-                                {% if good_on_application.item_type %}
-                                    {{ good_on_application.item_type }}
-                                {% elif good_on_application.other_item_type %}
-                                    {{ good_on_application.other_item_type }}
-                                {% else %}
-                                    N/A
-                                {% endif %}
-                            </td>
-                        </tr>
                         {% if good_on_application.good.firearm_details %}
-                            <tr class="govuk-table__row app-table__row">
-                                <th scope="row" class="govuk-table__header">Year of manufacture</th>
-                                <td class="govuk-table__cell">{{ good_on_application.good.firearm_details.year_of_manufacture }}</td>
-                            </tr>
-                            <tr class="govuk-table__row app-table__row">
-                                <th scope="row" class="govuk-table__header">Calibre</th>
-                                <td class="govuk-table__cell">{{ good_on_application.good.firearm_details.calibre }}</td>
-                            </tr>
-                            <tr class="govuk-table__row app-table__row">
-                                <th scope="row" class="govuk-table__header">Covered by Firearms Act 1968</th>
-                                <td class="govuk-table__cell">
-                                    {% if good_on_application.good.firearm_details.is_covered_by_firearm_act_section_one_two_or_five %}
-                                        Yes, section {{ good_on_application.good.firearm_details.section_certificate_number}} 
-                                    {% else %}
-                                        No
-                                    {% endif %}
-                                </td>
-                            </tr>
-                            <tr class="govuk-table__row app-table__row">
-                                <th scope="row" class="govuk-table__header">Identification markings</th>
-                                <td class="govuk-table__cell">
-                                    {% if good_on_application.good.firearm_details.has_identification_markings %}
-                                        Yes, {{ good_on_application.good.firearm_details.identification_markings_details }}
-                                    {% else %}
-                                        No, {{ good_on_application.no_identification_markings_details.identification_markings_details }}
-                                    {% endif %}
-                                </td>
-                            </tr>
+                            {% if good_on_application.good.firearm_details.type.key in "firearms,ammunition,components_for_firearms,components_for_ammunition" %}
+                                <tr class="govuk-table__row app-table__row">
+                                    <th scope="row" class="govuk-table__header">Year of manufacture</th>
+                                    <td class="govuk-table__cell">{{ good_on_application.good.firearm_details.year_of_manufacture }}</td>
+                                </tr>
+                                <tr class="govuk-table__row app-table__row">
+                                    <th scope="row" class="govuk-table__header">Calibre</th>
+                                    <td class="govuk-table__cell">{{ good_on_application.good.firearm_details.calibre }}</td>
+                                </tr>
+                                <tr class="govuk-table__row app-table__row">
+                                    <th scope="row" class="govuk-table__header">Covered by Firearms Act 1968</th>
+                                    <td class="govuk-table__cell">
+                                        {% if good_on_application.good.firearm_details.is_covered_by_firearm_act_section_one_two_or_five %}
+                                            Yes, section {{ good_on_application.good.firearm_details.section_certificate_number}} 
+                                        {% else %}
+                                            No
+                                        {% endif %}
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row app-table__row">
+                                    <th scope="row" class="govuk-table__header">Identification markings</th>
+                                    <td class="govuk-table__cell">
+                                        {% if good_on_application.good.firearm_details.has_identification_markings %}
+                                            Yes, {{ good_on_application.good.firearm_details.identification_markings_details }}
+                                        {% else %}
+                                            No, {{ good_on_application.no_identification_markings_details.identification_markings_details }}
+                                        {% endif %}
+                                    </td>
+                                </tr>
+                            {% endif %}
+
+                            {% if good_on_application.good.firearm_details.type.key == "firearms_accessory" %}
+                                <tr class="govuk-table__row app-table__row">
+                                    <th scope="row" class="govuk-table__header">Military use</th>
+                                    <td class="govuk-table__cell">{{ good_on_application.good.is_military_use.value|default_na }}
+                                        {% if good_on_application.good.modified_military_use_details %}
+                                        <span class="govuk-hint"> {{ good_on_application.good.modified_military_use_details }} </span>
+                                        {% endif %}
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row app-table__row">
+                                    <th scope="row" class="govuk-table__header">Component</th>
+                                    <td class="govuk-table__cell">{{ good_on_application.good.is_component.value|default_na }}
+                                        {% if good_on_application.good.modified_military_use_details %}
+                                        <span class="govuk-hint"> {{ good_on_application.good.component_details }} </span>
+                                        {% endif %}
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row app-table__row">
+                                    <th scope="row" class="govuk-table__header">Information security features</th>
+                                    <td class="govuk-table__cell">{{ good_on_application.good.uses_information_security|friendly_boolean }}
+                                        {% if good_on_application.good.information_security_details %}
+                                        <span class="govuk-hint"> {{ good_on_application.good.information_security_details }} </span>
+                                        {% endif %}
+                                    </td>
+                                </tr>
+                            {% endif %}
+
+                            {% if good_on_application.good.firearm_details.type.key in "software_related_to_firearms,technology_related_to_firearms" %}
+                                <tr class="govuk-table__row app-table__row">
+                                    <th scope="row" class="govuk-table__header">Purpose</th>
+                                    <td class="govuk-table__cell">{{ good_on_application.good.software_or_technology_details|default_na }}</td>
+                                </tr>
+                                <tr class="govuk-table__row app-table__row">
+                                    <th scope="row" class="govuk-table__header">Military use</th>
+                                    <td class="govuk-table__cell">{{ good_on_application.good.is_military_use.value|default_na }}
+                                        {% if good_on_application.good.modified_military_use_details %}
+                                        <span class="govuk-hint"> {{ good_on_application.good.modified_military_use_details }} </span>
+                                        {% endif %}
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row app-table__row">
+                                    <th scope="row" class="govuk-table__header">Information security features</th>
+                                    <td class="govuk-table__cell">{{ good_on_application.good.uses_information_security|friendly_boolean }}
+                                        {% if good_on_application.good.information_security_details %}
+                                        <span class="govuk-hint"> {{ good_on_application.good.information_security_details }} </span>
+                                        {% endif %}
+                                    </td>
+                                </tr>
+                            {% endif %}
                         {% endif %}
                         <tr class="govuk-table__row app-table__row">
                             <th scope="row" class="govuk-table__header">Incorporated</th>

--- a/exporter/applications/views/goods.py
+++ b/exporter/applications/views/goods.py
@@ -108,6 +108,10 @@ class AddGood(LoginRequiredMixin, MultiFormView):
 
     def on_submission(self, request, **kwargs):
         copied_request = request.POST.copy()
+
+        # We are only allowing firearms categories temporarily
+        copied_request["item_category"] = "group2_firearms"
+
         is_pv_graded = copied_request.get("is_pv_graded", "") == "yes"
         is_software_technology = copied_request.get("item_category") in ["group3_software", "group3_technology"]
         is_firearms = copied_request.get("item_category") == "group2_firearms"

--- a/exporter/applications/views/goods.py
+++ b/exporter/applications/views/goods.py
@@ -108,15 +108,27 @@ class AddGood(LoginRequiredMixin, MultiFormView):
 
     def on_submission(self, request, **kwargs):
         copied_request = request.POST.copy()
-
-        # We are only allowing firearms categories temporarily
-        copied_request["item_category"] = "group2_firearms"
-
         is_pv_graded = copied_request.get("is_pv_graded", "") == "yes"
         is_software_technology = copied_request.get("item_category") in ["group3_software", "group3_technology"]
-        is_firearms = copied_request.get("item_category") == "group2_firearms"
+        is_firearms_core = copied_request.get("type") in [
+            "firearms",
+            "ammunition",
+            "components_for_firearms",
+            "components_for_ammunition",
+        ]
+        is_firearms_accessory = copied_request.get("type") == "firearms_accessory"
+        is_firearms_software_tech = copied_request.get("type") in [
+            "software_related_to_firearms",
+            "technology_related_to_firearms",
+        ]
         self.forms = add_good_form_group(
-            request, is_pv_graded, is_software_technology, is_firearms, draft_pk=self.draft_pk
+            request,
+            is_pv_graded,
+            is_software_technology,
+            is_firearms_core,
+            is_firearms_accessory,
+            is_firearms_software_tech,
+            draft_pk=self.draft_pk,
         )
 
         # we require the form index of the last form in the group, not the total number

--- a/exporter/goods/forms.py
+++ b/exporter/goods/forms.py
@@ -345,14 +345,13 @@ def add_good_form_group(
     control_list_entries = get_control_list_entries(request, convert_to_options=True)
     return FormGroup(
         [
-            product_category_form(request),
+            group_two_product_type_form(),
             add_goods_questions(control_list_entries, draft_pk),
             conditional(is_pv_graded, pv_details_form(request)),
             conditional(is_software_technology, software_technology_details_form(request)),
             conditional(not is_firearms, product_military_use_form(request)),
             conditional(not is_software_technology and not is_firearms, product_component_form(request)),
             conditional(not is_firearms, product_uses_information_security(request)),
-            conditional(is_firearms, group_two_product_type_form()),
             conditional(is_firearms, firearm_ammunition_details_form()),
             conditional(is_firearms, firearms_act_confirmation_form()),
             conditional(is_firearms, identification_markings_form()),
@@ -526,11 +525,11 @@ def group_two_product_type_form():
                 name="type",
                 options=[
                     Option(key="firearms", value=CreateGoodForm.FirearmGood.ProductType.FIREARM),
+                    Option(key="ammunition", value=CreateGoodForm.FirearmGood.ProductType.AMMUNITION),
                     Option(
                         key="components_for_firearms",
                         value=CreateGoodForm.FirearmGood.ProductType.COMPONENTS_FOR_FIREARM,
                     ),
-                    Option(key="ammunition", value=CreateGoodForm.FirearmGood.ProductType.AMMUNITION),
                     Option(
                         key="components_for_ammunition",
                         value=CreateGoodForm.FirearmGood.ProductType.COMPONENTS_FOR_AMMUNITION,

--- a/exporter/goods/forms.py
+++ b/exporter/goods/forms.py
@@ -63,23 +63,14 @@ def product_category_form(request):
     )
 
 
-def software_technology_details_form(request, item_category=None):
-    category_type = request.POST.get("item_category", "") if not item_category else item_category
-    if request.POST.get("type") in ["software_related_to_firearms", "technology_related_to_firearms"]:
-        category_type = request.POST.get("type")
-
-    category = get_category_display_string(category_type)
+def software_technology_details_form(request, category_type):
+    category_text = get_category_display_string(category_type)
 
     return Form(
-        title=CreateGoodForm.TechnologySoftware.TITLE + category,
+        title=CreateGoodForm.TechnologySoftware.TITLE + category_text,
         questions=[
             HiddenField("is_software_or_technology_step", True),
-            TextArea(
-                title="",
-                description="",
-                name="software_or_technology_details",
-                optional=False,
-            ),
+            TextArea(title="", description="", name="software_or_technology_details", optional=False,),
         ],
     )
 
@@ -361,7 +352,7 @@ def add_good_form_group(
             conditional(is_firearms_core, firearm_ammunition_details_form()),
             conditional(is_firearms_core, firearms_act_confirmation_form()),
             conditional(is_firearms_core, identification_markings_form()),
-            conditional(is_firearms_software_tech, software_technology_details_form(request)),
+            conditional(is_firearms_software_tech, software_technology_details_form(request, request.POST.get("type"))),
             conditional(is_firearms_accessory or is_firearms_software_tech, product_military_use_form(request)),
             conditional(is_firearms_accessory, product_component_form(request)),
             conditional(is_firearms_accessory or is_firearms_software_tech, product_uses_information_security(request)),
@@ -488,11 +479,7 @@ def raise_a_goods_query(good_id, raise_a_clc: bool, raise_a_pv: bool):
                 name="clc_control_code",
                 optional=True,
             ),
-            TextArea(
-                title=GoodsQueryForm.CLCQuery.Details.TITLE,
-                name="clc_raised_reasons",
-                optional=True,
-            ),
+            TextArea(title=GoodsQueryForm.CLCQuery.Details.TITLE, name="clc_raised_reasons", optional=True,),
         ]
 
     if raise_a_pv:
@@ -501,11 +488,7 @@ def raise_a_goods_query(good_id, raise_a_clc: bool, raise_a_pv: bool):
                 Heading(GoodsQueryForm.PVGrading.TITLE, HeadingStyle.M),
             ]
         questions += [
-            TextArea(
-                title=GoodsQueryForm.PVGrading.Details.TITLE,
-                name="pv_grading_raised_reasons",
-                optional=True,
-            ),
+            TextArea(title=GoodsQueryForm.PVGrading.Details.TITLE, name="pv_grading_raised_reasons", optional=True,),
         ]
 
     return Form(
@@ -564,6 +547,7 @@ def group_two_product_type_form():
                 ],
             ),
         ],
+        default_button_name="Save and continue",
     )
 
 

--- a/exporter/goods/helpers.py
+++ b/exporter/goods/helpers.py
@@ -26,7 +26,12 @@ COMPONENT_SELECTION_TO_DETAIL_FIELD_MAP = {
 }
 
 
-ITEM_CATEGORY_TO_DISPLAY_STRING_MAP = {"group3_software": "software", "group3_technology": "technology"}
+ITEM_CATEGORY_TO_DISPLAY_STRING_MAP = {
+    "group3_software": "software",
+    "group3_technology": "technology",
+    "software_related_to_firearms": "software",
+    "technology_related_to_firearms": "technology",
+}
 
 
 def get_category_display_string(category):

--- a/exporter/goods/services.py
+++ b/exporter/goods/services.py
@@ -57,6 +57,19 @@ def add_firearm_details_to_data(json):
     if "product_type_step" in json:
         # parent component doesnt get sent when empty unlike the remaining form fields
         firearm_details["type"] = json.get("type")
+
+        # set default values as they are not applicable in these cases
+        if firearm_details["type"] in [
+            "firearms_accessory",
+            "software_related_to_firearms",
+            "technology_related_to_firearms",
+        ]:
+            firearm_details["is_covered_by_firearm_act_section_one_two_or_five"] = "no"
+            firearm_details["section_certificate_number"] = ""
+            firearm_details["section_certificate_date_of_expiry"] = ""
+            firearm_details["has_identification_markings"] = "False"
+            firearm_details["identification_markings_details"] = ""
+            firearm_details["no_identification_markings_details"] = ""
     if "firearm_ammunition_step" in json:
         firearm_details["year_of_manufacture"] = json.get("year_of_manufacture")
         firearm_details["calibre"] = json.get("calibre")

--- a/exporter/goods/services.py
+++ b/exporter/goods/services.py
@@ -23,6 +23,8 @@ def get_good_details(request, pk):
 
 
 def post_goods(request, json):
+    json["item_category"] = "group2_firearms"
+
     if "is_pv_graded" in json and json["is_pv_graded"] == "yes":
         if "reference" in json:
             json["pv_grading_details"] = {

--- a/exporter/goods/services.py
+++ b/exporter/goods/services.py
@@ -64,6 +64,8 @@ def add_firearm_details_to_data(json):
             "software_related_to_firearms",
             "technology_related_to_firearms",
         ]:
+            firearm_details["year_of_manufacture"] = None
+            firearm_details["calibre"] = ""
             firearm_details["is_covered_by_firearm_act_section_one_two_or_five"] = "no"
             firearm_details["section_certificate_number"] = ""
             firearm_details["section_certificate_date_of_expiry"] = ""

--- a/exporter/goods/views.py
+++ b/exporter/goods/views.py
@@ -176,8 +176,25 @@ class AddGood(LoginRequiredMixin, MultiFormView):
         copied_request = request.POST.copy()
         is_pv_graded = copied_request.get("is_pv_graded", "").lower() == "yes"
         is_software_technology = copied_request.get("item_category") in ["group3_software", "group3_technology"]
-        is_firearms = copied_request.get("item_category") == "group2_firearms"
-        self.forms = add_good_form_group(request, is_pv_graded, is_software_technology, is_firearms)
+        is_firearms_core = copied_request.get("type") in [
+            "firearms",
+            "ammunition",
+            "components_for_firearms",
+            "components_for_ammunition",
+        ]
+        is_firearms_accessory = copied_request.get("type") == "firearms_accessory"
+        is_firearms_software_tech = copied_request.get("type") in [
+            "software_related_to_firearms",
+            "technology_related_to_firearms",
+        ]
+        self.forms = add_good_form_group(
+            request,
+            is_pv_graded,
+            is_software_technology,
+            is_firearms_core,
+            is_firearms_accessory,
+            is_firearms_software_tech,
+        )
 
         # we require the form index of the last form in the group, not the total number
         number_of_forms = len(self.forms.get_forms()) - 1

--- a/exporter/goods/views.py
+++ b/exporter/goods/views.py
@@ -508,13 +508,13 @@ class EditFirearmProductType(LoginRequiredMixin, SingleFormView):
 
     def get_success_url(self):
         # Next question firearm and ammunition details
-        if not self.data.get("year_of_manufacture") or not self.data.get("calibre"):
+        if self.data.get("type"):
             if "good_pk" in self.kwargs:
                 return reverse_lazy(
-                    "applications:ammunition", kwargs={"pk": self.application_id, "good_pk": self.object_pk}
+                    "applications:edit_good", kwargs={"pk": self.application_id, "good_pk": self.object_pk}
                 )
             else:
-                return reverse_lazy("goods:ammunition", kwargs={"pk": self.object_pk})
+                return reverse_lazy("goods:edit", kwargs={"pk": self.object_pk})
         elif self.draft_pk:
             return reverse(
                 "goods:good_detail_application",

--- a/exporter/templates/applications/goods/add-good-detail-summary.html
+++ b/exporter/templates/applications/goods/add-good-detail-summary.html
@@ -15,13 +15,18 @@
 	<dl class="govuk-summary-list" id="good-detail-summary">
 		<div class="govuk-summary-list__row">
 			<dt class="govuk-summary-list__key">
-				{% lcs 'Goods.AddGoodSummary.CATEGORY' %}
+				{% lcs "Goods.AddGoodSummary.FirearmDetails.PRODUCT_TYPE" %}
 			</dt>
 			<dd class="govuk-summary-list__value">
-				{{ good.item_category.value }}
+				{{ good.firearm_details.type.value|default_na }}
 			</dd>
-			<dd class="govuk-summary-list__actions"></dd>
+			<dd class="govuk-summary-list__actions">
+				{% if good.status.key == 'draft' %}
+					<a id="change-product-type" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:firearm_type' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "Goods.AddGoodSummary.FirearmDetails.PRODUCT_TYPE" %}</span></a>
+				{% endif %}
+			</dd>
 		</div>
+
 		<div class="govuk-summary-list__row">
 			<dt class="govuk-summary-list__key">
 				{% lcs "Goods.AddGoodSummary.DESCRIPTION" %}
@@ -159,21 +164,9 @@
 		{% endif %}
 
 		{% if good.item_category.key == 'group2_firearms' %}
-			<div class="govuk-summary-list__row">
-				<dt class="govuk-summary-list__key">
-					{% lcs "Goods.AddGoodSummary.FirearmDetails.PRODUCT_TYPE" %}
-				</dt>
-				<dd class="govuk-summary-list__value">
-					{{ good.firearm_details.type.value|default_na }}
-				</dd>
-				<dd class="govuk-summary-list__actions">
-					{% if good.status.key == 'draft' %}
-						<a id="change-product-type" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:firearm_type' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "Goods.AddGoodSummary.FirearmDetails.PRODUCT_TYPE" %}</span></a>
-					{% endif %}
-				</dd>
-			</div>
-
-				<div class="govuk-summary-list__row">
+		{% with firearms_core_types="firearms ammunition components_for_firearms components_for_ammunition" %}
+			{% if good.firearm_details.type.key in firearms_core_types.split %}
+			    <div class="govuk-summary-list__row">
 					<dt class="govuk-summary-list__key">
 						{% lcs "Goods.AddGoodSummary.FirearmDetails.YEAR_OF_MANUFACTURE" %}
 					</dt>
@@ -243,6 +236,117 @@
 						{% endif %}
 					</dd>
 				</div>
+			{% endif %}
+		{% endwith %}
+
+		{% if good.firearm_details.type.key == "firearms_accessory" %}
+			<div class="govuk-summary-list__row">
+				<dt class="govuk-summary-list__key">
+					{% lcs "Goods.AddGoodSummary.MILITARY_USE" %}
+				</dt>
+				<dd class="govuk-summary-list__value">
+					{{ good.is_military_use.value|default_na }}
+					{% if good.modified_military_use_details %}
+						<span class="govuk-hint"> {{ good.modified_military_use_details }} </span>
+					{% endif %}
+				</dd>
+				<dd class="govuk-summary-list__actions">
+					{% if good.status.key == 'draft' %}
+						<a id="change-good-details" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:good_military_use' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs 'Goods.AddGoodSummary.MILITARY_USE' %}</span></a>
+					{% endif %}
+				</dd>
+			</div>
+			<div class="govuk-summary-list__row">
+				<dt class="govuk-summary-list__key">
+					{% lcs "Goods.AddGoodSummary.COMPONENT" %}
+				</dt>
+				<dd class="govuk-summary-list__value">
+					{{ good.is_component.value|default_na }}
+					{% if good.component_details %}
+						<span class="govuk-hint"> {{ good.component_details }} </span>
+					{% endif %}
+				</dd>
+				<dd class="govuk-summary-list__actions">
+					{% if good.status.key == 'draft' %}
+						<a class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:good_component' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs 'Goods.AddGoodSummary.COMPONENT' %}</span></a>
+					{% endif %}
+				</dd>
+			</div>
+
+			<div class="govuk-summary-list__row">
+				<dt class="govuk-summary-list__key">
+					{% lcs "Goods.AddGoodSummary.INFORMATION_SECURITY_FEATURES" %}
+				</dt>
+				<dd class="govuk-summary-list__value">
+					{% if good.uses_information_security is not None %}
+						{{ good.uses_information_security|friendly_boolean }}
+					{% else %}
+						{{ good.uses_information_security|default_na }}
+					{% endif %}
+					{% if good.information_security_details %}
+						<span class="govuk-hint"> {{ good.information_security_details }} </span>
+					{% endif %}
+				</dd>
+				<dd class="govuk-summary-list__actions">
+					{% if good.status.key == 'draft' %}
+						<a class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:good_information_security' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs 'Goods.AddGoodSummary.INFORMATION_SECURITY_FEATURES' %}</span></a>
+					{% endif %}
+				</dd>
+			</div>
+		{% endif %}
+
+		{% if good.firearm_details.type.key == "software_related_to_firearms" or good.firearm_details.type.key == "technology_related_to_firearms" %}
+			<div class="govuk-summary-list__row">
+				<dt class="govuk-summary-list__key">
+					{% lcs 'Goods.AddGoodSummary.PURPOSE_SOFTWARE_TECHNOLOGY' %}
+				</dt>
+				<dd class="govuk-summary-list__value">
+					{{ good.software_or_technology_details|default_na  }}
+				</dd>
+				<dd class="govuk-summary-list__actions">
+					{% if good.status.key == 'draft' %}
+						<a id="change-good-technology-software" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:good_software_technology' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs 'Goods.AddGoodSummary.PURPOSE_SOFTWARE_TECHNOLOGY' %}</span></a>
+					{% endif %}
+				</dd>
+			</div>
+			<div class="govuk-summary-list__row">
+				<dt class="govuk-summary-list__key">
+					{% lcs "Goods.AddGoodSummary.MILITARY_USE" %}
+				</dt>
+				<dd class="govuk-summary-list__value">
+					{{ good.is_military_use.value|default_na }}
+					{% if good.modified_military_use_details %}
+						<span class="govuk-hint"> {{ good.modified_military_use_details }} </span>
+					{% endif %}
+				</dd>
+				<dd class="govuk-summary-list__actions">
+					{% if good.status.key == 'draft' %}
+						<a id="change-good-details" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:good_military_use' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs 'Goods.AddGoodSummary.MILITARY_USE' %}</span></a>
+					{% endif %}
+				</dd>
+			</div>
+			<div class="govuk-summary-list__row">
+				<dt class="govuk-summary-list__key">
+					{% lcs "Goods.AddGoodSummary.INFORMATION_SECURITY_FEATURES" %}
+				</dt>
+				<dd class="govuk-summary-list__value">
+					{% if good.uses_information_security is not None %}
+						{{ good.uses_information_security|friendly_boolean }}
+					{% else %}
+						{{ good.uses_information_security|default_na }}
+					{% endif %}
+					{% if good.information_security_details %}
+						<span class="govuk-hint"> {{ good.information_security_details }} </span>
+					{% endif %}
+				</dd>
+				<dd class="govuk-summary-list__actions">
+					{% if good.status.key == 'draft' %}
+						<a class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:good_information_security' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs 'Goods.AddGoodSummary.INFORMATION_SECURITY_FEATURES' %}</span></a>
+					{% endif %}
+				</dd>
+			</div>
+		{% endif %}
+
 		{% endif %}
 	</dl>
 	<a class="govuk-button" id="button-attach-document" href="{% url 'applications:add_document' application_id good_id %}">{% lcs "Goods.AddGoodSummary.SAVE_AND_CONTINUE_BUTTON" %}</a>

--- a/exporter/templates/goods/good.html
+++ b/exporter/templates/goods/good.html
@@ -306,92 +306,226 @@
 					</dd>
 				</div>
 
-				<div class="govuk-summary-list__row">
-					<dt class="govuk-summary-list__key">
-						{% lcs "goods.GoodPage.Table.FirearmDetails.YEAR_OF_MANUFACTURE" %}
-					</dt>
-					<dd class="govuk-summary-list__value">
-						{{ good.firearm_details.year_of_manufacture|default_na }}
-					</dd>
-					<dd class="govuk-summary-list__actions">
-						{% if good.status.key == 'draft' %}
-							{% if draft_pk %}
-							<a id="change-year-of-manufacture" class="govuk-link govuk-link--no-visited-state" href="{% url 'goods:ammunition-add-application' good.id draft_pk %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "goods.GoodPage.Table.FirearmDetails.YEAR_OF_MANUFACTURE" %}</span></a>
-							{% else %}
-							<a id="change-year-of-manufacture" class="govuk-link govuk-link--no-visited-state" href="{% url 'goods:ammunition' good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "goods.GoodPage.Table.FirearmDetails.YEAR_OF_MANUFACTURE" %}</span></a>
-							{% endif %}
-						{% endif %}
-					</dd>
-				</div>
-
-				<div class="govuk-summary-list__row">
-					<dt class="govuk-summary-list__key">
-						{% lcs "goods.GoodPage.Table.FirearmDetails.CALIBRE" %}
-					</dt>
-					<dd class="govuk-summary-list__value">
-						{{ good.firearm_details.calibre|default_na }}
-					</dd>
-					<dd class="govuk-summary-list__actions">
-						{% if good.status.key == 'draft' %}
-							{% if draft_pk %}
-							<a id="change-calibre" class="govuk-link govuk-link--no-visited-state" href="{% url 'goods:ammunition-add-application' good.id draft_pk %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "goods.GoodPage.Table.FirearmDetails.CALIBRE" %}</span></a>
-							{% else %}
-							<a id="change-calibre" class="govuk-link govuk-link--no-visited-state" href="{% url 'goods:ammunition' good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "goods.GoodPage.Table.FirearmDetails.CALIBRE" %}</span></a>
-							{% endif %}
-						{% endif %}
-					</dd>
-				</div>
-
-				<div class="govuk-summary-list__row">
-					<dt class="govuk-summary-list__key">
-						{% lcs "goods.GoodPage.Table.FirearmDetails.COVERED_BY_THE_FIREARMS_ACT_1968" %}
-					</dt>
-					<dd class="govuk-summary-list__value">
-						{% if good.firearm_details.is_covered_by_firearm_act_section_one_two_or_five is not None %}
-							{{ good.firearm_details.is_covered_by_firearm_act_section_one_two_or_five|friendly_boolean}}
-							{% if good.firearm_details.is_covered_by_firearm_act_section_one_two_or_five %}
-								- certificate number {{ good.firearm_details.section_certificate_number|default_na }} expires on
-								{{ good.firearm_details.section_certificate_date_of_expiry|date_display }}
-							{% endif %}
-						{% endif %}
-					</dd>
-					<dd class="govuk-summary-list__actions">
-						{% if good.status.key == 'draft' %}
-							{% if draft_pk %}
-							<a id="change-firearms-act-details" class="govuk-link govuk-link--no-visited-state" href="{% url 'goods:firearms_act_add_application' good.id draft_pk %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "goods.GoodPage.Table.FirearmDetails.COVERED_BY_THE_FIREARMS_ACT_1968" %}</span></a>
-							{% else %}
-							<a id="change-firearms-act-details" class="govuk-link govuk-link--no-visited-state" href="{% url 'goods:firearms_act' good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "goods.GoodPage.Table.FirearmDetails.COVERED_BY_THE_FIREARMS_ACT_1968" %}</span></a>
-							{% endif %}
-						{% endif %}
-					</dd>
-				</div>
-
-				<div class="govuk-summary-list__row">
-					<dt class="govuk-summary-list__key">
-						{% lcs "goods.GoodPage.Table.FirearmDetails.IDENTIFICATION_MARKINGS" %}
-					</dt>
-					<dd class="govuk-summary-list__value">
-						{% if good.firearm_details.has_identification_markings is not None %}
-							{{ good.firearm_details.has_identification_markings|friendly_boolean }}
-							<span class="govuk-hint">
-								{% if good.firearm_details.has_identification_markings %}
-									{{ good.firearm_details.identification_markings_details|default_na }}
+				{% if good.firearm_details.type.key in 'firearms,ammunition,components_for_firearms,components_for_ammunition' %}
+					<div class="govuk-summary-list__row">
+						<dt class="govuk-summary-list__key">
+							{% lcs "goods.GoodPage.Table.FirearmDetails.YEAR_OF_MANUFACTURE" %}
+						</dt>
+						<dd class="govuk-summary-list__value">
+							{{ good.firearm_details.year_of_manufacture|default_na }}
+						</dd>
+						<dd class="govuk-summary-list__actions">
+							{% if good.status.key == 'draft' %}
+								{% if draft_pk %}
+								<a id="change-year-of-manufacture" class="govuk-link govuk-link--no-visited-state" href="{% url 'goods:ammunition-add-application' good.id draft_pk %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "goods.GoodPage.Table.FirearmDetails.YEAR_OF_MANUFACTURE" %}</span></a>
 								{% else %}
-									{{ good.firearm_details.no_identification_markings_details|default_na }}
+								<a id="change-year-of-manufacture" class="govuk-link govuk-link--no-visited-state" href="{% url 'goods:ammunition' good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "goods.GoodPage.Table.FirearmDetails.YEAR_OF_MANUFACTURE" %}</span></a>
 								{% endif %}
-							</span>
-						{% endif %}
-					</dd>
-					<dd class="govuk-summary-list__actions">
-						{% if good.status.key == 'draft' %}
-							{% if draft_pk %}
-							<a id="change-identification-markings" class="govuk-link govuk-link--no-visited-state" href="{% url 'goods:identification_markings_add_application' good.id draft_pk %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "goods.GoodPage.Table.FirearmDetails.IDENTIFICATION_MARKINGS" %}</span></a>
-							{% else %}
-							<a id="change-identification-markings" class="govuk-link govuk-link--no-visited-state" href="{% url 'goods:identification_markings' good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "goods.GoodPage.Table.FirearmDetails.IDENTIFICATION_MARKINGS" %}</span></a>
 							{% endif %}
-						{% endif %}
-					</dd>
-				</div>
+						</dd>
+					</div>
+
+					<div class="govuk-summary-list__row">
+						<dt class="govuk-summary-list__key">
+							{% lcs "goods.GoodPage.Table.FirearmDetails.CALIBRE" %}
+						</dt>
+						<dd class="govuk-summary-list__value">
+							{{ good.firearm_details.calibre|default_na }}
+						</dd>
+						<dd class="govuk-summary-list__actions">
+							{% if good.status.key == 'draft' %}
+								{% if draft_pk %}
+								<a id="change-calibre" class="govuk-link govuk-link--no-visited-state" href="{% url 'goods:ammunition-add-application' good.id draft_pk %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "goods.GoodPage.Table.FirearmDetails.CALIBRE" %}</span></a>
+								{% else %}
+								<a id="change-calibre" class="govuk-link govuk-link--no-visited-state" href="{% url 'goods:ammunition' good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "goods.GoodPage.Table.FirearmDetails.CALIBRE" %}</span></a>
+								{% endif %}
+							{% endif %}
+						</dd>
+					</div>
+
+					<div class="govuk-summary-list__row">
+						<dt class="govuk-summary-list__key">
+							{% lcs "goods.GoodPage.Table.FirearmDetails.COVERED_BY_THE_FIREARMS_ACT_1968" %}
+						</dt>
+						<dd class="govuk-summary-list__value">
+							{% if good.firearm_details.is_covered_by_firearm_act_section_one_two_or_five is not None %}
+								{{ good.firearm_details.is_covered_by_firearm_act_section_one_two_or_five|friendly_boolean}}
+								{% if good.firearm_details.is_covered_by_firearm_act_section_one_two_or_five %}
+									- certificate number {{ good.firearm_details.section_certificate_number|default_na }} expires on
+									{{ good.firearm_details.section_certificate_date_of_expiry|date_display }}
+								{% endif %}
+							{% endif %}
+						</dd>
+						<dd class="govuk-summary-list__actions">
+							{% if good.status.key == 'draft' %}
+								{% if draft_pk %}
+								<a id="change-firearms-act-details" class="govuk-link govuk-link--no-visited-state" href="{% url 'goods:firearms_act_add_application' good.id draft_pk %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "goods.GoodPage.Table.FirearmDetails.COVERED_BY_THE_FIREARMS_ACT_1968" %}</span></a>
+								{% else %}
+								<a id="change-firearms-act-details" class="govuk-link govuk-link--no-visited-state" href="{% url 'goods:firearms_act' good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "goods.GoodPage.Table.FirearmDetails.COVERED_BY_THE_FIREARMS_ACT_1968" %}</span></a>
+								{% endif %}
+							{% endif %}
+						</dd>
+					</div>
+
+					<div class="govuk-summary-list__row">
+						<dt class="govuk-summary-list__key">
+							{% lcs "goods.GoodPage.Table.FirearmDetails.IDENTIFICATION_MARKINGS" %}
+						</dt>
+						<dd class="govuk-summary-list__value">
+							{% if good.firearm_details.has_identification_markings is not None %}
+								{{ good.firearm_details.has_identification_markings|friendly_boolean }}
+								<span class="govuk-hint">
+									{% if good.firearm_details.has_identification_markings %}
+										{{ good.firearm_details.identification_markings_details|default_na }}
+									{% else %}
+										{{ good.firearm_details.no_identification_markings_details|default_na }}
+									{% endif %}
+								</span>
+							{% endif %}
+						</dd>
+						<dd class="govuk-summary-list__actions">
+							{% if good.status.key == 'draft' %}
+								{% if draft_pk %}
+								<a id="change-identification-markings" class="govuk-link govuk-link--no-visited-state" href="{% url 'goods:identification_markings_add_application' good.id draft_pk %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "goods.GoodPage.Table.FirearmDetails.IDENTIFICATION_MARKINGS" %}</span></a>
+								{% else %}
+								<a id="change-identification-markings" class="govuk-link govuk-link--no-visited-state" href="{% url 'goods:identification_markings' good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "goods.GoodPage.Table.FirearmDetails.IDENTIFICATION_MARKINGS" %}</span></a>
+								{% endif %}
+							{% endif %}
+						</dd>
+					</div>
+				{% endif %}
+
+				{% if good.firearm_details.type.key == "firearms_accessory" %}
+					<div class="govuk-summary-list__row">
+						<dt class="govuk-summary-list__key">
+							{% lcs "goods.GoodPage.Table.MILITARY_USE" %}
+						</dt>
+						<dd class="govuk-summary-list__value">
+							{{ good.is_military_use.value|default_na }}
+							{% if good.modified_military_use_details %}
+								<span class="govuk-hint"> {{ good.modified_military_use_details }} </span>
+							{% endif %}
+						</dd>
+						<dd class="govuk-summary-list__actions">
+							{% if good.status.key == 'draft' %}
+								{% if draft_pk %}
+								<a id="change-good-military-use" class="govuk-link govuk-link--no-visited-state" href="{% url 'goods:good_military_use_add_application' good.id draft_pk %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "goods.GoodPage.Table.MILITARY_USE" %}</span></a>
+								{% else %}
+								<a id="change-good-military-use" class="govuk-link govuk-link--no-visited-state" href="{% url 'goods:good_military_use' good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "goods.GoodPage.Table.MILITARY_USE" %}</span></a>
+								{% endif %}
+							{% endif %}
+						</dd>
+					</div>
+
+					<div class="govuk-summary-list__row">
+						<dt class="govuk-summary-list__key">
+							{% lcs "goods.GoodPage.Table.COMPONENT" %}
+						</dt>
+						<dd class="govuk-summary-list__value">
+							{{ good.is_component.value|default_na }}
+							{% if good.component_details %}
+								<span class="govuk-hint"> {{ good.component_details }} </span>
+							{% endif %}
+						</dd>
+						<dd class="govuk-summary-list__actions">
+							{% if good.status.key == 'draft' %}
+								{% if draft_pk %}
+								<a id="change-good-is-component" class="govuk-link govuk-link--no-visited-state" href="{% url 'goods:good_component_add_application' good.id draft_pk %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "goods.GoodPage.Table.COMPONENT" %}</span></a>
+								{% else %}
+								<a id="change-good-is-component" class="govuk-link govuk-link--no-visited-state" href="{% url 'goods:good_component' good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "goods.GoodPage.Table.COMPONENT" %}</span></a>
+								{% endif %}
+							{% endif %}
+						</dd>
+					</div>
+					<div class="govuk-summary-list__row">
+						<dt class="govuk-summary-list__key">
+							{% lcs "goods.GoodPage.Table.INFORMATION_SECURITY_FEATURES" %}
+						</dt>
+						<dd class="govuk-summary-list__value">
+							{% if good.uses_information_security is not None %}
+								{{ good.uses_information_security|friendly_boolean }}
+							{% else %}
+								{{ good.uses_information_security|default_na }}
+							{% endif %}
+							{% if good.information_security_details %}
+								<span class="govuk-hint"> {{ good.information_security_details }} </span>
+							{% endif %}
+						</dd>
+						<dd class="govuk-summary-list__actions">
+							{% if good.status.key == 'draft' %}
+								{% if draft_pk %}
+								<a id="change-good-information-security" class="govuk-link govuk-link--no-visited-state" href="{% url 'goods:good_information_security_add_application' good.id draft_pk %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "goods.GoodPage.Table.INFORMATION_SECURITY_FEATURES" %}</span></a>
+								{% else %}
+								<a id="change-good-information-security" class="govuk-link govuk-link--no-visited-state" href="{% url 'goods:good_information_security' good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "goods.GoodPage.Table.INFORMATION_SECURITY_FEATURES" %}</span></a>
+								{% endif %}
+							{% endif %}
+						</dd>
+					</div>
+				{% endif %}
+
+				{% if good.firearm_details.type.key in "software_related_to_firearms,technology_related_to_firearms" %}
+					<div class="govuk-summary-list__row">
+						<dt class="govuk-summary-list__key">
+							{% lcs "goods.GoodPage.Table.PURPOSE_SOFTWARE_TECHNOLOGY" %}
+						</dt>
+						<dd class="govuk-summary-list__value">
+							{{ good.software_or_technology_details|default_na }}
+						</dd>
+						<dd class="govuk-summary-list__actions">
+							{% if good.status.key == 'draft' %}
+								{% if draft_pk %}
+								<a id="change-good-technology-software" class="govuk-link govuk-link--no-visited-state" href="{% url 'goods:good_software_technology_add_application' good.id draft_pk %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "goods.GoodPage.Table.PURPOSE_SOFTWARE_TECHNOLOGY" %}</span></a>
+								{% else %}
+								<a id="change-good-technology-software" class="govuk-link govuk-link--no-visited-state" href="{% url 'goods:good_software_technology' good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "goods.GoodPage.Table.PURPOSE_SOFTWARE_TECHNOLOGY" %}</span></a>
+								{% endif %}
+							{% endif %}
+						</dd>
+					</div>
+					<div class="govuk-summary-list__row">
+						<dt class="govuk-summary-list__key">
+							{% lcs "goods.GoodPage.Table.MILITARY_USE" %}
+						</dt>
+						<dd class="govuk-summary-list__value">
+							{{ good.is_military_use.value|default_na }}
+							{% if good.modified_military_use_details %}
+								<span class="govuk-hint"> {{ good.modified_military_use_details }} </span>
+							{% endif %}
+						</dd>
+						<dd class="govuk-summary-list__actions">
+							{% if good.status.key == 'draft' %}
+								{% if draft_pk %}
+								<a id="change-good-military-use" class="govuk-link govuk-link--no-visited-state" href="{% url 'goods:good_military_use_add_application' good.id draft_pk %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "goods.GoodPage.Table.MILITARY_USE" %}</span></a>
+								{% else %}
+								<a id="change-good-military-use" class="govuk-link govuk-link--no-visited-state" href="{% url 'goods:good_military_use' good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "goods.GoodPage.Table.MILITARY_USE" %}</span></a>
+								{% endif %}
+							{% endif %}
+						</dd>
+					</div>
+					<div class="govuk-summary-list__row">
+						<dt class="govuk-summary-list__key">
+							{% lcs "goods.GoodPage.Table.INFORMATION_SECURITY_FEATURES" %}
+						</dt>
+						<dd class="govuk-summary-list__value">
+							{% if good.uses_information_security is not None %}
+								{{ good.uses_information_security|friendly_boolean }}
+							{% else %}
+								{{ good.uses_information_security|default_na }}
+							{% endif %}
+							{% if good.information_security_details %}
+								<span class="govuk-hint"> {{ good.information_security_details }} </span>
+							{% endif %}
+						</dd>
+						<dd class="govuk-summary-list__actions">
+							{% if good.status.key == 'draft' %}
+								{% if draft_pk %}
+								<a id="change-good-information-security" class="govuk-link govuk-link--no-visited-state" href="{% url 'goods:good_information_security_add_application' good.id draft_pk %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "goods.GoodPage.Table.INFORMATION_SECURITY_FEATURES" %}</span></a>
+								{% else %}
+								<a id="change-good-information-security" class="govuk-link govuk-link--no-visited-state" href="{% url 'goods:good_information_security' good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "goods.GoodPage.Table.INFORMATION_SECURITY_FEATURES" %}</span></a>
+								{% endif %}
+							{% endif %}
+						</dd>
+					</div>
+				{% endif %}
 			{% endif %}
 
 			<div class="govuk-summary-list__row">

--- a/lite_content/lite_exporter_frontend/goods.py
+++ b/lite_content/lite_exporter_frontend/goods.py
@@ -211,9 +211,9 @@ class CreateGoodForm:
         class ProductType:
             TITLE = "Select the type of product"
             FIREARM = "Firearm"
-            COMPONENTS_FOR_FIREARM = "Component for a firearm"
+            COMPONENTS_FOR_FIREARM = "Component of a firearm"
             AMMUNITION = "Ammunition"
-            COMPONENTS_FOR_AMMUNITION = "Component for ammunition"
+            COMPONENTS_FOR_AMMUNITION = "Component of firearm ammunition"
 
         class FirearmsAmmunitionDetails:
             TITLE = "Firearms and ammunition details"

--- a/lite_content/lite_exporter_frontend/goods.py
+++ b/lite_content/lite_exporter_frontend/goods.py
@@ -214,6 +214,9 @@ class CreateGoodForm:
             COMPONENTS_FOR_FIREARM = "Component of a firearm"
             AMMUNITION = "Ammunition"
             COMPONENTS_FOR_AMMUNITION = "Component of firearm ammunition"
+            FIREARMS_ACCESSORY = "Accessory of a firearm"
+            SOFTWARE_RELATED_TO_FIREARM = "Software relating to a firearm"
+            TECHNOLOGY_RELATED_TO_FIREARM = "Technology relating to a firearm"
 
         class FirearmsAmmunitionDetails:
             TITLE = "Firearms and ammunition details"

--- a/ui_tests/exporter/conftest.py
+++ b/ui_tests/exporter/conftest.py
@@ -404,7 +404,7 @@ def determine_that_there_is_a_closed_query(driver):  # noqa
 
 
 @when("I confirm I can upload a document")
-def confirm_can_upload_document(driver):
+def confirm_can_upload_document(driver):  # noqa
     # Confirm you have a document that is not sensitive
     AddGoodPage(driver).confirm_can_upload_good_document()
     functions.click_submit(driver)
@@ -743,9 +743,10 @@ def select_product_type(driver, product_type):  # noqa
         'I enter good description as "{description}" part number "{part_number}" controlled "{controlled}" control code "{control_code}" and graded "{graded}"'
     )
 )  # noqa
-def create_a_new_good_in_application(driver, description, part_number, controlled, control_code, graded):
+def create_a_new_good_in_application(driver, description, part_number, controlled, control_code, graded):  # noqa
     add_goods_page = AddGoodPage(driver)
     add_goods_page.enter_description_of_goods(description)
+    add_goods_page.enter_part_number(part_number)
     add_goods_page.select_is_your_good_controlled(controlled)
     add_goods_page.enter_control_list_entries(control_code)
     add_goods_page.select_is_your_good_graded(graded)
@@ -753,7 +754,7 @@ def create_a_new_good_in_application(driver, description, part_number, controlle
 
 
 @when(parsers.parse('I enter firearm year of manufacture as "{year}" and calibre as "{calibre}"'))
-def enter_firearm_year_of_manufacture_and_calibre(driver, year, calibre):
+def enter_firearm_year_of_manufacture_and_calibre(driver, year, calibre):  # noqa
     good_details_page = AddGoodDetails(driver)
     good_details_page.enter_year_of_manufacture(year)
     good_details_page.enter_calibre(calibre)
@@ -761,14 +762,14 @@ def enter_firearm_year_of_manufacture_and_calibre(driver, year, calibre):
 
 
 @when(parsers.parse('I specify firearms act sections apply as "{sections_choice}"'))
-def specify_firearms_act_sections_choice(driver, sections_choice):
+def specify_firearms_act_sections_choice(driver, sections_choice):  # noqa
     good_details_page = AddGoodDetails(driver)
     good_details_page.select_do_firearms_act_sections_apply(sections_choice)
     functions.click_submit(driver)
 
 
 @when(parsers.parse('I specify firearms identification markings as "{has_markings}" with details "{details}"'))
-def specify_firearms_identification_markings(driver, has_markings, details):
+def specify_firearms_identification_markings(driver, has_markings, details):  # noqa
     good_details_page = AddGoodDetails(driver)
     good_details_page.does_firearm_have_identification_markings(has_markings, details)
     functions.click_submit(driver)
@@ -805,7 +806,7 @@ def specify_product_infosec_details(driver, supports_infosec):  # noqa
 
 
 @when(parsers.parse('I see summary screen for "{product_type_value}" product with description "{description}"'))
-def summary_screen_for_product_type(driver, product_type_value, description):
+def summary_screen_for_product_type(driver, product_type_value, description):  # noqa
     summary_page = ProductSummary(driver)
     assert summary_page.get_page_heading() == "Product summary"
     summary = summary_page.get_summary_details()
@@ -839,7 +840,7 @@ def summary_screen_for_product_type(driver, product_type_value, description):
         'I enter product details with unit of measurement "{unit}", quantity "{quantity}" and value "{value}" and Save'
     )
 )  # noqa
-def i_enter_product_details_unit_quantity_and_value(driver, unit, quantity, value):
+def i_enter_product_details_unit_quantity_and_value(driver, unit, quantity, value):  # noqa
     details_page = StandardApplicationGoodDetails(driver)
     details_page.select_unit(unit)
     details_page.enter_quantity(quantity)
@@ -850,6 +851,6 @@ def i_enter_product_details_unit_quantity_and_value(driver, unit, quantity, valu
 
 
 @then(parsers.parse('the product "{description}" is added to the application'))
-def product_with_description_is_added_to_application(driver, description):
+def product_with_description_is_added_to_application(driver, description):  # noqa
     products_page = StandardApplicationGoodsPage(driver)
     assert products_page.good_with_description_exists(description)

--- a/ui_tests/exporter/features/submit_standard_application.feature
+++ b/ui_tests/exporter/features/submit_standard_application.feature
@@ -248,3 +248,57 @@ Feature: I want to indicate the standard licence I want
     And I append "updated" to description and submit
     And I see option to add product to application on details page    # to ensure that we are back on the same page
     And I add product to application
+
+
+  @LTD_389_Add_a_new_firearm_product @regression
+  Scenario: Add a new Firearm product of type firearms, ammunition, components of ammunition to the application
+    Given I go to exporter homepage and choose Test Org
+    When I create a standard application of a "permanent" export type
+    When I click on the "goods" section
+    And I choose to add a new product
+    And I select product type "firearm"
+    And I enter good description as "new firearm" part number "FR-123-M" controlled "True" control code "ML1a" and graded "no"
+    And I enter firearm year of manufacture as "2020" and calibre as "0.22"
+    And I specify firearms act sections apply as "Yes"
+    And I specify firearms identification markings as "Yes" with details "laser engraving"
+    And I see summary screen for "Firearms" product with description "new firearm"
+    And I confirm I can upload a document
+    And I upload file "file_for_doc_upload_test_1.txt" with description "File uploaded for firearms product."
+    And I enter product details with unit of measurement "Number of articles", quantity "5" and value "20,000" and Save
+    Then the product "new firearm" is added to the application
+
+
+  @LTD_389_Add_a_new_firearm_accessory @regression
+  Scenario: Add a new Firearm product of type firearms accesory to the application
+    Given I go to exporter homepage and choose Test Org
+    When I create a standard application of a "permanent" export type
+    When I click on the "goods" section
+    And I choose to add a new product
+    And I select product type "firearm_accessory"
+    And I enter good description as "firearm accessory" part number "FR-123-ACC" controlled "True" control code "ML1a" and graded "no"
+    And I specify military use details as "yes_designed"
+    And I specify component details as "yes_designed"
+    And I specify product employs information security features as "Yes"
+    And I see summary screen for "Accessory of a firearm" product with description "firearm accessory"
+    And I confirm I can upload a document
+    And I upload file "file_for_doc_upload_test_1.txt" with description "File uploaded for firearms product."
+    And I enter product details with unit of measurement "Number of articles", quantity "9" and value "25,000" and Save
+    Then the product "firearm accessory" is added to the application
+
+
+  @LTD_389_Add_a_new_software_related_to_firearm_product @regression
+  Scenario: Add a new Software relating to a Firearm product to the application
+    Given I go to exporter homepage and choose Test Org
+    When I create a standard application of a "permanent" export type
+    When I click on the "goods" section
+    And I choose to add a new product
+    And I select product type "software_for_firearm"
+    And I enter good description as "Test software for firearms" part number "FR-123-ACC" controlled "True" control code "ML1a" and graded "no"
+    And I specify the "software" product purpose as "For product diagnostics"
+    And I specify military use details as "yes_designed"
+    And I specify product employs information security features as "Yes"
+    And I see summary screen for "Software relating to a firearm" product with description "Test software for firearms"
+    And I confirm I can upload a document
+    And I upload file "file_for_doc_upload_test_1.txt" with description "File uploaded for firearms product."
+    And I enter product details with unit of measurement "Number of articles", quantity "25" and value "50,000" and Save
+    Then the product "Test software for firearms" is added to the application

--- a/ui_tests/exporter/features/submit_standard_application.feature
+++ b/ui_tests/exporter/features/submit_standard_application.feature
@@ -261,7 +261,7 @@ Feature: I want to indicate the standard licence I want
     And I enter firearm year of manufacture as "2020" and calibre as "0.22"
     And I specify firearms act sections apply as "Yes"
     And I specify firearms identification markings as "Yes" with details "laser engraving"
-    And I see summary screen for "Firearms" product with description "new firearm"
+    And I see summary screen for "Firearms" product with description "new firearm" and "continue"
     And I confirm I can upload a document
     And I upload file "file_for_doc_upload_test_1.txt" with description "File uploaded for firearms product."
     And I enter product details with unit of measurement "Number of articles", quantity "5" and value "20,000" and Save
@@ -279,7 +279,7 @@ Feature: I want to indicate the standard licence I want
     And I specify military use details as "yes_designed"
     And I specify component details as "yes_designed"
     And I specify product employs information security features as "Yes"
-    And I see summary screen for "Accessory of a firearm" product with description "firearm accessory"
+    And I see summary screen for "Accessory of a firearm" product with description "firearm accessory" and "continue"
     And I confirm I can upload a document
     And I upload file "file_for_doc_upload_test_1.txt" with description "File uploaded for firearms product."
     And I enter product details with unit of measurement "Number of articles", quantity "9" and value "25,000" and Save
@@ -297,8 +297,44 @@ Feature: I want to indicate the standard licence I want
     And I specify the "software" product purpose as "For product diagnostics"
     And I specify military use details as "yes_designed"
     And I specify product employs information security features as "Yes"
-    And I see summary screen for "Software relating to a firearm" product with description "Test software for firearms"
+    And I see summary screen for "Software relating to a firearm" product with description "Test software for firearms" and "continue"
     And I confirm I can upload a document
     And I upload file "file_for_doc_upload_test_1.txt" with description "File uploaded for firearms product."
     And I enter product details with unit of measurement "Number of articles", quantity "25" and value "50,000" and Save
     Then the product "Test software for firearms" is added to the application
+
+
+  @LTD_389_Add_a_new_firearm_product_and_check_edit @regression
+  Scenario: Add a new Firearm product and check if we can edit fields from summary screen
+    Given I go to exporter homepage and choose Test Org
+    When I create a standard application of a "permanent" export type
+    When I click on the "goods" section
+    And I choose to add a new product
+    And I select product type "firearm"
+    And I enter good description as "new firearm" part number "FR-123-M" controlled "True" control code "ML1a" and graded "no"
+    And I enter firearm year of manufacture as "2020" and calibre as "0.22"
+    And I specify firearms act sections apply as "Yes"
+    And I specify firearms identification markings as "Yes" with details "laser engraving"
+    And I see summary screen for "Firearms" product with description "new firearm" and "review"
+    And I can edit good "Description" as "updated firearm description"
+    And I can edit good "Part number" as "PN-ABC/123"
+    And I can edit good "Year of manufacture" as "2020"
+    And I can edit good "Calibre" as "0.45"
+
+
+  @LTD_389_Add_a_new_firearm_accessory_and_check_edit @regression
+  Scenario: Add a new Firearm accessory and check if we can edit fields from summary screen
+    Given I go to exporter homepage and choose Test Org
+    When I create a standard application of a "permanent" export type
+    When I click on the "goods" section
+    And I choose to add a new product
+    And I select product type "firearm_accessory"
+    And I enter good description as "firearm accessory" part number "FR-123-ACC" controlled "True" control code "ML1a" and graded "no"
+    And I specify military use details as "yes_designed"
+    And I specify component details as "yes_designed"
+    And I specify product employs information security features as "Yes"
+    And I see summary screen for "Accessory of a firearm" product with description "firearm accessory" and "review"
+    And I can edit good "Description" as "updated firearm accessory description"
+    And I can edit good "Part number" as "ACC-123/Y"
+    And I can edit good "Military use" as "yes_modified"
+    And I can edit good "Information security features" as "No"

--- a/ui_tests/exporter/pages/add_goods_details.py
+++ b/ui_tests/exporter/pages/add_goods_details.py
@@ -48,6 +48,9 @@ class AddGoodDetails(BasePage):
     FIREARM_TYPE_FIREARM_COMPONENT_ID = FIREARM_TYPE_PREFIX + "components_for_firearms"
     FIREARM_TYPE_AMMUNITION_ID = FIREARM_TYPE_PREFIX + "ammunition"
     FIREARM_TYPE_AMMUNITION_COMPONENT_ID = FIREARM_TYPE_PREFIX + "components_for_ammunition"
+    FIREARM_TYPE_FIREARM_ACCESSORY_ID = FIREARM_TYPE_PREFIX + "firearms_accessory"
+    FIREARM_TYPE_FIREARM_SOFTWARE_ID = FIREARM_TYPE_PREFIX + "software_related_to_firearms"
+    FIREARM_TYPE_FIREARM_TECHNOLOGY_ID = FIREARM_TYPE_PREFIX + "technology_related_to_firearms"
 
     # Firearms - Firearms and ammunition details
     FIREARM_YEAR_OF_MANUFACTURE_TEXTFIELD_ID = "year_of_manufacture"
@@ -140,12 +143,18 @@ class AddGoodDetails(BasePage):
             self.driver.find_element_by_id(self.FIREARM_TYPE_AMMUNITION_ID).click()
         if option == "component_for_ammunition":
             self.driver.find_element_by_id(self.FIREARM_TYPE_AMMUNITION_COMPONENT_ID).click()
+        if option == "firearm_accessory":
+            self.driver.find_element_by_id(self.FIREARM_TYPE_FIREARM_ACCESSORY_ID).click()
+        if option == "software_for_firearm":
+            self.driver.find_element_by_id(self.FIREARM_TYPE_FIREARM_SOFTWARE_ID).click()
+        if option == "technology_for_firearm":
+            self.driver.find_element_by_id(self.FIREARM_TYPE_FIREARM_TECHNOLOGY_ID).click()
 
-    def enter_year_of_manufacture(self):
-        self.enter_related_field_details(self.FIREARM_YEAR_OF_MANUFACTURE_TEXTFIELD_ID, text="2004")
+    def enter_year_of_manufacture(self, year):
+        self.enter_related_field_details(self.FIREARM_YEAR_OF_MANUFACTURE_TEXTFIELD_ID, text=year)
 
-    def enter_calibre(self):
-        self.enter_related_field_details(self.FIREARM_CALIBRE_TEXTFIELD_ID, text=".99mm")
+    def enter_calibre(self, calibre):
+        self.enter_related_field_details(self.FIREARM_CALIBRE_TEXTFIELD_ID, text=calibre)
 
     def select_do_firearms_act_sections_apply(self, option):
         if option == "Yes":
@@ -160,10 +169,10 @@ class AddGoodDetails(BasePage):
         self.driver.find_element_by_id(self.CERTIFICATE_EXPIRY_DATE_MONTH_ID).send_keys(month)
         self.driver.find_element_by_id(self.CERTIFICATE_EXPIRY_DATE_YEAR_ID).send_keys(year)
 
-    def does_firearm_have_identification_markings(self, has_markings):
+    def does_firearm_have_identification_markings(self, has_markings, details="details"):
         if has_markings == "Yes":
             self.driver.find_element_by_id(self.FIREARMS_IDENTIFICATION_MARKINGS_YES_ID).click()
-            self.enter_related_field_details(self.FIREARMS_IDENTIFICATION_MARKINGS_DETAILS_TEXTAREA_ID)
+            self.enter_related_field_details(self.FIREARMS_IDENTIFICATION_MARKINGS_DETAILS_TEXTAREA_ID, text=details)
         if has_markings == "No":
             self.driver.find_element_by_id(self.FIREARMS_IDENTIFICATION_MARKINGS_NO_ID).click()
-            self.enter_related_field_details(self.FIREARMS_NO_IDENTIFICATION_MARKINGS_DETAILS_TEXTAREA_ID)
+            self.enter_related_field_details(self.FIREARMS_NO_IDENTIFICATION_MARKINGS_DETAILS_TEXTAREA_ID, text=details)

--- a/ui_tests/exporter/pages/add_goods_page.py
+++ b/ui_tests/exporter/pages/add_goods_page.py
@@ -27,7 +27,9 @@ class AddGoodPage(BasePage):
     UNSURE_PV_GRADING_DETAILS = "pv_grading_raised_reasons"  # ID
 
     def enter_description_of_goods(self, description):
-        self.driver.find_element_by_id(self.DESCRIPTION).send_keys(description)
+        element = self.driver.find_element_by_id(self.DESCRIPTION)
+        element.clear()
+        element.send_keys(description)
 
     def select_is_your_good_controlled(self, option):
         # The options accepted here are 'True', 'False' and 'None'

--- a/ui_tests/exporter/pages/product_summary.py
+++ b/ui_tests/exporter/pages/product_summary.py
@@ -13,3 +13,15 @@ class ProductSummary(BasePage):
             summary[key] = value
 
         return summary
+
+    def get_field_details(self, field_name):
+        for row in self.driver.find_elements_by_class_name("govuk-summary-list__row"):
+            key = row.find_element_by_class_name("govuk-summary-list__key").text
+            value = row.find_element_by_class_name("govuk-summary-list__value").text
+            if key == field_name:
+                link_element = row.find_element_by_xpath("dd[@class='govuk-summary-list__actions']/a")
+
+                # in some cases we have additional details in the value, skip that
+                return value.split("\n")[0], link_element
+
+        return None, None

--- a/ui_tests/exporter/pages/product_summary.py
+++ b/ui_tests/exporter/pages/product_summary.py
@@ -1,6 +1,3 @@
-from selenium.webdriver.support.select import Select
-
-from tests_common import functions
 from ui_tests.exporter.pages.BasePage import BasePage
 
 

--- a/ui_tests/exporter/pages/product_summary.py
+++ b/ui_tests/exporter/pages/product_summary.py
@@ -1,0 +1,18 @@
+from selenium.webdriver.support.select import Select
+
+from tests_common import functions
+from ui_tests.exporter.pages.BasePage import BasePage
+
+
+class ProductSummary(BasePage):
+    def get_page_heading(self):
+        return self.driver.find_element_by_class_name("govuk-heading-l").text
+
+    def get_summary_details(self):
+        summary = {}
+        for row in self.driver.find_elements_by_class_name("govuk-summary-list__row"):
+            key = row.find_element_by_class_name("govuk-summary-list__key").text
+            value = row.find_element_by_class_name("govuk-summary-list__value").text
+            summary[key] = value
+
+        return summary

--- a/ui_tests/exporter/pages/standard_application/goods.py
+++ b/ui_tests/exporter/pages/standard_application/goods.py
@@ -51,6 +51,14 @@ class StandardApplicationGoodsPage(BasePage):
     def goods_exist_on_the_application(self):
         return functions.element_with_css_selector_exists(self.driver, self.REMOVE_GOOD_LINK)
 
+    def good_with_description_exists(self, expected):
+        for row in self.driver.find_elements_by_class_name("govuk-table__row"):
+            actual = row.find_elements_by_xpath('//td[@class="govuk-table__cell"]')[0].text
+            if actual == expected:
+                return True
+        else:
+            return False
+
     def find_remove_location_link(self):
         try:
             return self.driver.find_element_by_id(self.REMOVE_LOCATION_LINK)

--- a/ui_tests/exporter/step_defs/test_goods.py
+++ b/ui_tests/exporter/step_defs/test_goods.py
@@ -181,20 +181,6 @@ def create_a_new_good_in_application(driver, description, part_number, controlle
     functions.click_submit(driver)
 
 
-@when(
-    parsers.parse(
-        'I enter details for the new good on an application with value "{value}", quantity "{quantity}" and unit of measurement "{unit}" and I click Continue'
-    )
-)  # noqa
-def i_enter_detail_for_the_good_on_the_application(driver, value, quantity, unit):
-    StandardApplicationGoodDetails(driver).enter_value(value)
-    StandardApplicationGoodDetails(driver).enter_quantity(quantity)
-    StandardApplicationGoodDetails(driver).select_unit(unit)
-    StandardApplicationGoodDetails(driver).check_is_good_incorporated_false()
-
-    functions.click_submit(driver)
-
-
 @when("I confirm I can upload a document")
 def confirm_can_upload_document(driver):
     # Confirm you have a document that is not sensitive
@@ -316,24 +302,6 @@ def add_good_details(driver, category, military_use, component, infosec, context
         good_details_page.select_is_product_a_component(component)
         functions.click_submit(driver)
     good_details_page.does_product_employ_information_security(infosec)
-    functions.click_submit(driver)
-
-
-@when(  # noqa
-    parsers.parse(
-        'I specify the firearm good details type "{product_type}" year of manufacture, calibre, firearms act applicable "{firearms_act}" and identification markings "{has_markings}"'
-    )
-)
-def add_firearm_good_details(driver, product_type, firearms_act, has_markings, context):  # noqa
-    good_details_page = AddGoodDetails(driver)
-    good_details_page.select_firearm_product_type(product_type)
-    functions.click_submit(driver)
-    good_details_page.enter_year_of_manufacture()
-    good_details_page.enter_calibre()
-    functions.click_submit(driver)
-    good_details_page.select_do_firearms_act_sections_apply(firearms_act)
-    functions.click_submit(driver)
-    good_details_page.does_firearm_have_identification_markings(has_markings)
     functions.click_submit(driver)
 
 

--- a/ui_tests/exporter/step_defs/test_standard_application.py
+++ b/ui_tests/exporter/step_defs/test_standard_application.py
@@ -110,6 +110,11 @@ def i_add_a_non_incorporated_good_to_the_application(driver, context):  # noqa
     functions.click_submit(driver)
 
 
+@when("I choose to add a new product")  # noqa
+def i_choose_to_add_a_new_product(driver, context):  # noqa
+    StandardApplicationGoodsPage(driver).click_add_new_good_button()
+
+
 @when("I choose to add a product from product list")  # noqa
 def i_choose_to_add_product_from_product_list(driver, context):  # noqa
     StandardApplicationGoodsPage(driver).click_add_preexisting_good_button()

--- a/ui_tests/exporter/step_defs/test_standard_application.py
+++ b/ui_tests/exporter/step_defs/test_standard_application.py
@@ -33,6 +33,7 @@ from faker import Faker
 fake = Faker()
 
 scenarios(
+    "../features/goods.feature",
     "../features/submit_standard_application.feature",
     "../features/edit_standard_application.feature",
     strict_gherkin=False,


### PR DESCRIPTION
## Change description

To accurately categorise firearms products additional product types are introduced.
In the v3 Firearms flow Product type is the first screen (instead of Product category) as we will only be allowing Firearms products in the first version.
Moreover we cannot completely implement the flow in this PR because there are other tickets for the rest of the steps in the flow so this PR completes the flow to the extent possible. As we complete other tickets this needs to be adjusted.

The main difference is with respect to first four product types (Firearms, Ammunition, Components for firearms and Components for ammunition) where the next steps capture additional/new details (future tickets). So for now the next steps for all types are same as in current flow.

### Product summary screen
When adding a new product, after entering all details a product summary screen is displayed (before document upload), this is updated to show specific information whether it is a firearm, accessory or software/tech related to firearm.

Browser tests are added for adding firearms product types.