### PR TITLE
LTD-307: Update flagging rules to include exclusion entries

### DIFF
--- a/caseworker/flags/forms.py
+++ b/caseworker/flags/forms.py
@@ -181,6 +181,12 @@ def select_condition_and_flag(request, type: str):
                     description="Type to get suggestions. For example, ML8.\nThis will add every control list entry under ML8.",
                     options=clc_groups_options,
                 ),
+                TokenBar(
+                    title="Excluded control list entries",
+                    name="excluded_values",
+                    description="Type to get suggestions. For example, ML1a, ML8.\nThis will exclude ML1a and every control list entry under ML8.",
+                    options=clc_groups_options + clc_entries_options,
+                ),
                 Heading("Set an action", HeadingStyle.S),
                 Select(title=strings.FlaggingRules.Create.Condition_and_flag.FLAG, name="flag", options=flags),
                 is_for_verified_goods_only,

--- a/caseworker/flags/views.py
+++ b/caseworker/flags/views.py
@@ -216,6 +216,8 @@ class EditFlaggingRules(LoginRequiredMixin, SingleFormView):
             copied_request.setlist("matching_values[]", [])
         if self.data["level"] == "Good" and "matching_groups[]" not in copied_request:
             copied_request.setlist("matching_groups[]", [])
+        if self.data["level"] == "Good" and "excluded_values[]" not in copied_request:
+            copied_request.setlist("excluded_values[]", [])
 
         if self.data["level"] == "Destination":
             reverse_countries_map = {country["name"]: country["id"] for country in self.get_countries}

--- a/caseworker/templates/flags/flagging-rules-list.html
+++ b/caseworker/templates/flags/flagging-rules-list.html
@@ -29,6 +29,7 @@
 				<th class="govuk-table__header" scope="col">{% lcs 'FlaggingRules.List.TEAM' %}</th>
 				<th class="govuk-table__header" scope="col">{% lcs 'FlaggingRules.List.PARAMETER' %}</th>
 				<th class="govuk-table__header" scope="col">{% lcs 'FlaggingRules.List.CONDITION' %}</th>
+				<th class="govuk-table__header" scope="col">Applies to verified goods</th>
 				<th class="govuk-table__header" scope="col">{% lcs 'FlaggingRules.List.FLAG' %}</th>
 				<th class="govuk-table__header" scope="col">{% lcs 'FlaggingRules.List.STATUS' %}</th>
 				<th class="govuk-table__header" scope="col">{% lcs 'FlaggingRules.List.ACTIONS' %}</th>
@@ -62,6 +63,13 @@
 								<br>
 							{% endif %}
 							Excludes: {{ flagging_rule.excluded_values|join:", " }}
+						{% endif %}
+					</td>
+					<td class="govuk-table__cell">
+						{% if flagging_rule.level == "Good" %}
+							{{ flagging_rule.is_for_verified_goods_only|friendly_boolean }}
+						{% else %}
+							N/A
 						{% endif %}
 					</td>
 					<td class="govuk-table__cell">

--- a/caseworker/templates/flags/flagging-rules-list.html
+++ b/caseworker/templates/flags/flagging-rules-list.html
@@ -57,6 +57,12 @@
 							{% endif %}
 							{{ flagging_rule.matching_groups|join:", " }} group
 						{% endif %}
+						{% if flagging_rule.excluded_values %}
+							{% if flagging_rule.matching_values %}
+								<br>
+							{% endif %}
+							Excludes: {{ flagging_rule.excluded_values|join:", " }}
+						{% endif %}
 					</td>
 					<td class="govuk-table__cell">
 						{{ flagging_rule.flag_name }}


### PR DESCRIPTION
## Change description

Frontend changes to specify exclusion entries for flags.
Flag will be applied if the goods doesn't contain any of the clc entries specified in the exclusion entries.