### PR TITLE
Re-enable adding of non firearm products

### DIFF
--- a/conf/exporter.py
+++ b/conf/exporter.py
@@ -71,3 +71,4 @@ SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
 SPIRE_URL = "https://www.spire.trade.gov.uk/spire/fox/espire/LOGIN/login"
 
 FEATURE_FLAG_FIREARMS_ENABLED = env.bool("FEATURE_FLAG_FIREARMS_ENABLED", False)
+FEATURE_FLAG_ONLY_ALLOW_FIREARMS_PRODUCTS = env.bool("FEATURE_FLAG_ONLY_ALLOW_FIREARMS_PRODUCTS", False)

--- a/exporter/goods/forms.py
+++ b/exporter/goods/forms.py
@@ -349,7 +349,12 @@ def add_good_form_group(
     control_list_entries = get_control_list_entries(request, convert_to_options=True)
     return FormGroup(
         [
-            group_two_product_type_form(back_link=base_form_back_link),
+            conditional(not settings.FEATURE_FLAG_ONLY_ALLOW_FIREARMS_PRODUCTS, product_category_form(request)),
+            conditional(
+                request.POST.get("item_category") == PRODUCT_CATEGORY_FIREARM
+                or settings.FEATURE_FLAG_ONLY_ALLOW_FIREARMS_PRODUCTS,
+                group_two_product_type_form(back_link=base_form_back_link),
+            ),
             conditional(is_firearms_core and draft_pk, identification_markings_form()),
             conditional(is_firearms_core, firearms_sporting_shotgun_form(request.POST.get("type"))),
             add_goods_questions(control_list_entries, draft_pk),

--- a/exporter/goods/services.py
+++ b/exporter/goods/services.py
@@ -23,7 +23,7 @@ def get_good_details(request, pk):
 
 
 def post_goods(request, json):
-    json["item_category"] = "group2_firearms"
+    json["item_category"] = json.get("item_category", "group2_firearms")
 
     if "is_pv_graded" in json and json["is_pv_graded"] == "yes":
         if "reference" in json:

--- a/unit_tests/exporter/goods/test_forms.py
+++ b/unit_tests/exporter/goods/test_forms.py
@@ -1,5 +1,6 @@
 import pytest
 import requests
+from django.test import override_settings
 
 from lite_forms.components import HelpSection
 
@@ -147,6 +148,7 @@ def pv_gradings(mock_pv_gradings, rf, client):
         ),
     ],
 )
+@override_settings(FEATURE_FLAG_ONLY_ALLOW_FIREARMS_PRODUCTS=True)
 def test_core_firearm_product_form_group(rf, client, params, num_forms, question_checks):
     """ Test to ensure correct set of questions are asked in adding a firearm product journey depending on the firearm_type."""
     data = {"product_type_step": True, "type": "firearms"}


### PR DESCRIPTION
This commit puts the recent limiting of adding products behind a feature flag
called FEATURE_FLAG_ONLY_ALLOW_FIREARMS_PRODUCTS. If this flag is not set then
all types of products can be added, however many of those scenarios are broken.

Enabling those broken flows allows up to identify where those things are broken
and raise bugs to fix them.