### PR TITLE
Firearms navigation fixes

### DIFF
--- a/exporter/applications/views/goods.py
+++ b/exporter/applications/views/goods.py
@@ -132,7 +132,7 @@ class AddGood(LoginRequiredMixin, MultiFormView):
             is_firearms_accessory,
             is_firearms_software_tech,
             draft_pk=self.draft_pk,
-            base_form_back_link=reverse("applications:goods", kwargs={"pk": self.kwargs["pk"]})
+            base_form_back_link=reverse("applications:goods", kwargs={"pk": self.kwargs["pk"]}),
         )
 
         # we require the form index of the last form in the group, not the total number

--- a/exporter/applications/views/goods.py
+++ b/exporter/applications/views/goods.py
@@ -2,7 +2,7 @@ from http import HTTPStatus
 
 from django.conf import settings
 from django.shortcuts import render, redirect
-from django.urls import reverse_lazy
+from django.urls import reverse_lazy, reverse
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import TemplateView
@@ -132,6 +132,7 @@ class AddGood(LoginRequiredMixin, MultiFormView):
             is_firearms_accessory,
             is_firearms_software_tech,
             draft_pk=self.draft_pk,
+            base_form_back_link=reverse("applications:goods", kwargs={"pk": self.kwargs["pk"]})
         )
 
         # we require the form index of the last form in the group, not the total number

--- a/exporter/goods/forms.py
+++ b/exporter/goods/forms.py
@@ -344,11 +344,12 @@ def add_good_form_group(
     is_firearms_accessory: bool = None,
     is_firearms_software_tech: bool = None,
     draft_pk: str = None,
+    base_form_back_link: str = None,
 ):
     control_list_entries = get_control_list_entries(request, convert_to_options=True)
     return FormGroup(
         [
-            group_two_product_type_form(),
+            group_two_product_type_form(back_link=base_form_back_link),
             conditional(is_firearms_core, firearms_sporting_shotgun_form(request.POST.get("type"))),
             add_goods_questions(control_list_entries, draft_pk),
             conditional(is_pv_graded, pv_details_form(request)),
@@ -523,8 +524,8 @@ def delete_good_form(good):
     )
 
 
-def group_two_product_type_form():
-    return Form(
+def group_two_product_type_form(back_link=None):
+    form = Form(
         title=CreateGoodForm.FirearmGood.ProductType.TITLE,
         questions=[
             HiddenField("product_type_step", True),
@@ -556,6 +557,11 @@ def group_two_product_type_form():
         ],
         default_button_name="Save and continue",
     )
+
+    if back_link:
+        form.back_link = BackLink("Back", back_link)
+
+    return form
 
 
 def firearms_sporting_shotgun_form(firearm_type):

--- a/exporter/goods/services.py
+++ b/exporter/goods/services.py
@@ -115,6 +115,19 @@ def add_firearm_details_to_data(json):
     if firearm_details and "is_sporting_shotgun" not in firearm_details:
         firearm_details["is_sporting_shotgun"] = False
 
+    if firearm_details and "year_of_manufacture" not in firearm_details:
+        firearm_details["year_of_manufacture"] = 0
+
+    if firearm_details and "is_covered_by_firearm_act_section_one_two_or_five" not in firearm_details:
+        firearm_details["is_covered_by_firearm_act_section_one_two_or_five"] = False
+        firearm_details["section_certificate_number"] = ""
+        firearm_details["section_certificate_date_of_expiry"] = "2012-12-21"
+
+    if firearm_details and "has_identification_markings" not in firearm_details:
+        firearm_details["has_identification_markings"] = False
+        firearm_details["no_identification_markings_details"] = "n/a"
+        firearm_details["identification_markings_details"] = "n/a"
+
     if firearm_details:
         json["firearm_details"] = firearm_details
     return json

--- a/exporter/goods/services.py
+++ b/exporter/goods/services.py
@@ -48,6 +48,42 @@ def post_goods(request, json):
     return data.json(), data.status_code
 
 
+def add_section_certificate_details(firearm_details, json):
+    if "section_certificate_step" in json:
+        # parent component doesnt get sent when empty unlike the remaining form fields
+        firearm_details["is_covered_by_firearm_act_section_one_two_or_five"] = json.get(
+            "is_covered_by_firearm_act_section_one_two_or_five", ""
+        )
+        firearm_details["section_certificate_number"] = json.get("section_certificate_number")
+        formatted_section_certificate_date = format_date(json, "section_certificate_date_of_expiry")
+        firearm_details["section_certificate_date_of_expiry"] = (
+            formatted_section_certificate_date if formatted_section_certificate_date != "--" else None
+        )
+        del json["section_certificate_number"]
+    elif firearm_details and "is_covered_by_firearm_act_section_one_two_or_five" not in firearm_details:
+        firearm_details["is_covered_by_firearm_act_section_one_two_or_five"] = False
+        firearm_details["section_certificate_number"] = ""
+        firearm_details["section_certificate_date_of_expiry"] = "2012-12-21"
+
+    return firearm_details
+
+
+def add_identification_marking_details(firearm_details, json):
+    if "identification_markings_step" in json:
+        # parent component doesnt get sent when empty unlike the remaining form fields
+        firearm_details["has_identification_markings"] = json.get("has_identification_markings", "")
+        firearm_details["identification_markings_details"] = json.get("identification_markings_details")
+        firearm_details["no_identification_markings_details"] = json.get("no_identification_markings_details")
+        del json["identification_markings_details"]
+        del json["no_identification_markings_details"]
+    elif firearm_details and "has_identification_markings" not in firearm_details:
+        firearm_details["has_identification_markings"] = False
+        firearm_details["no_identification_markings_details"] = "n/a"
+        firearm_details["identification_markings_details"] = "n/a"
+
+    return firearm_details
+
+
 def add_firearm_details_to_data(json):
     """
     Return a firearm_details dictionary to be used when creating/editing a group 2 firearm good
@@ -61,12 +97,16 @@ def add_firearm_details_to_data(json):
     if "sporting_shotgun_step" in json:
         firearm_details["type"] = json.get("type")
         firearm_details["is_sporting_shotgun"] = json.get("is_sporting_shotgun")
+    elif firearm_details and "is_sporting_shotgun" not in firearm_details:
+        firearm_details["is_sporting_shotgun"] = False
 
     if "firearm_year_of_manufacture_step" in json:
         firearms_year_of_manufacture = json.pop("year_of_manufacture")
         if firearms_year_of_manufacture == "":
             firearms_year_of_manufacture = None
         firearm_details["year_of_manufacture"] = firearms_year_of_manufacture
+    elif firearm_details and "year_of_manufacture" not in firearm_details:
+        firearm_details["year_of_manufacture"] = 0
 
     if "is_replica_step" in json:
         firearm_details["type"] = json.get("type")
@@ -80,24 +120,9 @@ def add_firearm_details_to_data(json):
             firearm_calibre = None
         firearm_details["calibre"] = firearm_calibre
 
-    if "section_certificate_step" in json:
-        # parent component doesnt get sent when empty unlike the remaining form fields
-        firearm_details["is_covered_by_firearm_act_section_one_two_or_five"] = json.get(
-            "is_covered_by_firearm_act_section_one_two_or_five", ""
-        )
-        firearm_details["section_certificate_number"] = json.get("section_certificate_number")
-        formatted_section_certificate_date = format_date(json, "section_certificate_date_of_expiry")
-        firearm_details["section_certificate_date_of_expiry"] = (
-            formatted_section_certificate_date if formatted_section_certificate_date != "--" else None
-        )
-        del json["section_certificate_number"]
-    if "identification_markings_step" in json:
-        # parent component doesnt get sent when empty unlike the remaining form fields
-        firearm_details["has_identification_markings"] = json.get("has_identification_markings", "")
-        firearm_details["identification_markings_details"] = json.get("identification_markings_details")
-        firearm_details["no_identification_markings_details"] = json.get("no_identification_markings_details")
-        del json["identification_markings_details"]
-        del json["no_identification_markings_details"]
+    firearm_details = add_section_certificate_details(firearm_details, json)
+
+    firearm_details = add_identification_marking_details(firearm_details, json)
 
     for name in [
         "date_of_deactivation",
@@ -111,22 +136,6 @@ def add_firearm_details_to_data(json):
     ]:
         if name in json:
             firearm_details[name] = json.pop(name)
-
-    if firearm_details and "is_sporting_shotgun" not in firearm_details:
-        firearm_details["is_sporting_shotgun"] = False
-
-    if firearm_details and "year_of_manufacture" not in firearm_details:
-        firearm_details["year_of_manufacture"] = 0
-
-    if firearm_details and "is_covered_by_firearm_act_section_one_two_or_five" not in firearm_details:
-        firearm_details["is_covered_by_firearm_act_section_one_two_or_five"] = False
-        firearm_details["section_certificate_number"] = ""
-        firearm_details["section_certificate_date_of_expiry"] = "2012-12-21"
-
-    if firearm_details and "has_identification_markings" not in firearm_details:
-        firearm_details["has_identification_markings"] = False
-        firearm_details["no_identification_markings_details"] = "n/a"
-        firearm_details["identification_markings_details"] = "n/a"
 
     if firearm_details:
         json["firearm_details"] = firearm_details

--- a/exporter/goods/views.py
+++ b/exporter/goods/views.py
@@ -198,6 +198,7 @@ class AddGood(LoginRequiredMixin, MultiFormView):
             is_firearms_core,
             is_firearms_accessory,
             is_firearms_software_tech,
+            base_form_back_link=reverse("goods:goods"),
         )
 
         # we require the form index of the last form in the group, not the total number

--- a/exporter/goods/views.py
+++ b/exporter/goods/views.py
@@ -234,23 +234,15 @@ class GoodSoftwareTechnology(LoginRequiredMixin, SingleFormView):
         }
 
     def get_success_url(self):
-        good = get_good(self.request, self.object_pk, full_detail=True)[0]
-        # Next question military use
-        if not good.get("is_military_use"):
-            if "good_pk" in self.kwargs:
-                return reverse_lazy(
-                    "applications:good_military_use", kwargs={"pk": self.application_id, "good_pk": self.object_pk}
-                )
-            else:
-                return reverse_lazy("goods:good_military_use", kwargs={"pk": self.object_pk})
-        elif self.draft_pk:
+        if self.draft_pk:
             return reverse(
                 "goods:good_detail_application",
                 kwargs={"pk": self.object_pk, "type": "application", "draft_pk": self.draft_pk},
             )
-        # Edit
-        else:
+        elif self.application_id and self.object_pk:
             return return_to_good_summary(self.kwargs, self.application_id, self.object_pk)
+        elif self.object_pk:
+            return reverse_lazy("goods:good", kwargs={"pk": self.object_pk})
 
 
 class GoodMilitaryUse(LoginRequiredMixin, SingleFormView):
@@ -293,22 +285,16 @@ class GoodMilitaryUse(LoginRequiredMixin, SingleFormView):
                     )
                 else:
                     return reverse_lazy("goods:good_information_security", kwargs={"pk": self.object_pk})
-        # Next question good component if good is in category 1
-        if not good.get("is_component") and not is_software_technology:
-            if "good_pk" in self.kwargs:
-                return reverse_lazy(
-                    "applications:good_component", kwargs={"pk": self.application_id, "good_pk": self.object_pk}
-                )
-            else:
-                return reverse_lazy("goods:good_component", kwargs={"pk": self.object_pk})
-        elif self.draft_pk:
+
+        if self.draft_pk:
             return reverse(
                 "goods:good_detail_application",
                 kwargs={"pk": self.object_pk, "type": "application", "draft_pk": self.draft_pk},
             )
-        # Edit
-        else:
+        elif self.application_id and self.object_pk:
             return return_to_good_summary(self.kwargs, self.application_id, self.object_pk)
+        elif self.object_pk:
+            return reverse_lazy("goods:good", kwargs={"pk": self.object_pk})
 
 
 class GoodComponent(LoginRequiredMixin, SingleFormView):
@@ -334,24 +320,15 @@ class GoodComponent(LoginRequiredMixin, SingleFormView):
         return {"is_component": self.data.get("is_component")}
 
     def get_success_url(self):
-        good = get_good(self.request, self.object_pk, full_detail=True)[0]
-        # Next question information security - boolean
-        if good.get("uses_information_security") is None:
-            if "good_pk" in self.kwargs:
-                return reverse_lazy(
-                    "applications:good_information_security",
-                    kwargs={"pk": self.application_id, "good_pk": self.object_pk},
-                )
-            else:
-                return reverse_lazy("goods:good_information_security", kwargs={"pk": self.object_pk})
-        elif self.draft_pk:
+        if self.draft_pk:
             return reverse(
                 "goods:good_detail_application",
                 kwargs={"pk": self.object_pk, "type": "application", "draft_pk": self.draft_pk},
             )
-        # Edit
-        else:
+        elif self.application_id and self.object_pk:
             return return_to_good_summary(self.kwargs, self.application_id, self.object_pk)
+        elif self.object_pk:
+            return reverse_lazy("goods:good", kwargs={"pk": self.object_pk})
 
 
 class GoodInformationSecurity(LoginRequiredMixin, SingleFormView):
@@ -377,17 +354,14 @@ class GoodInformationSecurity(LoginRequiredMixin, SingleFormView):
         return new_data
 
     def get_success_url(self):
-        # Return to the application add good summary if adding/editing good from the application
-        if "good_pk" in self.kwargs:
-            return reverse_lazy(
-                "applications:add_good_summary", kwargs={"pk": self.application_id, "good_pk": self.object_pk}
-            )
-        elif self.draft_pk:
+        if self.draft_pk:
             return reverse(
                 "goods:good_detail_application",
                 kwargs={"pk": self.object_pk, "type": "application", "draft_pk": self.draft_pk},
             )
-        else:
+        elif self.application_id and self.object_pk:
+            return return_to_good_summary(self.kwargs, self.application_id, self.object_pk)
+        elif self.object_pk:
             return reverse_lazy("goods:good", kwargs={"pk": self.object_pk})
 
 
@@ -549,22 +523,16 @@ class EditFirearmSportingShotgunStatus(LoginRequiredMixin, SingleFormView):
         self.action = edit_good_firearm_details
 
     def get_success_url(self):
-        # Next question product details
-        if self.data.get("type"):
-            if "good_pk" in self.kwargs:
-                return reverse_lazy(
-                    "applications:edit_good", kwargs={"pk": self.application_id, "good_pk": self.object_pk}
-                )
-            else:
-                return reverse_lazy("goods:edit", kwargs={"pk": self.object_pk})
-        elif self.draft_pk:
+        if self.draft_pk:
             return reverse(
                 "goods:good_detail_application",
                 kwargs={"pk": self.object_pk, "type": "application", "draft_pk": self.draft_pk},
             )
-        # Edit
-        else:
+        # coming from product summary screen when adding a new product to an application
+        elif self.application_id and self.object_pk:
             return return_to_good_summary(self.kwargs, self.application_id, self.object_pk)
+        elif self.object_pk:
+            return reverse_lazy("goods:good", kwargs={"pk": self.object_pk})
 
 
 class EditYearOfManufacture(LoginRequiredMixin, SingleFormView):
@@ -583,21 +551,15 @@ class EditYearOfManufacture(LoginRequiredMixin, SingleFormView):
         self.action = edit_good_firearm_details
 
     def get_success_url(self):
-        if self.data.get("is_covered_by_firearm_act_section_one_two_or_five") is None:
-            if "good_pk" in self.kwargs:
-                return reverse_lazy(
-                    "applications:replica", kwargs={"pk": self.application_id, "good_pk": self.object_pk}
-                )
-            else:
-                return reverse_lazy("goods:replica", kwargs={"pk": self.object_pk})
-        elif self.draft_pk:
+        if self.draft_pk:
             return reverse(
                 "goods:good_detail_application",
                 kwargs={"pk": self.object_pk, "type": "application", "draft_pk": self.draft_pk},
             )
-        # Edit
-        else:
+        elif self.application_id and self.object_pk:
             return return_to_good_summary(self.kwargs, self.application_id, self.object_pk)
+        elif self.object_pk:
+            return reverse_lazy("goods:good", kwargs={"pk": self.object_pk})
 
 
 class EditFirearmReplica(LoginRequiredMixin, SingleFormView):
@@ -616,22 +578,15 @@ class EditFirearmReplica(LoginRequiredMixin, SingleFormView):
         self.action = edit_good_firearm_details
 
     def get_success_url(self):
-        # Next question product details
-        if self.data.get("type"):
-            if "good_pk" in self.kwargs:
-                return reverse_lazy(
-                    "applications:calibre", kwargs={"pk": self.application_id, "good_pk": self.object_pk}
-                )
-            else:
-                return reverse_lazy("goods:calibre", kwargs={"pk": self.object_pk})
-        elif self.draft_pk:
+        if self.draft_pk:
             return reverse(
                 "goods:good_detail_application",
                 kwargs={"pk": self.object_pk, "type": "application", "draft_pk": self.draft_pk},
             )
-        # Edit
-        else:
+        elif self.application_id and self.object_pk:
             return return_to_good_summary(self.kwargs, self.application_id, self.object_pk)
+        elif self.object_pk:
+            return reverse_lazy("goods:good", kwargs={"pk": self.object_pk})
 
 
 class EditCalibre(LoginRequiredMixin, SingleFormView):
@@ -650,22 +605,15 @@ class EditCalibre(LoginRequiredMixin, SingleFormView):
         self.action = edit_good_firearm_details
 
     def get_success_url(self):
-        # Next question is_covered_by_firearm_act_section_one_two_or_five - boolean
-        if self.data.get("is_covered_by_firearm_act_section_one_two_or_five") is None:
-            if "good_pk" in self.kwargs:
-                return reverse_lazy(
-                    "applications:firearms_act", kwargs={"pk": self.application_id, "good_pk": self.object_pk}
-                )
-            else:
-                return reverse_lazy("goods:firearms_act", kwargs={"pk": self.object_pk})
-        elif self.draft_pk:
+        if self.draft_pk:
             return reverse(
                 "goods:good_detail_application",
                 kwargs={"pk": self.object_pk, "type": "application", "draft_pk": self.draft_pk},
             )
-        # Edit
-        else:
+        elif self.application_id and self.object_pk:
             return return_to_good_summary(self.kwargs, self.application_id, self.object_pk)
+        elif self.object_pk:
+            return reverse_lazy("goods:good", kwargs={"pk": self.object_pk})
 
 
 class EditFirearmActDetails(LoginRequiredMixin, SingleFormView):
@@ -705,23 +653,15 @@ class EditFirearmActDetails(LoginRequiredMixin, SingleFormView):
             return new_data
 
     def get_success_url(self):
-        # Next question identification markings - boolean
-        if self.data.get("has_identification_markings") is None:
-            if "good_pk" in self.kwargs:
-                return reverse_lazy(
-                    "applications:identification_markings",
-                    kwargs={"pk": self.application_id, "good_pk": self.object_pk},
-                )
-            else:
-                return reverse_lazy("goods:identification_markings", kwargs={"pk": self.object_pk})
-        elif self.draft_pk:
+        if self.draft_pk:
             return reverse(
                 "goods:good_detail_application",
                 kwargs={"pk": self.object_pk, "type": "application", "draft_pk": self.draft_pk},
             )
-        # Edit
-        else:
+        elif self.application_id and self.object_pk:
             return return_to_good_summary(self.kwargs, self.application_id, self.object_pk)
+        elif self.object_pk:
+            return reverse_lazy("goods:good", kwargs={"pk": self.object_pk})
 
 
 class EditIdentificationMarkings(LoginRequiredMixin, SingleFormView):
@@ -740,17 +680,14 @@ class EditIdentificationMarkings(LoginRequiredMixin, SingleFormView):
         self.action = edit_good_firearm_details
 
     def get_success_url(self):
-        # Return to the application add good summary if adding/editing good from the application
-        if "good_pk" in self.kwargs:
-            return reverse_lazy(
-                "applications:add_good_summary", kwargs={"pk": self.application_id, "good_pk": self.object_pk}
-            )
-        elif self.draft_pk:
+        if self.draft_pk:
             return reverse(
                 "goods:good_detail_application",
                 kwargs={"pk": self.object_pk, "type": "application", "draft_pk": self.draft_pk},
             )
-        else:
+        elif self.application_id and self.object_pk:
+            return return_to_good_summary(self.kwargs, self.application_id, self.object_pk)
+        elif self.object_pk:
             return reverse_lazy("goods:good", kwargs={"pk": self.object_pk})
 
 

--- a/exporter/templates/applications/goods/add-good-detail-summary.html
+++ b/exporter/templates/applications/goods/add-good-detail-summary.html
@@ -21,9 +21,6 @@
 				{{ good.firearm_details.type.value|default_na }}
 			</dd>
 			<dd class="govuk-summary-list__actions">
-				{% if good.status.key == 'draft' %}
-					<a id="change-product-type" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:firearm_type' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "Goods.AddGoodSummary.FirearmDetails.PRODUCT_TYPE" %}</span></a>
-				{% endif %}
 			</dd>
 		</div>
 		{% if good.item_category.key == 'group2_firearms' %}

--- a/exporter/templates/goods/good.html
+++ b/exporter/templates/goods/good.html
@@ -296,13 +296,6 @@
 						{{ good.firearm_details.type.value|default_na }}
 					</dd>
 					<dd class="govuk-summary-list__actions">
-						{% if good.status.key == 'draft' %}
-							{% if draft_pk %}
-							<a id="change-product-type" class="govuk-link govuk-link--no-visited-state" href="{% url 'goods:firearm_type_add_application' good.id draft_pk %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "goods.GoodPage.Table.FirearmDetails.PRODUCT_TYPE" %}</span></a>
-							{% else %}
-							<a id="change-product-type" class="govuk-link govuk-link--no-visited-state" href="{% url 'goods:firearm_type' good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "goods.GoodPage.Table.FirearmDetails.PRODUCT_TYPE" %}</span></a>
-							{% endif %}
-						{% endif %}
 					</dd>
 				</div>
 

--- a/ui_tests/exporter/conftest.py
+++ b/ui_tests/exporter/conftest.py
@@ -865,15 +865,16 @@ def summary_screen_for_product_type(driver, product_type_value, description, pro
 
 @when(
     parsers.parse(
-        'I enter product details with unit of measurement "{unit}", quantity "{quantity}" and value "{value}" and Save'
+        'I enter product details with unit of measurement "{unit}", quantity "{quantity}", value "{value}" and deactivated "{status}" and Save'
     )
 )  # noqa
-def i_enter_product_details_unit_quantity_and_value(driver, unit, quantity, value):  # noqa
+def i_enter_product_details_unit_quantity_and_value(driver, unit, quantity, value, status):  # noqa
     details_page = StandardApplicationGoodDetails(driver)
     details_page.select_unit(unit)
     details_page.enter_quantity(quantity)
     details_page.enter_value(value)
     details_page.check_is_good_incorporated_false()
+    details_page.set_deactivated_status(status)
 
     functions.click_submit(driver)
 

--- a/ui_tests/exporter/features/submit_standard_application.feature
+++ b/ui_tests/exporter/features/submit_standard_application.feature
@@ -268,7 +268,7 @@ Feature: I want to indicate the standard licence I want
     And I see summary screen for "Firearms" product with description "new firearm" and "continue"
     And I confirm I can upload a document
     And I upload file "file_for_doc_upload_test_1.txt" with description "File uploaded for firearms product."
-    And I enter product details with unit of measurement "Number of articles", quantity "5" and value "20,000" and Save
+    And I enter product details with unit of measurement "Number of articles", quantity "5", value "20,000" and deactivated "No" and Save
     Then the product "new firearm" is added to the application
 
 
@@ -286,7 +286,7 @@ Feature: I want to indicate the standard licence I want
     And I see summary screen for "Accessory of a firearm" product with description "firearm accessory" and "continue"
     And I confirm I can upload a document
     And I upload file "file_for_doc_upload_test_1.txt" with description "File uploaded for firearms product."
-    And I enter product details with unit of measurement "Number of articles", quantity "9" and value "25,000" and Save
+    And I enter product details with unit of measurement "Number of articles", quantity "9", value "25,000" and deactivated "No" and Save
     Then the product "firearm accessory" is added to the application
 
 
@@ -304,7 +304,7 @@ Feature: I want to indicate the standard licence I want
     And I see summary screen for "Software relating to a firearm" product with description "Test software for firearms" and "continue"
     And I confirm I can upload a document
     And I upload file "file_for_doc_upload_test_1.txt" with description "File uploaded for firearms product."
-    And I enter product details with unit of measurement "Number of articles", quantity "25" and value "50,000" and Save
+    And I enter product details with unit of measurement "Number of articles", quantity "25", value "50,000" and deactivated "No" and Save
     Then the product "Test software for firearms" is added to the application
 
 

--- a/ui_tests/exporter/pages/standard_application/good_details.py
+++ b/ui_tests/exporter/pages/standard_application/good_details.py
@@ -25,3 +25,7 @@ class StandardApplicationGoodDetails(BasePage):
 
     def check_is_good_incorporated_false(self):
         self.driver.find_element_by_id(self.RADIO_IS_GOOD_INCORPORATED_FALSE_ID).click()
+
+    def set_deactivated_status(self, status):
+        status = "True" if status == "Yes" else "False"
+        self.driver.find_element_by_id(f"is_deactivated-{status}").click()


### PR DESCRIPTION
## Change description

Fixes issues found during review,
 - When editing sporting shotgun either from Product summary or Product detail, we currently ask few additional questions instead of going directly to summary screen. Similarly for other fields
 - Clicking back on sporting shotgun and product type again causes endless loop
 - Changing product type from eg ammunition to firearms, it is possible to proceed with some questions having invalid value eg firearms replica - we are temporarily not allowing editing product type