### PR TITLE
Stop great social

### DIFF
--- a/exporter/auth/views.py
+++ b/exporter/auth/views.py
@@ -1,3 +1,5 @@
+from logging import getLogger
+
 from django.conf import settings
 from django.shortcuts import redirect
 from django.urls import reverse
@@ -9,12 +11,23 @@ from lite_forms.generators import error_page
 from exporter.organisation.members.services import get_user
 
 
+logger = getLogger(__name__)
+
+
 class AuthCallbackView(auth_views.AbstractAuthCallbackView, View):
     def authenticate_user(self):
+        # Great SSO is adding social login. We do not want users
+        # to authenticate with Great SSO using e.g. LinkedIn.
+        # This seems like as good a place as any to stop this.
+        # P.S. Great SSO has added social_login flag in user profiles.
+        logger.warn("Authenticating exporter with Great SSO: %s", self.user_profile)
+        if self.user_profile.get("social_login", False):
+            logger.error("Exporter tried using Great social auth: %s", self.user_profile)
+            return {"errors": "We do not support social login. Please use a secure email."}, 403
         return authenticate_exporter_user(self.request, self.user_profile)
 
     def handle_failure(self, data, status_code):
-        if status_code == 400:
+        if status_code in {400, 403}:
             return error_page(self.request, data["errors"])
         elif status_code == 401:
             return redirect("core:register_an_organisation_triage")


### PR DESCRIPTION
Great SSO is rolling out social auth. We do not want people who e.g. login to Great using LinkedIn to be able to access LITE. This PR proposes changes that do this.

ATM, I get the following when logging in using an email (test user) -

```
   2021-05-26T11:21:52.11+0100 [APP/PROC/WEB/0] ERR {"asctime": "2021-05-26 11:21:52,112", "levelname": "WARNING", "message": "Authenticating exporter with Great SSO: {'id': 80159, 'email': 'test+3a1e062c0c96412583ee25ee5fab8215@ci.uktrade.io', 'hashed_uuid': '3b9df322c39bbe86967ce8e76c0557e3f72baae2b4eb30e98a37c24ff9b319fe', 'social_login': False, 'user_profile': {'first_name': 'Automated', 'last_name': 'Test', 'job_title': 'AUTOMATED TESTS', 'mobile_phone_number': '5347428247784', 'segment': None, 'profile_image': None, 'social_account': 'email'}}", "filename": "views.py", "lineno": 23, "threadName": "MainThread", "name": "exporter.auth.views", "thread": 139706225571328, "created": 1622024512.1127532, "process": 103, "processName": "MainProcess", "relativeCreated": 306421.7338562012, "module": "views", "funcName": "authenticate_user", "levelno": 30, "msecs": 112.75315284729004, "pathname": "/home/vcap/app/exporter/auth/views.py"}
```

On the other hand, if I go to [Great UAT](https://great.uat.uktrade.digital), sign-in using e.g. LinkedIn and try to access LITE, I get the following -

```
   2021-05-26T11:37:41.23+0100 [APP/PROC/WEB/0] ERR {"asctime": "2021-05-26 11:37:41,229", "levelname": "WARNING", "message": "Authenticating exporter with Great SSO: {'id': 80158, 'email': 'alixedi@gmail.com', 'hashed_uuid': 'e7274b9760e07d5d24d83432ad26ba2169065aafd1fdf93bd5ddde2f3c6dc447', 'social_login': True, 'user_profile': {'first_name': 'Ali', 'last_name': 'Zaidi', 'job_title': None, 'mobile_phone_number': None, 'segment': None, 'profile_image': None, 'social_account': 'linkedin_oauth2'}}", "filename": "views.py", "lineno": 23, "threadName": "MainThread", "name": "exporter.auth.views", "thread": 139706225571328, "created": 1622025461.2298217, "process": 103, "processName": "MainProcess", "relativeCreated": 1255538.8023853302, "module": "views", "funcName": "authenticate_user", "levelno": 30, "msecs": 229.82168197631836, "pathname": "/home/vcap/app/exporter/auth/views.py"}
   2021-05-26T11:37:41.23+0100 [APP/PROC/WEB/0] ERR {"asctime": "2021-05-26 11:37:41,230", "levelname": "ERROR", "message": "Exporter tried using Great social auth: {'id': 80158, 'email': 'alixedi@gmail.com', 'hashed_uuid': 'e7274b9760e07d5d24d83432ad26ba2169065aafd1fdf93bd5ddde2f3c6dc447', 'social_login': True, 'user_profile': {'first_name': 'Ali', 'last_name': 'Zaidi', 'job_title': None, 'mobile_phone_number': None, 'segment': None, 'profile_image': None, 'social_account': 'linkedin_oauth2'}}", "filename": "views.py", "lineno": 25, "threadName": "MainThread", "name": "exporter.auth.views", "thread": 139706225571328, "created": 1622025461.2301366, "process": 103, "processName": "MainProcess", "relativeCreated": 1255539.1173362732, "module": "views", "funcName": "authenticate_user", "levelno": 40, "msecs": 230.13663291931152, "pathname": "/home/vcap/app/exporter/auth/views.py"}
```

This is also [surfaced in Sentry](https://sentry.ci.uktrade.digital/organizations/dit/issues/39366/?environment=devpopcorn&project=154&query=is%3Aunresolved).

Finally, for the second case, I get the following page -

![Screenshot 2021-05-26 at 11 43 27](https://user-images.githubusercontent.com/3349430/119646917-9946a080-be17-11eb-80a1-e83b56b3a3d0.png)
