### PR TITLE
[LTD-751] Add middleware to validate `return_to` links

### DIFF
--- a/conf/base.py
+++ b/conf/base.py
@@ -60,7 +60,7 @@ MIDDLEWARE = [
     "core.auth.middleware.AuthbrokerClientMiddleware",
     "core.middleware.UploadFailedMiddleware",
     "core.middleware.RequestsSessionMiddleware",
-    "core.middleware.NoCacheMiddlware",
+    "core.middleware.NoCacheMiddleware",
 ]
 
 FEATURE_CSP_MIDDLEWARE_ENABLED = env.bool("FEATURE_CSP_MIDDLEWARE_ENABLED", True)

--- a/conf/base.py
+++ b/conf/base.py
@@ -61,6 +61,7 @@ MIDDLEWARE = [
     "core.middleware.UploadFailedMiddleware",
     "core.middleware.RequestsSessionMiddleware",
     "core.middleware.NoCacheMiddleware",
+    "core.middleware.ValidateReturnToMiddleware",
 ]
 
 FEATURE_CSP_MIDDLEWARE_ENABLED = env.bool("FEATURE_CSP_MIDDLEWARE_ENABLED", True)

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -63,7 +63,7 @@ class RequestsSessionMiddleware:
         return self.get_response(request)
 
 
-class NoCacheMiddlware:
+class NoCacheMiddleware:
     """Tell the browser to not cache the pages, because otherwise information that should be kept private can be
     viewed by anyone with access to the files in the browser's cache directory.
 

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -2,11 +2,14 @@ import time
 
 import requests
 from s3chunkuploader.file_handler import UploadFailed
+from urllib.parse import urlparse
 
 from django.conf import settings
 from django.contrib.auth import logout
 from django.shortcuts import redirect
 from django.utils.cache import add_never_cache_headers
+from rest_framework.response import Response
+from rest_framework import status
 
 from lite_content.lite_internal_frontend.strings import cases
 from lite_forms.generators import error_page
@@ -75,4 +78,26 @@ class NoCacheMiddleware:
     def __call__(self, request):
         response = self.get_response(request)
         add_never_cache_headers(response)
+        return response
+
+
+class ValidateReturnToMiddleware:
+    """We are using return_to parameter to override the backlink in the
+    application journey. We need to validate if the return_to parameter is
+    (1) a valid URL and (2) a relative URL.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        return_to = request.GET.get("return_to", None)
+        if return_to is not None:
+            try:
+                url = urlparse(return_to)
+            except ValueError as e:
+                return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+            if url.netloc != "" or url.scheme != "" or return_to.startswith("//"):
+                return Response({"error": "Invalid return_to parameter"}, status=status.HTTP_400_BAD_REQUEST)
+        response = self.get_response(request)
         return response

--- a/exporter/applications/forms/locations.py
+++ b/exporter/applications/forms/locations.py
@@ -74,7 +74,7 @@ def add_external_location(request):
             )
         ],
         default_button_name=strings.CONTINUE,
-        back_link=BackLink(url=request.GET.get("return_to_link")),
+        back_link=BackLink(url=request.GET.get("return_to")),
     )
 
 
@@ -106,7 +106,7 @@ def location_type_form(request, application_type=None):
             ),
         ],
         default_button_name=LocationTypeForm.CONTINUE,
-        back_link=BackLink(url=request.GET.get("return_to_link")),
+        back_link=BackLink(url=request.GET.get("return_to")),
     )
 
 

--- a/exporter/applications/views/locations.py
+++ b/exporter/applications/views/locations.py
@@ -88,7 +88,7 @@ class EditGoodsLocation(LoginRequiredMixin, SingleFormView):
         if choice == Locations.EXTERNAL:
             return (
                 reverse_lazy("applications:select_add_external_location", kwargs={"pk": self.object_pk})
-                + "?return_to_link="
+                + "?return_to="
                 + self.request.get_full_path()
             )
         elif choice == Locations.ORGANISATION:
@@ -108,7 +108,7 @@ class SelectAddExternalLocation(LoginRequiredMixin, SingleFormView):
         if choice == "new":
             return (
                 reverse_lazy("applications:add_external_location", kwargs={"pk": self.object_pk})
-                + "?return_to_link="
+                + "?return_to="
                 + self.request.get_full_path()
             )
         else:

--- a/exporter/templates/applications/goods-locations/goods-locations.html
+++ b/exporter/templates/applications/goods-locations/goods-locations.html
@@ -51,7 +51,7 @@
 				<a href="{% url 'applications:add_preexisting_external_location' application.id %}" class="govuk-button">
 					{% lcs 'Goods.LocationLists.FIND_ADDRESS_BUTTON' %}
 				</a>
-				<a href="{% url 'applications:add_external_location' application.id %}?return_to_link={{ CURRENT_PATH }}" class="govuk-button">
+				<a href="{% url 'applications:add_external_location' application.id %}?return_to={{ CURRENT_PATH }}" class="govuk-button">
 					{% lcs 'Goods.LocationLists.ADD_ADDRESS_BUTTON' %}
 				</a>
 			{% endif %}

--- a/unit_tests/core/test_middleware.py
+++ b/unit_tests/core/test_middleware.py
@@ -7,9 +7,7 @@ from core import middleware
 
 def test_no_cache_middleware(rf):
     request = rf.get("/")
-    get_response = mock.Mock(return_value=HttpResponse(""))
-    instance = middleware.NoCacheMiddlware(get_response)
-
+    instance = middleware.NoCacheMiddleware(get_response)
     response = instance(request)
 
     assert response["Cache-Control"] == "max-age=0, no-cache, no-store, must-revalidate"

--- a/unit_tests/core/test_middleware.py
+++ b/unit_tests/core/test_middleware.py
@@ -1,13 +1,39 @@
 from unittest import mock
 
-from django.http import HttpResponse
+import pytest
+from rest_framework import status
+from rest_framework.response import Response
 
 from core import middleware
 
 
 def test_no_cache_middleware(rf):
     request = rf.get("/")
+    get_response = mock.Mock(return_value=Response())
     instance = middleware.NoCacheMiddleware(get_response)
     response = instance(request)
-
     assert response["Cache-Control"] == "max-age=0, no-cache, no-store, must-revalidate"
+
+
+@pytest.mark.parametrize(
+    "url,response_code",
+    [
+        ("?return_to=hello", status.HTTP_200_OK),
+        ("?return_to=hello/", status.HTTP_200_OK),
+        ("?return_to=/hello", status.HTTP_200_OK),
+        ("?return_to=/hello/", status.HTTP_200_OK),
+        ("?return_to=http://example.com", status.HTTP_400_BAD_REQUEST),
+        ("?return_to=http://example.com/", status.HTTP_400_BAD_REQUEST),
+        ("?return_to=https://example.com/", status.HTTP_400_BAD_REQUEST),
+        ('?return_to=javascript:alert("hello!")', status.HTTP_400_BAD_REQUEST),
+        # Protocol-relative URL
+        ("?return_to=////example.com", status.HTTP_400_BAD_REQUEST),
+        ("?return_to=///example.com", status.HTTP_400_BAD_REQUEST),
+        ("?return_to=//example.com", status.HTTP_400_BAD_REQUEST),
+    ],
+)
+def test_validate_return_to_middleware(rf, url, response_code):
+    request = rf.get(url)
+    get_response = mock.Mock(return_value=Response())
+    response = middleware.ValidateReturnToMiddleware(get_response)(request)
+    assert response.status_code == response_code


### PR DESCRIPTION
The `return_to` parameter is used to set back-links in the application journey.

This adds a middleware to the application that validates if the `return_to` parameter is:

1. A valid URL
2. A relative URL

Would recommend reviewing commit-wise.