### PR TITLE
LTD-508: Remove application specific details from Product detail page

### DIFF
--- a/exporter/applications/forms/goods.py
+++ b/exporter/applications/forms/goods.py
@@ -56,7 +56,6 @@ def good_on_application_form_group(
     # but not if the good being added to the application is a new good created as part of this same flow
     firearm_type = None
     number_of_items = None
-    is_firearm = None
 
     if good.get("firearm_details"):
         firearm_type = good["firearm_details"]["type"]["key"]

--- a/exporter/applications/services.py
+++ b/exporter/applications/services.py
@@ -155,7 +155,7 @@ def serialize_good_on_app_data(json, good=None, preexisting=False):
 
         if preexisting and good:
             if good["firearm_details"]["type"]["key"] in FIREARM_AMMUNITION_COMPONENT_TYPES:
-                post_data["quantity"] = firearm_details["number_of_items"]
+                post_data["quantity"] = firearm_details.get("number_of_items", 0)
                 post_data["unit"] = "NAR"  # number of articles
 
     return post_data

--- a/exporter/applications/views/goods.py
+++ b/exporter/applications/views/goods.py
@@ -522,12 +522,13 @@ class AddGoodToApplication(LoginRequiredMixin, RegisteredFirearmDealersMixin, Se
         is_preexisting = str_to_bool(request.GET.get("preexisting", True))
         show_attach_rfd = str_to_bool(request.POST.get("is_registered_firearm_dealer"))
         is_rfd = show_attach_rfd or has_valid_rfd_certificate(self.application)
+        firearm_product_type = self.good["firearm_details"]["type"]["key"]
         (
             is_firearm,
             is_firearm_ammunition_or_component,
             is_firearms_accessory,
             is_firearms_software_or_tech,
-        ) = get_firearms_subcategory(self.good.get("type"))
+        ) = get_firearms_subcategory(firearm_product_type)
 
         self.forms = good_on_application_form_group(
             request=request,

--- a/exporter/goods/services.py
+++ b/exporter/goods/services.py
@@ -77,8 +77,6 @@ def add_identification_marking_details(firearm_details, json):
             firearm_details["number_of_items"] = int(json.get("number_of_items"))
         except ValueError:
             firearm_details["number_of_items"] = 0
-    elif firearm_details and "number_of_items" not in firearm_details:
-        firearm_details["number_of_items"] = 0
 
     if "identification_markings_step" in json:
         # parent component doesnt get sent when empty unlike the remaining form fields

--- a/exporter/goods/views.py
+++ b/exporter/goods/views.py
@@ -206,12 +206,12 @@ class AddGood(LoginRequiredMixin, MultiFormView):
         ) = get_firearms_subcategory(copied_request.get("type"))
         self.forms = add_good_form_group(
             request,
-            is_pv_graded,
-            is_software_technology,
-            is_firearm,
-            is_firearm_ammunition_or_component,
-            is_firearms_accessory,
-            is_firearms_software_or_tech,
+            is_pv_graded=is_pv_graded,
+            is_software_technology=is_software_technology,
+            is_firearm=is_firearm,
+            is_firearm_ammunition_or_component=is_firearm_ammunition_or_component,
+            is_firearms_accessory=is_firearms_accessory,
+            is_firearms_software_or_tech=is_firearms_software_or_tech,
             base_form_back_link=reverse("goods:goods"),
         )
 

--- a/exporter/templates/goods/good.html
+++ b/exporter/templates/goods/good.html
@@ -346,24 +346,6 @@
 					{% if good.firearm_details.type.key == "firearms" %}
 						<div class="govuk-summary-list__row">
 							<dt class="govuk-summary-list__key">
-								{% lcs "goods.GoodPage.Table.FirearmDetails.YEAR_OF_MANUFACTURE" %}
-							</dt>
-							<dd class="govuk-summary-list__value">
-								{{ good.firearm_details.year_of_manufacture|default_na }}
-							</dd>
-							<dd class="govuk-summary-list__actions">
-								{% if good.status.key == 'draft' %}
-									{% if draft_pk %}
-									<a id="change-year-of-manufacture" class="govuk-link govuk-link--no-visited-state" href="{% url 'goods:year-of-manufacture-add-application' good.id draft_pk %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "goods.GoodPage.Table.FirearmDetails.YEAR_OF_MANUFACTURE" %}</span></a>
-									{% else %}
-									<a id="change-year-of-manufacture" class="govuk-link govuk-link--no-visited-state" href="{% url 'goods:year-of-manufacture' good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "goods.GoodPage.Table.FirearmDetails.YEAR_OF_MANUFACTURE" %}</span></a>
-									{% endif %}
-								{% endif %}
-							</dd>
-						</div>
-
-						<div class="govuk-summary-list__row">
-							<dt class="govuk-summary-list__key">
 								{% lcs "goods.GoodPage.Table.FirearmDetails.REPLICA_FIREARM" %}
 							</dt>
 							<dd class="govuk-summary-list__value">
@@ -462,34 +444,6 @@
 						</div>
 					{% endif %}
 
-					<div class="govuk-summary-list__row">
-						<dt class="govuk-summary-list__key">
-							{% lcs "goods.GoodPage.Table.FirearmDetails.IDENTIFICATION_MARKINGS" %}
-						</dt>
-						<dd class="govuk-summary-list__value">
-							{% if good.firearm_details.has_identification_markings is not None %}
-								{{ good.firearm_details.has_identification_markings|friendly_boolean }}
-								<span class="govuk-hint">
-									{% if good.firearm_details.has_identification_markings %}
-										{{ good.firearm_details.identification_markings_details|default_na }}
-									{% else %}
-										{{ good.firearm_details.no_identification_markings_details|default_na }}
-									{% endif %}
-								</span>
-							{% else %}
-								{{ good.firearm_details.has_identification_markings|default_na }}
-							{% endif %}
-						</dd>
-						<dd class="govuk-summary-list__actions">
-							{% if good.status.key == 'draft' %}
-								{% if draft_pk %}
-								<a id="change-identification-markings" class="govuk-link govuk-link--no-visited-state" href="{% url 'goods:identification_markings_add_application' good.id draft_pk %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "goods.GoodPage.Table.FirearmDetails.IDENTIFICATION_MARKINGS" %}</span></a>
-								{% else %}
-								<a id="change-identification-markings" class="govuk-link govuk-link--no-visited-state" href="{% url 'goods:identification_markings' good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "goods.GoodPage.Table.FirearmDetails.IDENTIFICATION_MARKINGS" %}</span></a>
-								{% endif %}
-							{% endif %}
-						</dd>
-					</div>
 				{% endif %}
 				{% endwith %}
 

--- a/unit_tests/exporter/goods/test_views.py
+++ b/unit_tests/exporter/goods/test_views.py
@@ -1,0 +1,76 @@
+import pytest
+from django.template import Context, Template
+from django.urls import reverse
+from unittest import mock
+
+from core import client
+
+
+@pytest.fixture(scope="function")
+def good():
+    return {
+        "id": "e0a485d0-156e-4152-bec9-4798c9f2871e",
+        "name": "Advanced automatic rifle",
+        "description": "Newly developed rifle for research purposes",
+        "control_list_entries": [],
+        "part_number": "12345/XZ",
+        "is_good_controlled": {"key": "False", "value": "No"},
+        "is_pv_graded": {"key": "no", "value": "No"},
+        "item_category": {"key": "group2_firearms", "value": "Firearms"},
+        "is_military_use": None,
+        "is_component": None,
+        "uses_information_security": None,
+        "modified_military_use_details": None,
+        "component_details": None,
+        "information_security_details": None,
+        "pv_grading_details": None,
+        "software_or_technology_details": None,
+        "firearm_details": {
+            "type": {"key": "firearms", "value": "Firearms"},
+            "year_of_manufacture": 0,
+            "calibre": "50mm",
+            "is_sporting_shotgun": False,
+            "is_replica": False,
+            "replica_description": "",
+            "is_covered_by_firearm_act_section_one_two_or_five": "",
+            "firearms_act_section": "",
+            "section_certificate_missing": None,
+            "section_certificate_missing_reason": "",
+            "section_certificate_number": None,
+            "section_certificate_date_of_expiry": None,
+            "has_identification_markings": None,
+            "no_identification_markings_details": None,
+            "has_proof_mark": None,
+            "no_proof_mark_details": "",
+            "is_deactivated": None,
+            "is_deactivated_to_standard": None,
+            "date_of_deactivation": None,
+            "deactivation_standard": "",
+            "deactivation_standard_other": "",
+            "number_of_items": None,
+            "serial_numbers": [],
+        },
+        "case_id": None,
+        "documents": [],
+        "is_document_available": False,
+        "is_document_sensitive": None,
+        "status": {"key": "draft", "value": "Draft"},
+        "query": None,
+        "case_officer": None,
+        "case_status": None,
+    }
+
+
+def test_get_good_detail_doesnot_contain_application_specific_details(authorized_client, requests_mock, good):
+    requests_mock.get(client._build_absolute_uri("/goods/e0a485d0-156e-4152-bec9-4798c9f2871e/"), json={"good": good})
+    requests_mock.get(client._build_absolute_uri("/goods/e0a485d0-156e-4152-bec9-4798c9f2871e/documents/"), json={})
+
+    url = reverse("goods:good_detail", kwargs={"pk": "e0a485d0-156e-4152-bec9-4798c9f2871e", "type": "case-notes"})
+    response = authorized_client.get(url)
+    assert response.status_code == 200
+    response_html = response.content.decode("utf-8")
+    assert ("Name" in response_html) == True
+    assert ("Product type" in response_html) == True
+    assert ("Controlled" in response_html) == True
+    assert ("Year of manufacture" in response_html) == False
+    assert ("Identification markings" in response_html) == False


### PR DESCRIPTION
## Change description

Remove application specific details (Year of manufacture and Identification markings) from the product detail page on exporter side.

Noticed adding a product to product list is broken because we are sending kwargs as positional arguments resulting in incorrect values for some of the variables, fixed as part of this change.