### PR TITLE
Change BlocksApproval to BlocksFinalising.

### DIFF
--- a/caseworker/flags/forms.py
+++ b/caseworker/flags/forms.py
@@ -79,11 +79,11 @@ def add_flag_form():
             ),
             RadioButtons(
                 name="blocks_approval",
-                title=CreateFlagForm.BlocksApproval.TITLE,
+                title=CreateFlagForm.BlocksFinalising.TITLE,
                 options=[
                     Option(
                         key=True,
-                        value=CreateFlagForm.BlocksApproval.YES,
+                        value=CreateFlagForm.BlocksFinalising.YES,
                         components=[
                             RadioButtons(
                                 name="removable_by",
@@ -102,7 +102,7 @@ def add_flag_form():
                             )
                         ],
                     ),
-                    Option(key=False, value=CreateFlagForm.BlocksApproval.NO),
+                    Option(key=False, value=CreateFlagForm.BlocksFinalising.NO),
                 ],
                 classes=["govuk-radios--inline"],
             ),
@@ -142,11 +142,11 @@ def edit_flag_form():
             ),
             RadioButtons(
                 name="blocks_approval",
-                title=EditFlagForm.BlocksApproval.TITLE,
+                title=EditFlagForm.BlocksFinalising.TITLE,
                 options=[
                     Option(
                         key=True,
-                        value=EditFlagForm.BlocksApproval.YES,
+                        value=EditFlagForm.BlocksFinalising.YES,
                         components=[
                             RadioButtons(
                                 name="removable_by",
@@ -165,7 +165,7 @@ def edit_flag_form():
                             )
                         ],
                     ),
-                    Option(False, EditFlagForm.BlocksApproval.NO),
+                    Option(False, EditFlagForm.BlocksFinalising.NO),
                 ],
             ),
         ],

--- a/lite_content/lite_internal_frontend/flags.py
+++ b/lite_content/lite_internal_frontend/flags.py
@@ -46,8 +46,8 @@ class CreateFlagForm:
         TITLE = "Priority"
         DESCRIPTION = "This relates to the ordering of the flag. 0 is the highest."
 
-    class BlocksApproval:
-        TITLE = "Blocks application approval"
+    class BlocksFinalising:
+        TITLE = "Blocks application finalising"
         YES = "Yes"
         NO = "No"
 
@@ -74,8 +74,8 @@ class EditFlagForm:
         TITLE = "Priority"
         DESCRIPTION = "This relates to the ordering of the flag. 0 is the highest."
 
-    class BlocksApproval:
-        TITLE = "Blocks application approval"
+    class BlocksFinalising:
+        TITLE = "Blocks application finalising"
         YES = "Yes"
         NO = "No"
 


### PR DESCRIPTION
[LTD-878](https://uktrade.atlassian.net/browse/LTD-878) Users should be able to block cases from being finalised
(ATM, they can block cases from being approved only)

This has 3 parts -

1. [lite-api](https://github.com/uktrade/lite-api/pull/768) - I think this is where the business logic lives. This is the important [commit](https://github.com/uktrade/lite-api/pull/768/commits/877b1fa92775c8b5952d58df638afc7e2bd56825). The rest is me renaming a field.
2. [lite-content](https://github.com/uktrade/lite-content/pull/282) - Because I renamed the field, the header in this CSV needed to be updated.
3. [lite-frontend](https://github.com/uktrade/lite-frontend/pull/196) - There was some logic here that needs updating. Hopefully for presentation only. I also renamed a class to reflect the change.

I would propose reviewing in this order. And commit-wise within each PR.