### PR TITLE
Firearms section certificate upload form fixes

### DIFF
--- a/exporter/assets/javascripts/add-good.js
+++ b/exporter/assets/javascripts/add-good.js
@@ -63,6 +63,15 @@ $("input[name='section_certificate_missing']").change(function () {
 	showHideCertificateMissingReason()
 });
 
+
+function populateUploadedCertificate() {
+	var existingCertificate = $("input[name='uploaded_file_name']").val();
+	if (existingCertificate) {
+		$("input[type=file]").next().html(existingCertificate + "<br><span class='lite-file-upload__or-label'>Drag and drop your document here or <span class='lite-file-upload__link'>click to browse</span> to replace it</span>");
+	}
+}
+
 (function () {
+	populateUploadedCertificate()
 	showHideCertificateMissingReason()
 })();

--- a/exporter/goods/forms.py
+++ b/exporter/goods/forms.py
@@ -710,13 +710,14 @@ def firearms_act_confirmation_form():
     )
 
 
-def upload_firearms_act_certificate_form(section, back_link):
+def upload_firearms_act_certificate_form(section, filename, back_link):
     return Form(
         title=f"Upload your Firearms Act 1968 {section} certificate",
         description="The file must be smaller than 50MB",
         questions=[
             HiddenField("firearms_certificate_uploaded", False),
             FileUpload(),
+            HiddenField("uploaded_file_name", filename),
             TextInput(
                 title=CreateGoodForm.FirearmGood.FirearmsActCertificate.SECTION_CERTIFICATE_NUMBER,
                 description="",


### PR DESCRIPTION
## Change description

Firearms section certificate upload form fixes
 - display the title as per the selected section
 - don't clear the selected file on validation errors
 - populate the selected filename when editing

Save selected file details temporarily in session and clear once
the request is completed successfully.

We setup `upload_handlers` to upload the file to S3. This gets processed as and when we read `request.POST` and the file
gets uploaded to S3 but if there is a validation error we use the saved details from session and populate the fileupload field with the previously selected file name. If the user wishes to replace then another file can be selected. This is required both when initially adding the certificate or when editing it from the summary screen.
While editing if user changes the section then the previously uploaded file gets removed.