### PR TITLE
LTD-536: Routing rules flags section updates

### DIFF
--- a/caseworker/routing_rules/forms.py
+++ b/caseworker/routing_rules/forms.py
@@ -132,13 +132,22 @@ def get_flag_details_html(flag):
     """
 
 
-def select_flags(request, team_id, flags_to_include, flags_to_exclude):
+def select_flags(request, team_id, flags_to_include, flags_to_exclude, is_editing):
     return Form(
-        title=Forms.FLAGS,
+        title=Forms.FLAGS if not is_editing else "Edit flags",
         questions=[
             HiddenField(name="flags_to_include", value=",".join(flags_to_include)),
             HiddenField(name="flags_to_exclude", value=",".join(flags_to_exclude)),
             HTMLBlock("<div id='routing-rules-flags-details'></div>"),
+            Label(id="condition-label", text="Apply the routing rule to:"),
+            RadioButtons(
+                title="",
+                name="routing_rules_flags_condition",
+                options=[
+                    Option(key="contain_selected_flags", value="Cases that contain selected flags"),
+                    Option(key="doesnot_contain_selected_flags", value="Cases that do not contain selected flags"),
+                ],
+            ),
             Filter(),
             Checkboxes(
                 name="flags[]",
@@ -150,19 +159,10 @@ def select_flags(request, team_id, flags_to_include, flags_to_exclude):
                 ],
                 import_custom_js=["/javascripts/filter-checkbox-list-flags.js"],
             ),
-            Label(text="Apply routing rules to cases that"),
-            RadioButtons(
-                title="",
-                name="routing_rules_flags_condition",
-                options=[
-                    Option(key="contain_selected_flags", value="Contain selected flags"),
-                    Option(key="doesnot_contain_selected_flags", value="Do not contain selected flags"),
-                ],
-            ),
         ],
         buttons=[
             Button("Save and continue", "submit", id="save_and_continue"),
-            Button("Add another condition", "", ButtonStyle.SECONDARY, link="#"),
+            Button("Add another condition", "", ButtonStyle.SECONDARY, id="add-another-condition", link="#"),
         ],
         javascript_imports={"/javascripts/routing-rules-flags.js"},
     )
@@ -194,7 +194,8 @@ def routing_rule_form_group(
             initial_routing_rule_questions(request, select_team, team_id, is_editing),
             conditional("case_types" in additional_rules, select_case_type(request)),
             conditional(
-                "flags" in additional_rules, select_flags(request, team_id, flags_to_include, flags_to_exclude)
+                "flags" in additional_rules,
+                select_flags(request, team_id, flags_to_include, flags_to_exclude, is_editing),
             ),
             conditional("country" in additional_rules, select_country(request)),
             conditional("users" in additional_rules, select_team_member(request, team_id)),

--- a/core/assets/javascripts/filter-checkbox-list-flags.js
+++ b/core/assets/javascripts/filter-checkbox-list-flags.js
@@ -1,4 +1,6 @@
-$(".lite-search__container").show();
+if (!$(".lite-search__container").is(":hidden")) {
+    $(".lite-search__container").show();
+}
 
 $("#filter-box").on('input', function () {
     var value = $(this).val().toLowerCase();
@@ -37,9 +39,9 @@ function addCheckedCheckboxesToList() {
     });
     $("#checkbox-list").append("<ol class='govuk-list govuk-!-padding-left-4' style='list-style:decimal'>" + formattedText + "</ol>")
     if ($("input[type='checkbox']:checked").length == 0) {
-        $("#checkbox-counter").hide();
+        $("#checkbox-counter").hide().children().hide();
     } else {
-        $("#checkbox-counter").show();
+        $("#checkbox-counter").show().children().show();
     }
 
     $("a").on('click', function (event) {

--- a/core/assets/javascripts/routing-rules-flags.js
+++ b/core/assets/javascripts/routing-rules-flags.js
@@ -1,108 +1,378 @@
 (function () {
     var flagsConditions = [];
+    var editing = false;
+    var flagGroups = { "flags_to_include": [], "flags_to_exclude": [] };
 
     function renderTable(conditions) {
-        if (conditions && conditions.length === 0) {
+        if (conditions && conditions.flags_to_include.length === 0 && conditions.flags_to_exclude.length === 0) {
             $("#routing-rules-flags-details").hide();
             return;
         }
+        edit_column_header = editing ? '<th class="govuk-table__header" scope="col"></th>' : ""
         var header = `
             <thead class="govuk-table__head">
             <tr class="govuk-table__row">
                 <th class="govuk-table__header" scope="col">Condition</th>
                 <th class="govuk-table__header" scope="col">Flags</th>
+                ${edit_column_header}
                 <th class="govuk-table__header" scope="col"></th>
             </tr>
         </thead>`
 
-        var rows = conditions.map(function (row, index) {
-            var condition_text = row.condition === "contain_selected_flags" ? "Cases including" : "Cases excluding";
-            var flags = row.flags.map(function (flag) { return flag.name; });
-            return `
+        var rows = [];
+        if (conditions.flags_to_include.length) {
+            var flags = conditions.flags_to_include.map(function (flag, index) {
+                return flag.name;
+            });
+            var edit_column_data = editing ? '<td class="govuk-table__cell govuk-table__cell"><a id="edit-inclusive-flags" class="condition-edit" href="#" style="color:#1D70B8">Edit</a></td>' : ""
+
+            rows.push(`
                 <tr class="govuk-table__row">
-                    <td class="govuk-table__cell govuk-table__cell">${condition_text}</td>
+                    <td class="govuk-table__cell govuk-table__cell">Applies to cases that contain selected flags</td>
                     <td class="govuk-table__cell govuk-table__cell">${flags.join(", ")}</td>
+                    ${edit_column_data}
                     <td class="govuk-table__cell govuk-table__cell">
-                        <a class="condition-remove" href="#">Remove</a>
+                        <a id="remove-inclusive-flags" class="condition-remove" href="#" style="color:#1D70B8">Remove</a>
                     </td>
                 </tr>
-            `;
-        });
+            `);
+        } else {
+            var edit_column_data = editing ? '<td class="govuk-table__cell govuk-table__cell"><a id="edit-inclusive-flags" class="condition-edit" href="#" style="color:#1D70B8">Add</a></td>' : ""
+            rows.push(`
+                <tr class="govuk-table__row">
+                    <td class="govuk-table__cell govuk-table__cell">Applies to cases that contain selected flags</td>
+                    <td class="govuk-table__cell govuk-table__cell">None</td>
+                    ${edit_column_data}
+                    <td class="govuk-table__cell govuk-table__cell">
+                        <a id="remove-inclusive-flags" class="condition-remove-none" href="#"></a>
+                    </td>
+                </tr>
+            `);
+        }
+
+        if (conditions.flags_to_exclude.length) {
+            var flags = conditions.flags_to_exclude.map(function (flag, index) {
+                return flag.name;
+            });
+
+            var edit_column_data = editing ? '<td class="govuk-table__cell govuk-table__cell"><a id="edit-exclusive-flags" class="condition-edit" href="#" style="color:#1D70B8">Edit</a></td>' : ""
+            rows.push(`
+                <tr class="govuk-table__row">
+                    <td class="govuk-table__cell govuk-table__cell">Applies to cases that do not contain selected flags</td>
+                    <td class="govuk-table__cell govuk-table__cell">${flags.join(", ")}</td>
+                    ${edit_column_data}
+                    <td class="govuk-table__cell govuk-table__cell">
+                        <a id="remove-exclusive-flags" class="condition-remove" href="#" style="color:#1D70B8">Remove</a>
+                    </td>
+                </tr>
+            `);
+        } else {
+            var edit_column_data = editing ? '<td class="govuk-table__cell govuk-table__cell"><a id="edit-exclusive-flags" class="condition-edit" href="#" style="color:#1D70B8">Add</a></td>' : ""
+            rows.push(`
+                <tr class="govuk-table__row">
+                    <td class="govuk-table__cell govuk-table__cell">Appies to cases that do not contain selected flags</td>
+                    <td class="govuk-table__cell govuk-table__cell">None</td>
+                    ${edit_column_data}
+                    <td class="govuk-table__cell govuk-table__cell">
+                        <a id="remove-exclusive-flags" class="condition-remove-none" href="#"></a>
+                    </td>
+                </tr>
+            `);
+        }
 
         var table = `
         <table class="govuk-table" id="results-table">
             ${header}
-            <tbody class="govuk-table__body">${rows}</tbody>
+            <tbody class="govuk-table__body">${rows.join('')}</tbody>
         </table>
         `;
 
         $("#routing-rules-flags-details").html(table);
         $("#routing-rules-flags-details").show();
 
+        editLinks = document.getElementsByClassName("condition-edit");
         removeLinks = document.getElementsByClassName("condition-remove");
+        for (var i = 0; i < editLinks.length; i++) {
+            editLinks[i].index = i;
+            editLinks[i].addEventListener("click", editFlags, false);
+        }
         for (var i = 0; i < removeLinks.length; i++) {
             removeLinks[i].index = i;
             removeLinks[i].addEventListener("click", removeFlags, false);
         }
     }
 
+    function resetControls(editing) {
+        $("#condition-label").text("Apply the routing rule to:").show();
+        $(".govuk-radios").show();
+        $(".lite-search__container").show();
+        $(".govuk-checkboxes").show();
+        $("#routing_rules_flags_condition-contain_selected_flags").prop("checked", false);
+        $("#routing_rules_flags_condition-contain_selected_flags").prop("disabled", false);
+        $("#routing_rules_flags_condition-doesnot_contain_selected_flags").prop("checked", false);
+        $("#routing_rules_flags_condition-doesnot_contain_selected_flags").prop("disabled", false);
+        $('a:contains("Add another condition")').show().text("Add another condition");
+        $('a:contains("Save changes")').show().text("Save changes");
+    }
+
     function updateFlagInputFields(conditions) {
-        var includingIds = getFlagIds("contain_selected_flags", conditions)
-        var excludingIds = getFlagIds("doesnot_contain_selected_flags", conditions)
+        var includingIds = conditions.flags_to_include.map(function (flag) { return flag.id });
+        var excludingIds = conditions.flags_to_exclude.map(function (flag) { return flag.id });
 
         $('input[name="flags_to_include"]').val(String(includingIds.join(",")));
         $('input[name="flags_to_exclude"]').val(String(excludingIds.join(",")));
     }
 
+    function editFlags(event) {
+        event.preventDefault();
+
+        $("#condition-label").show();
+        $(".govuk-radios").show();
+        $(".govuk-checkboxes").show();
+        $(".lite-search__container").show();
+        if (event.target.id === "edit-inclusive-flags") {
+            $("#condition-label").text("The routing rule will be applied to cases that contain your selected flags");
+            $("#routing_rules_flags_condition-contain_selected_flags").prop("checked", true);
+            $("#routing_rules_flags_condition-contain_selected_flags").prop("disabled", false);
+            $("#routing_rules_flags_condition-doesnot_contain_selected_flags").prop("checked", false);
+            $("#routing_rules_flags_condition-doesnot_contain_selected_flags").prop("disabled", true);
+
+            setFlagsDisabledStatus(flagGroups.flags_to_exclude, true);
+            setFlagsCheckedStatus(flagGroups.flags_to_include, true);
+            if (flagGroups.flags_to_include.length) {
+                showSideMenu();
+            } else {
+                hidesidemenu();
+            }
+        } else if (event.target.id === "edit-exclusive-flags") {
+            $("#condition-label").text("The routing rule will be applied to cases that do not contain your selected flags");
+            $("#routing_rules_flags_condition-doesnot_contain_selected_flags").prop("checked", true);
+            $("#routing_rules_flags_condition-doesnot_contain_selected_flags").prop("disabled", false);
+            $("#routing_rules_flags_condition-contain_selected_flags").prop("checked", false);
+            $("#routing_rules_flags_condition-contain_selected_flags").prop("disabled", true);
+
+            setFlagsDisabledStatus(flagGroups.flags_to_include, true);
+            setFlagsCheckedStatus(flagGroups.flags_to_exclude, true);
+            if (flagGroups.flags_to_exclude.length) {
+                showSideMenu();
+            } else {
+                hidesidemenu();
+            }
+        }
+
+        $(".govuk-radios").hide();
+        $('a:contains("Add another condition")').show();
+        $('a:contains("Add another condition")').text("Save changes");
+        $('a:contains("Save changes")').show();
+        $("#button-save_and_continue").hide();
+    }
+
     function removeFlags(event) {
         event.preventDefault();
-        flagsConditions.splice(event.currentTarget.index, 1);
+        var condition = getSelectedCondition();
+        if (event.target.id === "remove-inclusive-flags") {
+            if (condition === "contain_selected_flags") {
+                setFlagsCheckedStatus(flagGroups.flags_to_include, false);
+                hidesidemenu();
+            } else if (condition === "doesnot_contain_selected_flags") {
+                setFlagsCheckedStatus(flagGroups.flags_to_exclude, true);
+                setFlagsDisabledStatus(flagGroups.flags_to_include, false);
+            }
+            flagGroups.flags_to_include = [];
+        } else if (event.target.id === "remove-exclusive-flags") {
+            if (condition === "doesnot_contain_selected_flags") {
+                setFlagsCheckedStatus(flagGroups.flags_to_include, false);
+                setFlagsDisabledStatus(flagGroups.flags_to_include, true);
+                hidesidemenu();
+            } else if (condition === "contain_selected_flags") {
+                setFlagsDisabledStatus(flagGroups.flags_to_exclude, false);
+            }
+            flagGroups.flags_to_exclude = [];
+        }
+        updateFlagInputFields(flagGroups);
+        renderTable(flagGroups);
 
-        updateFlagInputFields(flagsConditions);
-        renderTable(flagsConditions);
+        if (flagGroups.flags_to_include.length === 0 && flagGroups.flags_to_exclude.length === 0) {
+            resetControls(editing);
+        }
     }
 
-    function getFlagIds(condition, flags) {
-        var filtered = flags.filter(function (flag) { return flag.condition === condition; })
-        var allIds = filtered.map(function (item) { return item.ids; })
-        return allIds;
+    function showSideMenu() {
+        $("#checkbox-counter").show().children().show();
     }
 
-    function addConditionWithSelectedFlags() {
-        // get all the selected flags
+    function hidesidemenu() {
+        $("#checkbox-counter").hide().children().hide();
+    }
+
+    function setFlagsCheckedStatus(flags, status) {
+        $("input[type='checkbox']").prop("checked", false);
+        var allFlags = $("input[type='checkbox']").map(function () {
+            return this;
+        }).toArray();
+
+
+        flags.forEach(function (item, index) {
+            allFlags.forEach(function (flag, i) {
+                if (flag.value === item.id) {
+                    $(flag).prop("checked", status).trigger("change");
+                }
+            });
+        });
+    }
+
+    function setFlagsDisabledStatus(flags, status) {
+        $("input[type='checkbox']").prop("disabled", false);
+        var allFlags = $("input[type='checkbox']").map(function () {
+            return this;
+        }).toArray();
+
+
+        flags.forEach(function (item, index) {
+            allFlags.forEach(function (flag, i) {
+                if (flag.value === item.id) {
+                    $(flag).prop("disabled", status);
+                }
+            });
+        });
+    }
+
+    function addFlagsToCondition(options) {
+        var { condition, selectedFlags, append } = options;
+
+        if (condition) {
+            if (condition === "contain_selected_flags") {
+                if (append) {
+                    // add the flag only if it is not included already
+                    var currentFlagIds = flagGroups.flags_to_include.map(flag => flag.id);
+                    for (var i = 0; i < selectedFlags.length; i++) {
+                        if (!currentFlagIds.includes(selectedFlags[i].id)) {
+                            flagGroups.flags_to_include.push(selectedFlags[i]);
+                        }
+                    }
+                } else {
+                    flagGroups.flags_to_include = selectedFlags
+                }
+            }
+            if (condition === "doesnot_contain_selected_flags") {
+                if (append) {
+                    // add the flag only if it is not included already
+                    var currentFlagIds = flagGroups.flags_to_exclude.map(flag => flag.id);
+                    for (var i = 0; i < selectedFlags.length; i++) {
+                        if (!currentFlagIds.includes(selectedFlags[i].id)) {
+                            flagGroups.flags_to_exclude.push(selectedFlags[i]);
+                        }
+                    }
+                } else {
+                    flagGroups.flags_to_exclude = selectedFlags
+                }
+            }
+        }
+
+        updateFlagInputFields(flagGroups);
+        renderTable(flagGroups);
+    }
+
+    function getSelectedFlags() {
         var selectedFlags = $("input[type='checkbox']:checked").map(function () {
             var text = $(this).parent().find(".govuk-checkboxes__label").text();
             return { id: this.value, name: text };
         }).toArray();
 
-        var condition = $('input[name="routing_rules_flags_condition"]:checked').val();
-        if (condition) {
-            var flag_ids = selectedFlags.map(function (flag) { return flag.id; });
-            flagsConditions.push({ condition: condition, flags: selectedFlags, ids: flag_ids.join(",") });
-        }
-        updateFlagInputFields(flagsConditions);
+        return selectedFlags;
+    }
 
-        if (selectedFlags.length) {
-            renderTable(flagsConditions);
+    function getSelectedCondition() {
+        if ($('#routing_rules_flags_condition-contain_selected_flags').is(':checked')) {
+            return "contain_selected_flags"
+        } else if ($('#routing_rules_flags_condition-doesnot_contain_selected_flags').is(':checked')) {
+            return "doesnot_contain_selected_flags"
+        } else {
+            return "none"
         }
     }
 
-    $('.lite-buttons-row').on('click', '#button-save_and_continue', function(){
-        addConditionWithSelectedFlags()
+    $("#routing_rules_flags_condition-contain_selected_flags").change(function () {
+        setFlagsDisabledStatus(flagGroups.flags_to_exclude, true);
+        setFlagsCheckedStatus(flagGroups.flags_to_include, true);
+    });
+
+    $("#routing_rules_flags_condition-doesnot_contain_selected_flags").change(function () {
+        setFlagsDisabledStatus(flagGroups.flags_to_include, true);
+        setFlagsCheckedStatus(flagGroups.flags_to_exclude, true);
+    });
+
+    $('.lite-buttons-row').on('click', '#button-save_and_continue', function () {
+        var condition = getSelectedCondition();
+        var selectedFlags = getSelectedFlags();
+        addFlagsToCondition({ "condition": condition, "selectedFlags": selectedFlags, "append": !editing });
     });
 
     $('a:contains("Add another condition")').click(function () {
-        addConditionWithSelectedFlags()
+        var condition = getSelectedCondition();
+        var selectedFlags = getSelectedFlags();
+
+        addFlagsToCondition({ "condition": condition, "selectedFlags": selectedFlags, "append": !editing });
+
+        if (editing) {
+            $("#condition-label").hide();
+            $(".govuk-radios").hide();
+            $(".govuk-checkboxes").hide();
+            $(".lite-search__container").hide();
+            $('a:contains("Save changes")').hide();
+            $('a:contains("Add another condition")').hide();
+            $("#button-save_and_continue").show();
+            hidesidemenu();
+        }
+
+        if (!editing) {
+            if (condition === "contain_selected_flags") {
+                setFlagsCheckedStatus(flagGroups.flags_to_include, true);
+            } else if (condition === "doesnot_contain_selected_flags") {
+                setFlagsCheckedStatus(flagGroups.flags_to_exclude, true);
+            }
+        }
+
+        // Clear the error if there is any.
+        // It gets cleared automatically if either condition is selected and "Save and continue"
+        // but if we are only saving changes the error is persistent in the UI so clear it here
+        // till we are ready to submit
+        if ($(".govuk-error-summary")[0] || $(".govuk-error-message")[0]) {
+            var condition = getSelectedCondition();
+            if (condition !== "none" && (flagGroups.flags_to_include.length || flagGroups.flags_to_exclude.length)) {
+                $(".govuk-error-summary").hide().children().hide();
+                $(".govuk-error-message").hide();
+                $("#pane_routing_rules_flags_condition").removeClass("govuk-form-group--error");
+            }
+        }
     });
 
-    // pre-populate selected flags in case of editing the rule
-    function prePopulateFlags() {
+    $('a:contains("Save changes")').click(function () {
+        var condition = getSelectedCondition();
+        var selectedFlags = getSelectedFlags();
+        addFlagsToCondition({ "condition": condition, "selectedFlags": selectedFlags, "append": false });
+
+        if (editing) {
+            $("#condition-label").hide();
+            $(".govuk-radios").hide();
+            $(".govuk-checkboxes").hide();
+            $(".lite-search__container").hide();
+            $('a:contains("Save changes")').hide();
+        }
+    });
+
+    function setInitialState(editing) {
+        flags_to_include = $('input[name="flags_to_include"]').val().split(",").filter(function (el) { return el; });
+        flags_to_exclude = $('input[name="flags_to_exclude"]').val().split(",").filter(function (el) { return el; });
+
+        if (flags_to_include.length === 0 && flags_to_exclude.length === 0) {
+            resetControls(editing);
+            return;
+        }
+
         var allFlags = $("input[type='checkbox']").map(function () {
             return this;
         }).toArray();
-
-        flags_to_include = $('input[name="flags_to_include"]').val().split(",");
-        flags_to_exclude = $('input[name="flags_to_exclude"]').val().split(",");
 
         include_flags = [];
         exclude_flags = [];
@@ -115,7 +385,7 @@
             });
         });
         if (include_flags.length) {
-            flagsConditions.push({ condition: "contain_selected_flags", flags: include_flags, ids: flags_to_include.join(",") })
+            flagGroups.flags_to_include.push(...include_flags);
         }
 
         flags_to_exclude.forEach(function (item, index) {
@@ -127,11 +397,33 @@
             });
         });
         if (exclude_flags.length) {
-            flagsConditions.push({ condition: "doesnot_contain_selected_flags", flags: exclude_flags, ids: flags_to_exclude.join(",") })
+            flagGroups.flags_to_exclude.push(...exclude_flags);
         }
 
-        renderTable(flagsConditions);
+        if (editing) {
+            $("#condition-label").hide();
+            $(".govuk-radios").hide();
+            $(".govuk-checkboxes").hide();
+            $(".lite-search__container").hide();
+            $('a:contains("Add another condition")').hide();
+        } else {
+            var condition = getSelectedCondition();
+
+            $("#condition-label").text("Apply the routing rule to:").show();
+            if (condition === "contain_selected_flags") {
+                setFlagsCheckedStatus(flagGroups.flags_to_include, true);
+                setFlagsDisabledStatus(flagGroups.flags_to_exclude, true);
+            } else if (condition === "doesnot_contain_selected_flags") {
+                setFlagsCheckedStatus(flagGroups.flags_to_exclude, true);
+                setFlagsDisabledStatus(flagGroups.flags_to_include, true);
+            }
+        }
+
+        renderTable(flagGroups);
+
     }
 
-    prePopulateFlags();
+    editing = $(".govuk-fieldset__heading").text().trim() == "Edit flags";
+
+    setInitialState(editing);
 })();


### PR DESCRIPTION
## Change description

Design changes for the way flags are added and edited in routing rules
    
A routing rule can be applied if the case contain certain flags and does not contain some other flags. The UI allows setting up these two conditions and had to make sure a flag is included in either of the condition but not both. This change updates the design and fixes some of the inconsistencies in previous implementation.

All of the changes are in javascript mostly to show/hide controls, enable/disable and check/uncheck flags.
