### PR TITLE
[LTD-775] Session Termination

### DIFF
--- a/conf/base.py
+++ b/conf/base.py
@@ -64,6 +64,9 @@ MIDDLEWARE = [
     "core.middleware.ValidateReturnToMiddleware",
 ]
 
+if not DEBUG:
+    MIDDLEWARE += ["core.middleware.AuthBrokerTokenIntrospectionMiddleware"]
+
 FEATURE_CSP_MIDDLEWARE_ENABLED = env.bool("FEATURE_CSP_MIDDLEWARE_ENABLED", True)
 
 if FEATURE_CSP_MIDDLEWARE_ENABLED:
@@ -255,3 +258,5 @@ if FEATURE_DEBUG_TOOLBAR_ON:
 
     index = MIDDLEWARE.index("django.middleware.gzip.GZipMiddleware")
     MIDDLEWARE.insert(index + 1, "debug_toolbar.middleware.DebugToolbarMiddleware")
+
+AUTHBROKER_TOKEN_INTROSPECTION_TTL = env.int("AUTHBROKER_TOKEN_INTROSPECTION_TTL", default=60 * 5)

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -1,4 +1,5 @@
 import time
+import logging
 
 import requests
 from s3chunkuploader.file_handler import UploadFailed
@@ -6,16 +7,20 @@ from urllib.parse import urlparse
 
 from django.conf import settings
 from django.contrib.auth import logout
+from django.core.cache import cache
 from django.shortcuts import redirect
 from django.utils.cache import add_never_cache_headers
+from oauthlib.oauth2 import OAuth2Error
 from rest_framework.response import Response
 from rest_framework import status
+from requests.exceptions import RequestException
 
 from lite_content.lite_internal_frontend.strings import cases
 from lite_forms.generators import error_page
 
 
 SESSION_TIMEOUT_KEY = "_session_timeout_seconds_"
+logger = logging.getLogger(__name__)
 
 
 class UploadFailedMiddleware:
@@ -101,3 +106,39 @@ class ValidateReturnToMiddleware:
                 return Response({"error": "Invalid return_to parameter"}, status=status.HTTP_400_BAD_REQUEST)
         response = self.get_response(request)
         return response
+
+
+class AuthBrokerTokenIntrospectionMiddleware:
+    """Introspect tokens to ensure that a user cannot continue to access LITE
+    if their account is deleted from the sso service.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def introspect(self, request):
+        client = request.authbroker_client
+        token = client.token.get("access_token", "")
+        cache_key = f"sso_introspection:{token}"
+        cache_value = cache.get(cache_key)
+        if cache_value is not None:
+            return
+        logger.info("Introspecting with SSO: %s", request.session.get("lite_api_user_id"))
+        response = client.get(settings.AUTHBROKER_PROFILE_URL)
+        response.raise_for_status()
+        ttl = settings.AUTHBROKER_TOKEN_INTROSPECTION_TTL
+        cache.set(cache_key, True, timeout=ttl)
+
+    def __call__(self, request):
+        # It is important to NOT run this middleware
+        # when a user has not been authenticated.
+        if not request.authbroker_client.authorized:
+            return self.get_response(request)
+        try:
+            self.introspect(request)
+        except (OAuth2Error, RequestException) as e:
+            logger.error(
+                "Introspecting with SSO failed for user %s: %s", request.session.get("lite_api_user_id"), str(e),
+            )
+            return redirect(settings.LOGOUT_URL)
+        return self.get_response(request)

--- a/unit_tests/core/test_middleware.py
+++ b/unit_tests/core/test_middleware.py
@@ -1,8 +1,12 @@
 from unittest import mock
 
 import pytest
+from django.conf import settings
+from oauthlib.oauth2 import OAuth2Error, TokenExpiredError
+from rest_framework.exceptions import AuthenticationFailed
 from rest_framework import status
 from rest_framework.response import Response
+from requests.models import Response as RResponse
 
 from core import middleware
 
@@ -37,3 +41,85 @@ def test_validate_return_to_middleware(rf, url, response_code):
     get_response = mock.Mock(return_value=Response())
     response = middleware.ValidateReturnToMiddleware(get_response)(request)
     assert response.status_code == response_code
+
+
+@mock.patch("core.middleware.cache")
+def test_sso_introspection_middleware_success(mock_cache, rf):
+    # Set up mock request and response
+    request = rf.get("/")
+    request.authbroker_client = mock.Mock()
+    request.authbroker_client.token = {"access_token": "test"}
+    request.authbroker_client.get = mock.Mock()
+    request.session = {"lite_api_user_id": "test-user"}
+    get_response = mock.Mock(return_value=Response())
+    # Set up mock cache
+    mock_cache.set = mock.Mock()
+    mock_cache.get = mock.Mock(return_value=None)
+    # Instantiate and call the middleware
+    instance = middleware.AuthBrokerTokenIntrospectionMiddleware(get_response)
+    # We should get a 200 and the token should be cached
+    response = instance(request)
+    assert response.status_code == status.HTTP_200_OK
+    request.authbroker_client.get.assert_called_once_with(settings.AUTHBROKER_PROFILE_URL)
+    mock_cache.get.assert_called_once_with("sso_introspection:test")
+    mock_cache.set.assert_called_once_with("sso_introspection:test", True, timeout=300)
+    # If get returns a value, cache will not be set
+    mock_cache.set = mock.Mock()
+    mock_cache.get = mock.Mock(return_value=True)
+    response = instance(request)
+    assert response.status_code == status.HTTP_200_OK
+    mock_cache.get.assert_called_once_with("sso_introspection:test")
+    mock_cache.set.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "status_code",
+    (
+        status.HTTP_400_BAD_REQUEST,
+        status.HTTP_401_UNAUTHORIZED,
+        status.HTTP_403_FORBIDDEN,
+        status.HTTP_404_NOT_FOUND,
+        status.HTTP_405_METHOD_NOT_ALLOWED,
+        status.HTTP_406_NOT_ACCEPTABLE,
+        status.HTTP_408_REQUEST_TIMEOUT,
+    ),
+)
+@mock.patch("core.middleware.cache")
+def test_sso_introspection_middleware_request_error(mock_cache, status_code, rf):
+    # Set up mock request and response
+    request = rf.get("/")
+    request.authbroker_client = mock.Mock()
+    request.authbroker_client.token = {"access_token": "test"}
+    request.session = {"lite_api_user_id": "test-user"}
+    get_response = mock.Mock(return_value=Response())
+    # Set up mock SSO response
+    response = RResponse()
+    response.status_code = status_code
+    request.authbroker_client.get = mock.Mock(return_value=response)
+    # Mock cache
+    mock_cache.get = mock.Mock(return_value=None)
+    # Call the middleware
+    instance = middleware.AuthBrokerTokenIntrospectionMiddleware(get_response)
+    response = instance(request)
+    assert response.status_code == status.HTTP_302_FOUND
+
+
+@pytest.mark.parametrize(
+    "error", (OAuth2Error, TokenExpiredError),
+)
+@mock.patch("core.middleware.cache")
+def test_sso_introspection_middleware_oauth_error(mock_cache, error, rf):
+    # Set up mock request and response
+    request = rf.get("/")
+    request.authbroker_client = mock.Mock()
+    request.authbroker_client.token = {"access_token": "test"}
+    request.session = {"lite_api_user_id": "test-user"}
+    get_response = mock.Mock(return_value=Response())
+    # Set up mock SSO response
+    request.authbroker_client.get = mock.Mock(side_effect=error())
+    # Mock cache
+    mock_cache.get = mock.Mock(return_value=None)
+    # Call the middleware
+    instance = middleware.AuthBrokerTokenIntrospectionMiddleware(get_response)
+    response = instance(request)
+    assert response.status_code == status.HTTP_302_FOUND


### PR DESCRIPTION
During pen tests, we found that even when a user account was terminated on the SSO, the user would still be able to access LITE using browser cookies.

Other DIT services get around this by using introspection middleware. This middleware hits the introspection endpoint on the SSO service and caches the response for a small amount of time.

We are doing something very similar for LITE.

P.S. It's not introspection technically because we are not using the `/o/introspect` endpoint from the SSO service. In the case of `staff-sso`, it is because this endpoint requires a different token. For the case of `directory-sso`, I haven't been able to find an endpoint for introspection.

