### PR TITLE
Fix End user status correctly as in progress

### DIFF
--- a/core/builtins/custom_tags.py
+++ b/core/builtins/custom_tags.py
@@ -825,6 +825,9 @@ def get_parties_status_optional_documents(parties):
         for party in parties:
             if not party:
                 return NOT_STARTED
+    else:
+        if not parties["document"]:
+            return IN_PROGRESS
 
     return DONE
 


### PR DESCRIPTION
## Change Description

When a draft application is copied and End user has not uploaded document
then the status should be "In progress".

Currently we are only checking if the party is valid and marking as saved even though
there is no End user document uploaded. This should be marked as "In progress" if
no document is available.