### PR TITLE
Make autocomplete widget support reusing existing values

### DIFF
--- a/caseworker/organisations/views.py
+++ b/caseworker/organisations/views.py
@@ -203,14 +203,14 @@ class EditOrganisationAddress(LoginRequiredMixin, SingleFormView):
         data = flatten_data(self.data)
         return {
             **flatten_data(self.data),
-            "country": self.organisation["primary_site"]["address"]["country"]["id"]
+            "primary_site.address.country": self.organisation["primary_site"]["address"]["country"]["id"]
         }
 
     def get_form(self):
         print(self.data)
         is_commercial = self.organisation["type"]["key"] == "commercial"
         in_uk = self.organisation["primary_site"]["address"]["country"]["id"] == "GB"
-        countries = get_countries(self.request, True, ["GB"])
+        countries = get_countries(self.request, True, [])
 
         user_permissions = get_user_permissions(self.request)
         can_edit_address = Permission.MANAGE_ORGANISATIONS.value in user_permissions

--- a/lite_forms/templates/components/autocomplete.html
+++ b/lite_forms/templates/components/autocomplete.html
@@ -12,9 +12,8 @@
 		$(document).ready(function() {
 	{% endif %}
 			var selectElement = document.querySelector('#{{ component.name|prefix_dots }}');
-
 			accessibleAutocomplete.enhanceSelectElement({
-				defaultValue: '{{ component.initial }}',
+				defaultValue: selectElement.value || '{{ component.initial }}',
 				displayMenu: 'overlay',
 				selectElement: selectElement,
 				cssNamespace: 'lite-autocomplete',


### PR DESCRIPTION
This is a example commit to show how to make autocomplete widget support using
the initial value from the form's data