### PR TITLE
LTD-507 Control List Entries cleared when adding new product to app

### DIFF
--- a/exporter/applications/views/goods.py
+++ b/exporter/applications/views/goods.py
@@ -161,7 +161,13 @@ class AddGood(LoginRequiredMixin, MultiFormView):
         if int(self.request.POST.get("form_pk")) == number_of_forms:
             if self.show_section_upload_form:
                 firearms_data_id = f"post_{request.session['lite_api_user_id']}_{self.draft_pk}"
-                request.session[firearms_data_id] = copied_request
+                session_data = copied_request.dict()
+                if "control_list_entries[]" in copied_request:
+                    session_data["control_list_entries"] = copied_request.getlist("control_list_entries[]")
+                    del session_data["control_list_entries[]"]
+
+                request.session[firearms_data_id] = session_data
+
             elif self.certificate_not_required:
                 self.action = post_goods
             else:


### PR DESCRIPTION
This fixes a bug with the serialisation of a new good when being added to an
application, there was an issue that if the user added a firearm certificate
then the control list entries would be lost. Fixing that bug in `lite-api`
also uncovered another bug in that only the first control list entry was
being sent to lite-api instead of the full list.

This commit makes sure the full list of `control_list_entries` is saved to the
session so it can be played back later.