### PR TITLE
LTD-801: Fix denials upload failure

### DIFF
--- a/caseworker/external_data/forms.py
+++ b/caseworker/external_data/forms.py
@@ -1,5 +1,7 @@
 from django import forms
 
+from storages.backends.s3boto3 import S3Boto3StorageFile
+
 
 class DenialUploadForm(forms.Form):
 
@@ -11,6 +13,10 @@ class DenialUploadForm(forms.Form):
 
     def clean_csv_file(self):
         value = self.cleaned_data["csv_file"]
+        if isinstance(value, S3Boto3StorageFile):
+            s3_obj = value.obj.get()["Body"]
+            return s3_obj.read().decode("utf-8")
+
         return value.read().decode("utf-8")
 
     def save(self):


### PR DESCRIPTION
## Change description

Upload currently failing with the error that "File was not opened in read mode".
We are using FILE_UPLOAD_HANDLERS which defaults to S3FileUploadHandler.
This is creating a S3Boto3StorageFile instance in write mode so when
we try to read it from this, it is complaining that it is not opened in read mode.

Fix this by reading it from the s3 object that is uploaded.
