### PR TITLE
LTD-392 Validation Fix for Firearm Details

### DIFF
--- a/exporter/goods/forms.py
+++ b/exporter/goods/forms.py
@@ -626,6 +626,7 @@ def firearm_replica_form(firearm_type):
 def firearm_calibre_details_form():
     return Form(
         title="What is the calibre of the product?",
+        default_button_name="Save and continue",
         questions=[
             HiddenField("firearm_calibre_step", True),
             TextInput(title="", description="", name="calibre", optional=False,),

--- a/exporter/goods/services.py
+++ b/exporter/goods/services.py
@@ -63,8 +63,10 @@ def add_firearm_details_to_data(json):
         firearm_details["is_sporting_shotgun"] = json.get("is_sporting_shotgun")
 
     if "firearm_year_of_manufacture_step" in json:
-        firearm_details["year_of_manufacture"] = json.get("year_of_manufacture")
-        del json["year_of_manufacture"]
+        firearms_year_of_manufacture = json.pop("year_of_manufacture")
+        if firearms_year_of_manufacture == "":
+            firearms_year_of_manufacture = None
+        firearm_details["year_of_manufacture"] = firearms_year_of_manufacture
 
     if "is_replica_step" in json:
         firearm_details["type"] = json.get("type")
@@ -73,8 +75,10 @@ def add_firearm_details_to_data(json):
         del json["replica_description"]
 
     if "firearm_calibre_step" in json:
-        firearm_details["calibre"] = json.get("calibre")
-        del json["calibre"]
+        firearm_calibre = json.pop("calibre")
+        if firearm_calibre == "":
+            firearm_calibre = None
+        firearm_details["calibre"] = firearm_calibre
 
     if "section_certificate_step" in json:
         # parent component doesnt get sent when empty unlike the remaining form fields


### PR DESCRIPTION
If a form containing calibre or year of manufacture was submitted we were
getting the wrong validation error from the serializer saying that the value was
`invalid` instead of `null`.

This sets empty strings to null for both calibre and year of manufacturer so
that you get the right validation error back from the API

related API change: https://github.com/uktrade/lite-api/pull/663