### PR TITLE
LTD-285: Add product name to FE

### DIFF
--- a/caseworker/templates/case/product-on-case.html
+++ b/caseworker/templates/case/product-on-case.html
@@ -8,7 +8,7 @@
             <a class="lite-back-link-button" id="back-link" href="{% url 'cases:case' queue_pk=queue.id pk=case.id %}">Back</a>
             <div class="govuk-!-margin-top-9 govuk-!-margin-bottom-9">
                 <h2 class="govuk-heading-xl govuk-!-margin-bottom-3">Product details</h2>
-				<div class="govuk-caption-l">{{ good_on_application.good.description}}</div>
+				<div class="govuk-caption-l">{% if good_on_application.good.name %} {{ good_on_application.good.name }} {% else %} {{ good_on_application.good.description }} {% endif %}</div>
 			</div>
 
             <div class="govuk-tabs" data-module="govuk-tabs">
@@ -70,6 +70,10 @@
 																			</td>
 																	</tr>
 													{% endif %}
+													<tr class="govuk-table__row app-table__row">
+														<th scope="row" class="govuk-table__header">Name</th>
+														<td class="govuk-table__cell">{% if good_on_application.good.name %} {{ good_on_application.good.name }} {% else %} {{ good_on_application.good.description }} {% endif %}</td>
+													</tr>
 													<tr class="govuk-table__row app-table__row">
 															<th scope="row" class="govuk-table__header">Description</th>
 															<td class="govuk-table__cell">{{ good_on_application.good.description }}</td>

--- a/caseworker/templates/case/review-good-base.html
+++ b/caseworker/templates/case/review-good-base.html
@@ -19,7 +19,7 @@
                     {{ wizard.steps.step1 }} of {{ wizard.steps.count }}
                 {% endif %}
             </h2>
-            <p class="govuk-!-margin-bottom-6 govuk-caption-m">{{ object.good.description }}</p>
+            <p class="govuk-!-margin-bottom-6 govuk-caption-m">{% if object.good.name %} {{ object.good.name }} {% else %} {{ object.good.description }} {% endif %}</p>
 			<form method="post" enctype="multipart/form-data" novalidate="novalidate">
                 {% csrf_token %}
                 <div class="w-2-3" id="form-container">

--- a/caseworker/templates/case/review-good-standard.html
+++ b/caseworker/templates/case/review-good-standard.html
@@ -24,6 +24,10 @@
                     </td>
             </tr>
             <tr class="govuk-table__row app-table__row">
+                <th scope="row" class="govuk-table__header">Name</th>
+                <td class="govuk-table__cell">{% if object.good.name %} {{ object.good.name }} {% else %} {{ object.good.description }} {% endif %}</td>
+            </tr>
+            <tr class="govuk-table__row app-table__row">
                 <th scope="row" class="govuk-table__header">Description</th>
                 <td class="govuk-table__cell">{{ object.good.description }}</td>
             </tr>

--- a/caseworker/templates/case/slices/goods.html
+++ b/caseworker/templates/case/slices/goods.html
@@ -34,7 +34,7 @@
 						</th>
 					{% endif %}
 					<th scope="col" class="govuk-table__header">#</th>
-					<th scope="col" class="govuk-table__header">Description</th>
+					<th scope="col" class="govuk-table__header">Name</th>
 					{% if case.goods.0.item_type %}
 						<th scope="col" class="govuk-table__header">Type</th>
 					{% endif %}
@@ -64,8 +64,8 @@
 						{% endif %}
 						<td class="govuk-table__cell govuk-table__cell--line-number {% if show_advice %}lite-!-no-border{% endif %}">{{ forloop.counter }}.</td>
 						<td class="govuk-table__cell govuk-table__cell--max-width-400 {% if show_advice %}lite-!-no-border{% endif %}">
-							<span class="govuk-table__header" aria-hidden="false">Description</span>
-							<span data-max-length="200">{{ good.good.description }}</span>
+							<span class="govuk-table__header" aria-hidden="false">Name</span>
+							<span data-max-length="200">{% if good.good.name %} {{ good.good.name }} {% else %} {{ good.good.description }} {% endif %}</span>
 						</td>
 						{% if case.goods.0.item_type %}
 							<td class="govuk-table__cell {% if show_advice %}lite-!-no-border{% endif %}">
@@ -142,7 +142,7 @@
 						</th>
 					{% endif %}
 					<th scope="col" class="govuk-table__header">#</th>
-					<th scope="col" class="govuk-table__header">Description</th>
+					<th scope="col" class="govuk-table__header">Name</th>
 					<th scope="col" class="govuk-table__header">Licence required</th>
 					<th scope="col" class="govuk-table__header">Rating</th>
 					<th scope="col" class="govuk-table__header">Flags</th>
@@ -167,8 +167,8 @@
 							{{ forloop.counter }}.
 						</td>
 						<td class="govuk-table__cell govuk-table__cell--max-width-400 {% if show_advice %}lite-!-no-border{% endif %}">
-							<span aria-hidden="true" class="govuk-table__header">Description</span>
-							<span data-max-length="200">{{ good.description }}</span>
+							<span aria-hidden="true" class="govuk-table__header">Name</span>
+							<span data-max-length="200">{% if good.name %} {{ good.name }} {% else %} {{ good.description }} {% endif %}</span>
 						</td>
 						<td class="govuk-table__cell {% if show_advice %}lite-!-no-border{% endif %}">
 							<span aria-hidden="true" class="govuk-table__header">Licence required</span>

--- a/caseworker/templates/search/results_cases.html
+++ b/caseworker/templates/search/results_cases.html
@@ -22,6 +22,7 @@
                 <tr class="govuk-table__row">
                     <th class="govuk-table__header" scope="col">Case</th>
                     <th class="govuk-table__header" scope="col">Part number</th>
+                    <th class="govuk-table__header" scope="col">Name</th>
                     <th class="govuk-table__header" scope="col">Description</th>
                     <th class="govuk-table__header" scope="col">Quantity</th>
                     <th class="govuk-table__header" scope="col">Rating</th>
@@ -69,6 +70,9 @@
                         {% endif %}
                         <td class="govuk-table__cell govuk-table__cell">
                             {{ good.part_number|default:'N/A' }}
+                        </td>
+                        <td class="govuk-table__cell govuk-table__cell">
+                            {% if good.name %} {{ good.name }} {% else %} {{ good.description }} {% endif %}
                         </td>
                         <td class="govuk-table__cell govuk-table__cell">
                             {{ good.description }}

--- a/exporter/applications/helpers/check_your_answers.py
+++ b/exporter/applications/helpers/check_your_answers.py
@@ -213,8 +213,14 @@ def convert_goods_on_application(goods_on_application, is_exhibition=False):
             control_list_application = convert_control_list_entries(good_on_application["control_list_entries"])
             if control_list_entries != control_list_application:
                 control_list_entries = f"<span class='strike'>{control_list_entries}</span> {control_list_application}"
+
+        if good_on_application["good"].get("name"):
+            name = good_on_application["good"]["name"]
+        else:
+            name = good_on_application["good"]["description"]
+
         item = {
-            "Description": good_on_application["good"]["description"],
+            "Name": name,
             "Part number": default_na(good_on_application["good"]["part_number"]),
             "Controlled": mark_safe(is_controlled),  # nosec
             "Control list entries": mark_safe(control_list_entries),  # nosec

--- a/exporter/applications/views/goods.py
+++ b/exporter/applications/views/goods.py
@@ -73,12 +73,14 @@ class ExistingGoodsList(LoginRequiredMixin, TemplateView):
         """
         application_id = str(kwargs["pk"])
         application = get_application(request, application_id)
+        name = request.GET.get("name", "").strip()
         description = request.GET.get("description", "").strip()
         part_number = request.GET.get("part_number", "").strip()
         control_list_entry = request.GET.get("control_list_entry", "").strip()
 
         filters = FiltersBar(
             [
+                TextInput(title="name", name="name"),
                 TextInput(title="description", name="description"),
                 TextInput(title="control list entry", name="control_list_entry"),
                 TextInput(title="part number", name="part_number"),
@@ -87,6 +89,7 @@ class ExistingGoodsList(LoginRequiredMixin, TemplateView):
 
         params = {
             "page": int(request.GET.get("page", 1)),
+            "name": name,
             "description": description,
             "part_number": part_number,
             "control_list_entry": control_list_entry,
@@ -97,6 +100,7 @@ class ExistingGoodsList(LoginRequiredMixin, TemplateView):
         context = {
             "application": application,
             "data": goods_list,
+            "name": name,
             "description": description,
             "part_number": part_number,
             "control_list_entry": control_list_entry,

--- a/exporter/applications/views/goods.py
+++ b/exporter/applications/views/goods.py
@@ -250,7 +250,8 @@ class CheckDocumentGrading(LoginRequiredMixin, SingleFormView):
     def init(self, request, **kwargs):
         self.draft_pk = kwargs["pk"]
         self.object_pk = kwargs["good_pk"]
-        self.form = document_grading_form(request, self.object_pk)
+        back_link = reverse("applications:add_good_summary", kwargs={"pk": self.draft_pk, "good_pk": self.object_pk})
+        self.form = document_grading_form(request, self.object_pk, back_url=back_link)
         self.action = post_good_document_sensitivity
 
     def get_success_url(self):

--- a/exporter/goods/forms.py
+++ b/exporter/goods/forms.py
@@ -252,15 +252,12 @@ def add_goods_questions(control_list_entries, application_pk=None):
     return Form(
         title=conditional(application_pk, "Add a product to your application", "Add a product to your product list"),
         questions=[
-            TextArea(
-                title="Description",
-                description=(
-                    "Start with the product name to make it easier to find the product when needed. Include the "
-                    "commodity code if you know it."
-                ),
-                name="description",
-                extras={"max_length": 280},
+            TextInput(
+                title="Name",
+                description=("Give your product a name so it is easier to find in your product list"),
+                name="name",
             ),
+            TextArea(title="Description", name="description", extras={"max_length": 280}, rows=5, optional=True,),
             TextInput(title="Part number", name="part_number", optional=True),
             RadioButtons(
                 title="Is the product on the control list?",
@@ -389,10 +386,16 @@ def edit_good_detail_form(request, good_id):
         title=EditGoodForm.TITLE,
         description=EditGoodForm.DESCRIPTION,
         questions=[
+            TextInput(
+                title="Name",
+                description=("Give your product a name so it is easier to find in your product list"),
+                name="name",
+            ),
             TextArea(
                 title=EditGoodForm.Description.TITLE,
-                description=EditGoodForm.Description.DESCRIPTION,
                 name="description",
+                rows=5,
+                optional=True,
                 extras={"max_length": 280},
             ),
             TextInput(title=EditGoodForm.PartNumber.TITLE, name="part_number", optional=True),

--- a/exporter/goods/helpers.py
+++ b/exporter/goods/helpers.py
@@ -11,7 +11,7 @@ def good_summary(good):
 
     return Summary(
         values={
-            "Description": good["description"],
+            "Name": good["description"] if not good["name"] else good["name"],
             "Control list entries": convert_control_list_entries(good["control_list_entries"]),
             "Part number": default_na(good["part_number"]),
         },

--- a/exporter/goods/services.py
+++ b/exporter/goods/services.py
@@ -6,7 +6,7 @@ from core.helpers import convert_parameters_to_query_params
 
 
 def get_goods(
-    request, page: int = 1, description=None, part_number=None, control_list_entry=None, for_application=None
+    request, page: int = 1, name=None, description=None, part_number=None, control_list_entry=None, for_application=None
 ):
     data = client.get(request, "/goods/" + convert_parameters_to_query_params(locals()))
     return data.json()

--- a/exporter/goods/views.py
+++ b/exporter/goods/views.py
@@ -413,6 +413,7 @@ class EditGood(LoginRequiredMixin, SingleFormView):
         self.data["control_list_entries"] = [
             {"key": clc["rating"], "value": clc["rating"]} for clc in self.data["control_list_entries"]
         ]
+        self.data["is_good_controlled"] = self.data["is_good_controlled"].get("key")
         return self.data
 
     def get_success_url(self):

--- a/exporter/goods/views.py
+++ b/exporter/goods/views.py
@@ -76,12 +76,14 @@ from core.auth.views import LoginRequiredMixin
 
 class Goods(LoginRequiredMixin, TemplateView):
     def get(self, request, **kwargs):
+        name = request.GET.get("name", "").strip()
         description = request.GET.get("description", "").strip()
         part_number = request.GET.get("part_number", "").strip()
         control_list_entry = request.GET.get("control_list_entry", "").strip()
 
         filters = FiltersBar(
             [
+                TextInput(title="name", name="name"),
                 TextInput(title="description", name="description"),
                 TextInput(title="control list entry", name="control_list_entry"),
                 TextInput(title="part number", name="part_number"),
@@ -90,6 +92,7 @@ class Goods(LoginRequiredMixin, TemplateView):
 
         params = {
             "page": int(request.GET.get("page", 1)),
+            "name": name,
             "description": description,
             "part_number": part_number,
             "control_list_entry": control_list_entry,
@@ -97,6 +100,7 @@ class Goods(LoginRequiredMixin, TemplateView):
 
         context = {
             "goods": get_goods(request, **params),
+            "name": name,
             "description": description,
             "part_number": part_number,
             "control_list_entry": control_list_entry,

--- a/exporter/templates/applications/goods/add-good-detail-summary.html
+++ b/exporter/templates/applications/goods/add-good-detail-summary.html
@@ -48,6 +48,19 @@
 		{% endif %}
 		<div class="govuk-summary-list__row">
 			<dt class="govuk-summary-list__key">
+				Name
+			</dt>
+			<dd class="govuk-summary-list__value">
+				{{ good.name }}
+			</dd>
+			<dd class="govuk-summary-list__actions">
+				{% if good.status.key == 'draft' %}
+					<a id="change-good-name" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:edit_good' application_id good.id %}#name">Change</a>
+				{% endif %}
+			</dd>
+		</div>
+		<div class="govuk-summary-list__row">
+			<dt class="govuk-summary-list__key">
 				{% lcs "Goods.AddGoodSummary.DESCRIPTION" %}
 			</dt>
 			<dd class="govuk-summary-list__value">

--- a/exporter/templates/applications/goods/goods-detail-summary.html
+++ b/exporter/templates/applications/goods/goods-detail-summary.html
@@ -27,6 +27,19 @@
 				</div>
 				<div class="govuk-summary-list__row">
 					<dt class="govuk-summary-list__key">
+						Name
+					</dt>
+					<dd class="govuk-summary-list__value">
+						{% if good.good.name %}
+							{{ good.good.name }}
+						{% else %}
+							{{ good.good.description }}
+						{% endif %}
+					</dd>
+				</div>
+
+				<div class="govuk-summary-list__row">
+					<dt class="govuk-summary-list__key">
 						{% lcs "goods.GoodPage.Table.DESCRIPTION" %}
 					</dt>
 					<dd class="govuk-summary-list__value">

--- a/exporter/templates/applications/goods/index.html
+++ b/exporter/templates/applications/goods/index.html
@@ -26,7 +26,7 @@
 			<thead class="govuk-table__head">
 				<tr class="govuk-table__row">
 					<th scope="col" class="govuk-table__header">#</th>
-					<th scope="col" class="govuk-table__header">{% lcs 'goods.GoodsList.Table.DESCRIPTION' %}</th>
+					<th scope="col" class="govuk-table__header">Name</th>
 					<th scope="col" class="govuk-table__header">{% lcs 'goods.GoodsList.Table.CONTROL_LIST_ENTRY' %}</th>
 					<th scope="col" class="govuk-table__header">{% lcs 'goods.GoodsList.Table.PART_NUMBER' %}</th>
 					{% if exhibition %}
@@ -46,7 +46,11 @@
 							{{ forloop.counter }}.
 						</td>
 						<td class="govuk-table__cell">
-							{{ good_on_application.good.description }}
+							{% if good_on_application.good.name %}
+								{{ good_on_application.good.name }}
+							{% else %}
+								{{ good_on_application.good.description }}
+							{% endif %}
 							{% if good_on_application.good.status.key == 'verified' %}<span class="app-verified__symbol">{% svg 'verified' %}</span><span class="govuk-visually-hidden"> (Verified product)</span>{% endif %}
 						</td>
 						<td class="govuk-table__cell">

--- a/exporter/templates/applications/goods/preexisting.html
+++ b/exporter/templates/applications/goods/preexisting.html
@@ -9,7 +9,7 @@
 {% block body %}
 	<h1 class="govuk-heading-l">{% block title %}{% lcs 'goods.AddPreexistingGoodToApplicationForm.TITLE' %}{% endblock %}</h1>
 
-	{% if data or description or part_number or control_code %}
+	{% if data or name or description or part_number or control_code %}
 
 		{% include 'filters.html' %}
 
@@ -17,6 +17,7 @@
 			<table class="govuk-table">
 				<thead class="govuk-table__head">
 					<tr class="govuk-table__row">
+						<th scope="col" class="govuk-table__header">Name</th>
 						<th scope="col" class="govuk-table__header">{% lcs 'goods.AddPreexistingGoodToApplicationForm.Table.DESCRIPTION' %}</th>
 						<th scope="col" class="govuk-table__header">{% lcs 'goods.AddPreexistingGoodToApplicationForm.Table.PART_NUMBER' %}</th>
 						<th scope="col" class="govuk-table__header">{% lcs 'goods.AddPreexistingGoodToApplicationForm.Table.CONTROL_LIST_ENTRIES' %}</th>
@@ -29,9 +30,16 @@
 				<tbody class="govuk-table__body">
 					{% for good in data.results %}
 						<tr class="govuk-table__row">
+							<td class="govuk-table__cell" id="good-name">
+								{% if good.name %}
+									{{ good.name|highlight_text:name }}
+								{% else %}
+									{{ good.description|highlight_text:description }}
+								{% endif %}
+								{% if good.status.key == 'verified' %}<span class="app-verified__symbol">{% svg 'verified' %}</span><span class="govuk-visually-hidden"> (Verified product)</span>{% endif %}
+							</td>
 							<td class="govuk-table__cell" id="good-description">
 								{{ good.description|highlight_text:description }}
-								{% if good.status.key == 'verified' %}<span class="app-verified__symbol">{% svg 'verified' %}</span><span class="govuk-visually-hidden"> (Verified product)</span>{% endif %}
 							</td>
 							<td class="govuk-table__cell" id="good-part-number">
 								{{ good.part_number|highlight_text:part_number|default_na }}
@@ -46,7 +54,7 @@
 							{% endif %}
 							<td class="govuk-table__cell lite-!-text-align-right">
 								<a href="{% url 'applications:add_good_to_application' draft_id good.id %}?preexisting=True" id="add-to-application" class="govuk-link govuk-link--no-visited-state" draggable="false">
-									Add <span class="govuk-visually-hidden">{{ good.description }}</span> to application
+									Add <span class="govuk-visually-hidden">{% if good.name %} {{ good.name }} {% else %} {{ good.description }} {% endif %}</span> to application
 								</a>
 							</td>
 						</tr>

--- a/exporter/templates/goods/good.html
+++ b/exporter/templates/goods/good.html
@@ -135,6 +135,27 @@
 		<dl class="govuk-summary-list" id="good-details">
 			<div class="govuk-summary-list__row">
 				<dt class="govuk-summary-list__key">
+					Name
+				</dt>
+				<dd class="govuk-summary-list__value">
+					{% if good.name %}
+						{{ good.name }}
+					{% else %}
+						{{ good.description }}
+					{% endif %}
+				</dd>
+				<dd class="govuk-summary-list__actions">
+					{% if good.status.key == 'draft' %}
+						{% if draft_pk %}
+						<a id="link-edit-name" class="govuk-link govuk-link--no-visited-state" href="{% url 'goods:edit-add-application' good.id draft_pk %}#name">Change</a>
+						{% else %}
+						<a id="link-edit-name" class="govuk-link govuk-link--no-visited-state" href="{% url 'goods:edit' good.id %}#name">Change</a>
+						{% endif %}
+					{% endif %}
+				</dd>
+			</div>
+			<div class="govuk-summary-list__row">
+				<dt class="govuk-summary-list__key">
 					{% lcs "goods.GoodPage.Table.DESCRIPTION" %}
 				</dt>
 				<dd class="govuk-summary-list__value">

--- a/exporter/templates/goods/goods.html
+++ b/exporter/templates/goods/goods.html
@@ -40,6 +40,7 @@
 		<table class="govuk-table">
 			<thead class="govuk-table__head">
 				<tr class="govuk-table__row">
+					<th class="govuk-table__header" scope="col">Name</th>
 					<th class="govuk-table__header" scope="col">{% lcs 'goods.GoodsList.Table.DESCRIPTION' %}</th>
 					<th class="govuk-table__header" scope="col"></th>
 					<th class="govuk-table__header" scope="col">{% lcs 'goods.GoodsList.Table.CONTROL_LIST_ENTRY' %}</th>
@@ -51,6 +52,14 @@
 			<tbody class="govuk-table__body">
 				{% for good in goods.results %}
 					<tr class="govuk-table__row">
+						<td class="govuk-table__cell">
+							<span class="govuk-table__header" aria-hidden="true">Name</span>
+							{% if good.name %}
+								{{ good.name|highlight_text:name }}
+							{% else %}
+								{{ good.description|highlight_text:description }}
+							{% endif %}
+						</td>
 						<td class="govuk-table__cell">
 							<span class="govuk-table__header" aria-hidden="true">{% lcs 'goods.GoodsList.Table.DESCRIPTION' %}</span>
 							{{ good.description|highlight_text:description }}

--- a/tests_common/api_client/libraries/request_data.py
+++ b/tests_common/api_client/libraries/request_data.py
@@ -1,8 +1,22 @@
 import random
+import string
 
 from faker import Faker
 
 fake = Faker()
+
+example_goods = [
+    {"name": "Rifle", "description": "Firearms"},
+    {"name": "Gatling gun", "description": "Firearms"},
+    {"name": "Router", "description": "Network router"},
+    {"name": "Artillery", "description": "Firearms"},
+    {"name": "Spectrometer", "description": "Specialized optics"},
+    {"name": "CCD Detector", "description": "Image sensor"},
+    {"name": "Cryptographical software", "description": "Encryption software"},
+    {"name": "Aileron", "description": "Aircraft component"},
+    {"name": "Ammunition", "description": "Sporting shotgun ammunition"},
+    {"name": "Assembly board", "description": "Electronics assembly board"},
+]
 
 
 def build_user(user):
@@ -48,8 +62,9 @@ def build_organisation(name, type, address):
     }
 
 
-def build_good(description, control_list_entry="ML1a", part_number="1234"):
+def build_good(name, description, control_list_entry="ML1a", part_number="1234"):
     return {
+        "name": name,
         "description": description,
         "is_good_controlled": True,
         "control_list_entries": [control_list_entry],
@@ -90,15 +105,26 @@ def random_colour():
     return random.choice(["red", "orange", "blue", "yellow", "green", "pink", "purple", "brown", "turquoise"])
 
 
+def random_part_number(max_len=16):
+    def randstr(len):
+        return "".join(random.choice(string.ascii_uppercase) for _ in range(len))
+
+    def randint(len):
+        return "".join(random.choice(string.digits) for _ in range(len))
+
+    return f"{randstr(2)}-{randstr(4)}-{randint(8)}"
+
+
 def build_request_data(exporter_user, gov_user):
     exporter = build_user(exporter_user)
+    good = random.choice(example_goods)
     request_data = {
         "organisation": build_organisation_with_user(exporter, "commercial", "Archway Communications"),
         # Please leave this as HMRC as tests depend on this being HMRC.
         "organisation_for_switching_organisations": build_organisation_with_user(
             exporter, "hmrc", "HMRC Wayne Enterprises"
         ),
-        "good": build_good("Lentils"),
+        "good": build_good(good["name"], good["description"], part_number=random_part_number()),
         "application": {
             "name": "application",
             "application_type": "siel",

--- a/ui_tests/exporter/conftest.py
+++ b/ui_tests/exporter/conftest.py
@@ -767,11 +767,13 @@ def select_sporting_gun_status(driver, status):  # noqa
 
 @when(
     parsers.parse(
-        'I enter good description as "{description}" part number "{part_number}" controlled "{controlled}" control code "{control_code}" and graded "{graded}"'
+        'I enter good name as "{name}" description as "{description}" part number "{part_number}" '
+        'controlled "{controlled}" control code "{control_code}" and graded "{graded}"'
     )
 )  # noqa
-def create_a_new_good_in_application(driver, description, part_number, controlled, control_code, graded):  # noqa
+def create_a_new_good_in_application(driver, name, description, part_number, controlled, control_code, graded):  # noqa
     add_goods_page = AddGoodPage(driver)
+    add_goods_page.enter_good_name(name)
     add_goods_page.enter_description_of_goods(description)
     add_goods_page.enter_part_number(part_number)
     add_goods_page.select_is_your_good_controlled(controlled)
@@ -926,6 +928,13 @@ def i_enter_product_details_unit_quantity_and_value(driver, unit, quantity, valu
     functions.click_submit(driver)
 
 
+@then(parsers.parse('the product with name "{expected}" is added to the application'))
+def product_with_name_is_added_to_application(driver, expected):  # noqa
+    products_page = StandardApplicationGoodsPage(driver)
+    actual = products_page.get_product_name()
+    assert actual == expected
+
+
 @then(parsers.parse('the product "{description}" is added to the application'))
 def product_with_description_is_added_to_application(driver, description):  # noqa
     products_page = StandardApplicationGoodsPage(driver)
@@ -940,6 +949,7 @@ def edit_good_details_in_application(driver, field_name, updated_value):  # noqa
     driver.execute_script("arguments[0].click();", link)
 
     pages_map = {
+        "Name": AddGoodPage(driver).enter_good_name,
         "Description": AddGoodPage(driver).enter_description_of_goods,
         "Part number": AddGoodPage(driver).enter_part_number,
         "Year of manufacture": AddGoodDetails(driver).enter_year_of_manufacture,

--- a/ui_tests/exporter/conftest.py
+++ b/ui_tests/exporter/conftest.py
@@ -872,17 +872,13 @@ def specify_product_infosec_details(driver, supports_infosec):  # noqa
     functions.click_submit(driver)
 
 
-@when(
-    parsers.parse(
-        'I see summary screen for "{product_type_value}" product with description "{description}" and "{proceed}"'
-    )
-)
-def summary_screen_for_product_type(driver, product_type_value, description, proceed):  # noqa
+@when(parsers.parse('I see summary screen for "{product_type_value}" product with name "{name}" and "{proceed}"'))
+def summary_screen_for_product_type(driver, product_type_value, name, proceed):  # noqa
     summary_page = ProductSummary(driver)
     assert summary_page.get_page_heading() == "Product summary"
     summary = summary_page.get_summary_details()
     assert summary["Product type"] == product_type_value
-    assert summary["Description"] == description
+    assert summary["Name"] == name
     expected_fields = [
         "Part number",
         "CLC",

--- a/ui_tests/exporter/features/submit_standard_application.feature
+++ b/ui_tests/exporter/features/submit_standard_application.feature
@@ -268,7 +268,29 @@ Feature: I want to indicate the standard licence I want
     And I select firearms act section "2"
     And I upload firearms certificate file "file_for_doc_upload_test_1.txt"
     And I enter certificate number as "FR2468/1234/1" with expiry date "12-10-2030"
-    And I see summary screen for "Firearms" product with description "new firearm" and "continue"
+    And I see summary screen for "Firearms" product with name "Rifle" and "continue"
+    And I confirm I can upload a document
+    And I upload file "file_for_doc_upload_test_1.txt" with description "File uploaded for firearms product."
+    And I enter product details with unit of measurement "Number of articles", quantity "5", value "20,000" and deactivated "No" and Save
+    Then the product with name "Rifle" is added to the application
+
+
+  @LTD_375_Add_a_new_firearm_product_not_covered_by_firearms_act @regression
+  Scenario: Add a new Firearm product of type firearms, ammunition, components of ammunition to the application that is not covered by Firearms Act
+    Given I go to exporter homepage and choose Test Org
+    When I create a standard application of a "permanent" export type
+    When I click on the "goods" section
+    And I choose to add a new product
+    And I select product type "component_for_ammunition"
+    And I select "Yes" for serial number of other identification marking with details as "serial number FR8654-Z"
+    And I select sporting shotgun status as "Yes"
+    And I enter good name as "Rifle" description as "new firearm" part number "FR-123-M" controlled "True" control code "ML1a" and graded "no"
+    And I enter calibre as "0.22"
+    And I specify firearms act sections apply as "Yes"
+    And I select firearms act section "2"
+    And I upload firearms certificate file "file_for_doc_upload_test_1.txt"
+    And I enter certificate number as "FR2468/1234/1" with expiry date "12-10-2030"
+    And I see summary screen for "Components for ammunition" product with name "Rifle" and "continue"
     And I confirm I can upload a document
     And I upload file "file_for_doc_upload_test_1.txt" with description "File uploaded for firearms product."
     And I enter product details with unit of measurement "Number of articles", quantity "5", value "20,000" and deactivated "No" and Save
@@ -286,7 +308,7 @@ Feature: I want to indicate the standard licence I want
     And I specify military use details as "yes_designed"
     And I specify component details as "yes_designed"
     And I specify product employs information security features as "Yes"
-    And I see summary screen for "Accessory of a firearm" product with description "firearm accessory" and "continue"
+    And I see summary screen for "Accessory of a firearm" product with name "firearm accessory" and "continue"
     And I confirm I can upload a document
     And I upload file "file_for_doc_upload_test_1.txt" with description "File uploaded for firearms product."
     And I enter product details with unit of measurement "Number of articles", quantity "9", value "25,000" and deactivated "No" and Save
@@ -304,7 +326,7 @@ Feature: I want to indicate the standard licence I want
     And I specify the "software" product purpose as "For product diagnostics"
     And I specify military use details as "yes_designed"
     And I specify product employs information security features as "Yes"
-    And I see summary screen for "Software relating to a firearm" product with description "Test software for firearms" and "continue"
+    And I see summary screen for "Software relating to a firearm" product with name "Firearms software" and "continue"
     And I confirm I can upload a document
     And I upload file "file_for_doc_upload_test_1.txt" with description "File uploaded for firearms product."
     And I enter product details with unit of measurement "Number of articles", quantity "25", value "50,000" and deactivated "No" and Save
@@ -328,7 +350,7 @@ Feature: I want to indicate the standard licence I want
     And I select firearms act section "1"
     And I upload firearms certificate file "file_for_doc_upload_test_1.txt"
     And I enter certificate number as "FR2468/1234/1" with expiry date "12-12-2025"
-    And I see summary screen for "Firearms" product with description "new firearm" and "review"
+    And I see summary screen for "Firearms" product with name "Rifle" and "review"
     And I can edit good "Name" as "Powerful Rifle"
     And I can edit good "Description" as "updated firearm description"
     And I can edit good "Part number" as "PN-ABC/123"
@@ -347,7 +369,7 @@ Feature: I want to indicate the standard licence I want
     And I specify military use details as "yes_designed"
     And I specify component details as "yes_designed"
     And I specify product employs information security features as "Yes"
-    And I see summary screen for "Accessory of a firearm" product with description "firearm accessory" and "review"
+    And I see summary screen for "Accessory of a firearm" product with name "firearm accessory" and "review"
     And I can edit good "Name" as "Updated firearm accessory"
     And I can edit good "Description" as "updated firearm accessory description"
     And I can edit good "Part number" as "ACC-123/Y"

--- a/ui_tests/exporter/features/submit_standard_application.feature
+++ b/ui_tests/exporter/features/submit_standard_application.feature
@@ -260,7 +260,7 @@ Feature: I want to indicate the standard licence I want
     And I select product type "firearm"
     And I select "Yes" for serial number of other identification marking with details as "serial number FR8654-Z"
     And I select sporting shotgun status as "Yes"
-    And I enter good description as "new firearm" part number "FR-123-M" controlled "True" control code "ML1a" and graded "no"
+    And I enter good name as "Rifle" description as "new firearm" part number "FR-123-M" controlled "True" control code "ML1a" and graded "no"
     And I enter firearm year of manufacture as "2020"
     And I select firearm replica status as "Yes" with description "More details about the replica"
     And I enter calibre as "0.22"
@@ -272,7 +272,7 @@ Feature: I want to indicate the standard licence I want
     And I confirm I can upload a document
     And I upload file "file_for_doc_upload_test_1.txt" with description "File uploaded for firearms product."
     And I enter product details with unit of measurement "Number of articles", quantity "5", value "20,000" and deactivated "No" and Save
-    Then the product "new firearm" is added to the application
+    Then the product with name "Rifle" is added to the application
 
 
   @LTD_398_Add_a_new_firearm_accessory @regression
@@ -282,7 +282,7 @@ Feature: I want to indicate the standard licence I want
     When I click on the "goods" section
     And I choose to add a new product
     And I select product type "firearm_accessory"
-    And I enter good description as "firearm accessory" part number "FR-123-ACC" controlled "True" control code "ML1a" and graded "no"
+    And I enter good name as "firearm accessory" description as "firearm accessory" part number "FR-123-ACC" controlled "True" control code "ML1a" and graded "no"
     And I specify military use details as "yes_designed"
     And I specify component details as "yes_designed"
     And I specify product employs information security features as "Yes"
@@ -290,7 +290,7 @@ Feature: I want to indicate the standard licence I want
     And I confirm I can upload a document
     And I upload file "file_for_doc_upload_test_1.txt" with description "File uploaded for firearms product."
     And I enter product details with unit of measurement "Number of articles", quantity "9", value "25,000" and deactivated "No" and Save
-    Then the product "firearm accessory" is added to the application
+    Then the product with name "firearm accessory" is added to the application
 
 
   @LTD_398_Add_a_new_software_related_to_firearm_product @regression
@@ -300,7 +300,7 @@ Feature: I want to indicate the standard licence I want
     When I click on the "goods" section
     And I choose to add a new product
     And I select product type "software_for_firearm"
-    And I enter good description as "Test software for firearms" part number "FR-123-ACC" controlled "True" control code "ML1a" and graded "no"
+    And I enter good name as "Firearms software" description as "Test software for firearms" part number "FR-123-ACC" controlled "True" control code "ML1a" and graded "no"
     And I specify the "software" product purpose as "For product diagnostics"
     And I specify military use details as "yes_designed"
     And I specify product employs information security features as "Yes"
@@ -308,7 +308,7 @@ Feature: I want to indicate the standard licence I want
     And I confirm I can upload a document
     And I upload file "file_for_doc_upload_test_1.txt" with description "File uploaded for firearms product."
     And I enter product details with unit of measurement "Number of articles", quantity "25", value "50,000" and deactivated "No" and Save
-    Then the product "Test software for firearms" is added to the application
+    Then the product with name "Firearms software" is added to the application
 
 
   @LTD_398_Add_a_new_firearm_product_and_check_edit @regression
@@ -318,14 +318,18 @@ Feature: I want to indicate the standard licence I want
     When I click on the "goods" section
     And I choose to add a new product
     And I select product type "firearm"
+    And I select "Yes" for serial number of other identification marking with details as "serial number FR8654-Z"
     And I select sporting shotgun status as "No"
-    And I enter good description as "new firearm" part number "FR-123-M" controlled "True" control code "ML1a" and graded "no"
+    And I enter good name as "Rifle" description as "new firearm" part number "FR-123-M" controlled "True" control code "ML1a" and graded "no"
     And I enter firearm year of manufacture as "2020"
     And I select firearm replica status as "No" with description "not required"
     And I enter calibre as "0.22"
     And I specify firearms act sections apply as "Yes"
-    And I specify firearms identification markings as "Yes" with details "laser engraving"
+    And I select firearms act section "1"
+    And I upload firearms certificate file "file_for_doc_upload_test_1.txt"
+    And I enter certificate number as "FR2468/1234/1" with expiry date "12-12-2025"
     And I see summary screen for "Firearms" product with description "new firearm" and "review"
+    And I can edit good "Name" as "Powerful Rifle"
     And I can edit good "Description" as "updated firearm description"
     And I can edit good "Part number" as "PN-ABC/123"
     And I can edit good "Year of manufacture" as "2020"
@@ -339,11 +343,12 @@ Feature: I want to indicate the standard licence I want
     When I click on the "goods" section
     And I choose to add a new product
     And I select product type "firearm_accessory"
-    And I enter good description as "firearm accessory" part number "FR-123-ACC" controlled "True" control code "ML1a" and graded "no"
+    And I enter good name as "firearm accessory" description as "firearm accessory" part number "FR-123-ACC" controlled "True" control code "ML1a" and graded "no"
     And I specify military use details as "yes_designed"
     And I specify component details as "yes_designed"
     And I specify product employs information security features as "Yes"
     And I see summary screen for "Accessory of a firearm" product with description "firearm accessory" and "review"
+    And I can edit good "Name" as "Updated firearm accessory"
     And I can edit good "Description" as "updated firearm accessory description"
     And I can edit good "Part number" as "ACC-123/Y"
     And I can edit good "Military use" as "yes_modified"

--- a/ui_tests/exporter/pages/add_goods_page.py
+++ b/ui_tests/exporter/pages/add_goods_page.py
@@ -27,10 +27,16 @@ class AddGoodPage(BasePage):
     UNSURE_CLC_DETAILS = "clc_raised_reasons"  # ID
     UNSURE_PV_GRADING_DETAILS = "pv_grading_raised_reasons"  # ID
 
-    def enter_description_of_goods(self, description):
-        element = self.driver.find_element_by_id(self.DESCRIPTION)
+    def input_element_by_id(self, id, text):
+        element = self.driver.find_element_by_id(id)
         element.clear()
-        element.send_keys(description)
+        element.send_keys(text)
+
+    def enter_good_name(self, name):
+        self.input_element_by_id("name", name)
+
+    def enter_description_of_goods(self, description):
+        self.input_element_by_id(self.DESCRIPTION, description)
 
     def select_is_your_good_controlled(self, option):
         # The options accepted here are 'True', 'False' and 'None'

--- a/ui_tests/exporter/pages/standard_application/goods.py
+++ b/ui_tests/exporter/pages/standard_application/goods.py
@@ -51,6 +51,11 @@ class StandardApplicationGoodsPage(BasePage):
     def goods_exist_on_the_application(self):
         return functions.element_with_css_selector_exists(self.driver, self.REMOVE_GOOD_LINK)
 
+    def get_product_name(self):
+        rows = self.driver.find_elements_by_class_name("govuk-table__row")
+        assert len(rows) == 2
+        return rows[1].find_elements_by_xpath('//td[@class="govuk-table__cell"]')[0].text
+
     def good_with_description_exists(self, expected):
         for row in self.driver.find_elements_by_class_name("govuk-table__row"):
             actual = row.find_elements_by_xpath('//td[@class="govuk-table__cell"]')[0].text

--- a/unit_tests/exporter/applications/forms/goods/test_goods.py
+++ b/unit_tests/exporter/applications/forms/goods/test_goods.py
@@ -28,6 +28,7 @@ def good_template():
         "uses_information_security": None,
         # to be set by fixture
         "item_category": {},
+        "name": "good",
         "description": "",
         "firearm_details": {},
     }
@@ -37,6 +38,7 @@ def good_template():
 def good_ammo(good_template):
     return {
         **good_template,
+        "name": "Ammunition",
         "description": "box of 25 game shot cartridges",
         "item_category": {"key": "group2_firearms", "value": "Firearms"},
         "firearm_details": {
@@ -59,6 +61,7 @@ def good_ammo(good_template):
 def good_shotgun(good_template):
     return {
         **good_template,
+        "name": "Shotgun",
         "description": "A shotgun",
         "item_category": {"key": "group2_firearms", "value": "Firearms"},
         "firearm_details": {
@@ -81,6 +84,7 @@ def good_shotgun(good_template):
 def good_gun_barrel(good_template):
     return {
         **good_template,
+        "name": "Gun barrel",
         "description": "A barrel",
         "item_category": {"key": "group2_firearms", "value": "Firearms"},
         "firearm_details": {
@@ -104,6 +108,7 @@ def good_widget(good_template):
 
     return {
         **good_template,
+        "name": "Widget",
         "description": "A widget",
         "item_category": {"key": "group1_components", "value": "Components, modules or accessories of something"},
     }

--- a/unit_tests/exporter/goods/test_forms.py
+++ b/unit_tests/exporter/goods/test_forms.py
@@ -27,8 +27,8 @@ def test_add_goods_questions_feature_flag_on(settings):
 
     form = forms.add_goods_questions(control_list_entries=[])
 
-    assert form.questions[2].options[-1].components[0].__class__ == HelpSection
     assert form.questions[3].options[-1].components[0].__class__ == HelpSection
+    assert form.questions[4].options[-1].components[0].__class__ == HelpSection
 
 
 def test_add_goods_questions_feature_flag_off(settings):
@@ -36,8 +36,8 @@ def test_add_goods_questions_feature_flag_off(settings):
 
     form = forms.add_goods_questions(control_list_entries=[])
 
-    assert form.questions[2].options[-1].components == []
     assert form.questions[3].options[-1].components == []
+    assert form.questions[4].options[-1].components == []
 
 
 @pytest.mark.parametrize(
@@ -105,7 +105,7 @@ def pv_gradings(mock_pv_gradings, rf, client):
             [
                 {"qindex": 1, "name": "type"},
                 {"qindex": 2, "name": "is_sporting_shotgun"},
-                {"qindex": 0, "name": "description"},
+                {"qindex": 0, "name": "name"},
                 {"qindex": 1, "name": "calibre"},
             ],
         ),
@@ -116,7 +116,7 @@ def pv_gradings(mock_pv_gradings, rf, client):
                 {"qindex": 1, "name": "type"},
                 {"qindex": 1, "name": "has_identification_markings"},
                 {"qindex": 2, "name": "is_sporting_shotgun"},
-                {"qindex": 0, "name": "description"},
+                {"qindex": 0, "name": "name"},
                 {"qindex": 1, "name": "year_of_manufacture"},
                 {"qindex": 2, "name": "is_replica"},
                 {"qindex": 1, "name": "calibre"},
@@ -128,7 +128,7 @@ def pv_gradings(mock_pv_gradings, rf, client):
             5,
             [
                 {"qindex": 1, "name": "type"},
-                {"qindex": 0, "name": "description"},
+                {"qindex": 0, "name": "name"},
                 {"qindex": 1, "name": "is_military_use"},
                 {"qindex": 1, "name": "is_component"},
                 {"qindex": 1, "name": "uses_information_security"},
@@ -139,7 +139,7 @@ def pv_gradings(mock_pv_gradings, rf, client):
             5,
             [
                 {"qindex": 1, "name": "type"},
-                {"qindex": 0, "name": "description"},
+                {"qindex": 0, "name": "name"},
                 {"qindex": 1, "name": "software_or_technology_details"},
                 {"qindex": 1, "name": "is_military_use"},
                 {"qindex": 1, "name": "uses_information_security"},


### PR DESCRIPTION
## Change description
We now have product name, changes update various templates, filter options and also show in search results.

For existing products where `name` is not available, `description` is taken as name instead.
Updated browser tests.