### PR TITLE
LTD-456 allow caseworker to indicate a good review sets precedent

### DIFF
--- a/caseworker/cases/forms/review_goods.py
+++ b/caseworker/cases/forms/review_goods.py
@@ -56,6 +56,7 @@ class ExportControlCharacteristicsForm(forms.Form):
     does_not_have_control_list_entries = forms.BooleanField(
         label="This product does not have a control list entry", required=False,
     )
+    is_precedent = forms.BooleanField(label="Mark this product rating as a precedent?", required=False)
     is_good_controlled = forms.TypedChoiceField(
         label="Is a licence required?",
         coerce=lambda x: x == "True",

--- a/caseworker/cases/views/goods.py
+++ b/caseworker/cases/views/goods.py
@@ -126,6 +126,7 @@ class ReviewStandardApplicationGoodWizardView(AbstractReviewGoodWizardView):
             "report_summary": self.object["good"]["report_summary"],
             "comment": source["comment"],
             "end_use_control": self.object["end_use_control"],
+            "is_precedent": self.object.get("is_precedent", False),
         }
         initial.update(super().get_form_initial(step))
         return initial

--- a/unit_tests/caseworker/cases/forms/test_review_goods.py
+++ b/unit_tests/caseworker/cases/forms/test_review_goods.py
@@ -37,9 +37,14 @@ def test_export_control_characteristics_form_mutex(control_list_entries):
     assert form.errors["does_not_have_control_list_entries"] == [form.MESSAGE_NO_CLC_MUTEX]
 
 
-def test_export_control_characteristics_form_ok(control_list_entries):
-    form = review_goods.ExportControlCharacteristicsForm(
-        control_list_entries_choices=control_list_entries,
-        data={"control_list_entries": ["ML1"], "report_summary": "Foo bar",},
-    )
+@pytest.mark.parametrize(
+    "data",
+    [
+        {"control_list_entries": ["ML1"], "report_summary": "Foo bar",},
+        {"control_list_entries": ["ML1"], "report_summary": "Foo bar", "is_precedent": True},
+        {"control_list_entries": ["ML1"], "report_summary": "Foo bar", "is_precedent": False},
+    ],
+)
+def test_export_control_characteristics_form_ok(control_list_entries, data):
+    form = review_goods.ExportControlCharacteristicsForm(control_list_entries_choices=control_list_entries, data=data,)
     assert form.is_valid() is True

--- a/unit_tests/caseworker/cases/test_views.py
+++ b/unit_tests/caseworker/cases/test_views.py
@@ -35,6 +35,7 @@ good_review_parametrize_data = (
             "is_good_controlled": True,
             "report_summary": "some-report-summary-id",
             "end_use_control": ["MEND", "MEND1"],
+            "is_precedent": False,
         },
         {
             "comment": "Some comment",
@@ -42,6 +43,7 @@ good_review_parametrize_data = (
             "is_good_controlled": True,
             "report_summary": "some-report-summary-id",
             "end_use_control": ["MEND", "MEND1"],
+            "is_precedent": False,
         },
     ),
     # multiple control list entries
@@ -52,6 +54,7 @@ good_review_parametrize_data = (
             "is_good_controlled": True,
             "report_summary": "some-report-summary-id",
             "end_use_control": [],
+            "is_precedent": False,
         },
         {
             "comment": "Some comment",
@@ -59,6 +62,7 @@ good_review_parametrize_data = (
             "is_good_controlled": True,
             "report_summary": "some-report-summary-id",
             "end_use_control": [],
+            "is_precedent": False,
         },
     ),
     # no comment
@@ -69,6 +73,7 @@ good_review_parametrize_data = (
             "is_good_controlled": True,
             "report_summary": "some-report-summary-id",
             "end_use_control": [],
+            "is_precedent": False,
         },
         {
             "comment": "",
@@ -76,6 +81,7 @@ good_review_parametrize_data = (
             "is_good_controlled": True,
             "report_summary": "some-report-summary-id",
             "end_use_control": [],
+            "is_precedent": False,
         },
     ),
     # not controlled and no control list entries
@@ -87,6 +93,7 @@ good_review_parametrize_data = (
             "is_good_controlled": False,
             "report_summary": "some-report-summary-id",
             "end_use_control": [],
+            "is_precedent": False,
         },
         {
             "comment": "Some comment",
@@ -94,6 +101,7 @@ good_review_parametrize_data = (
             "is_good_controlled": False,
             "report_summary": "some-report-summary-id",
             "end_use_control": [],
+            "is_precedent": False,
         },
     ),
     # is controlled but no control list entries
@@ -105,6 +113,7 @@ good_review_parametrize_data = (
             "is_good_controlled": True,
             "report_summary": "some-report-summary-id",
             "end_use_control": [],
+            "is_precedent": False,
         },
         {
             "comment": "Some comment",
@@ -112,6 +121,25 @@ good_review_parametrize_data = (
             "is_good_controlled": True,
             "report_summary": "some-report-summary-id",
             "end_use_control": [],
+            "is_precedent": False,
+        },
+    ),
+    # backwards compat, if API is not sending is_precedent
+    (
+        {
+            "comment": "Some comment",
+            "control_list_entries": ["ML1a"],
+            "is_good_controlled": True,
+            "report_summary": "some-report-summary-id",
+            "end_use_control": ["MEND", "MEND1"],
+        },
+        {
+            "comment": "Some comment",
+            "control_list_entries": ["ML1a"],
+            "is_good_controlled": True,
+            "report_summary": "some-report-summary-id",
+            "end_use_control": ["MEND", "MEND1"],
+            "is_precedent": False,
         },
     ),
 )

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -617,6 +617,7 @@ def data_good_on_application(data_standard_case):
         "end_use_control": ["MEND"],
         "comment": "",
         "report_summary": "",
+        "is_precedent": False,
         "audit_trail": [
             {
                 "id": "86f4d159-a282-4a25-b236-7e3d195356be",


### PR DESCRIPTION
This adds a new question to the good review form for standard applications that
allows caseworker to indicate if a good review sets precedent.