### PR TITLE
LTD-862: Display Section5 details on product detail page in all cases

### DIFF
--- a/exporter/templates/goods/good.html
+++ b/exporter/templates/goods/good.html
@@ -392,32 +392,23 @@
 
 					<div class="govuk-summary-list__row">
 						<dt class="govuk-summary-list__key">
-							{% lcs "goods.GoodPage.Table.FirearmDetails.COVERED_BY_THE_FIREARMS_ACT_1968" %}
+							Firearms Act 1968 Section 5
 						</dt>
-						<dd class="govuk-summary-list__value">
-							{% with covered_by_firearms_act=good.firearm_details.is_covered_by_firearm_act_section_one_two_or_five section=good.firearm_details.firearms_act_section %}
-							{% if covered_by_firearms_act == "Yes" %}
-								{{ covered_by_firearms_act }}
-								<span class="govuk-hint govuk-!-margin-0">
-									{% if section == "firearms_act_section1" %}
-										Section 1
-									{% elif section == "firearms_act_section2" %}
-										Section 2
-									{% endif %}
-								</span>
-								{% if not good.firearm_details.section_certificate_missing %}
-									<span class="govuk-hint govuk-!-margin-0">
-										Expires {{ good.firearm_details.section_certificate_date_of_expiry|date_display }}
+						<dd id="covered-by-firearms-act-value" class="govuk-summary-list__value">
+							{% with covered_by_firearms_act=good.firearm_details.is_covered_by_firearm_act_section_one_two_or_five details=good|firearms_act_details %}
+								{% if covered_by_firearms_act == "Yes" %}
+									{{ covered_by_firearms_act }}
+									<span id="firearms-act-certificate-expiry-date-value" class="govuk-hint govuk-!-margin-0">
+										Expires {{ details.expiry_date|date_display }}
 									</span>
-									<span class="govuk-hint govuk-!-margin-0">
-										Reference {{ good.firearm_details.section_certificate_number }}
+									<span id="firearms-act-certificate-number-value" class="govuk-hint govuk-!-margin-0">
+										Reference {{ details.reference }}
 									</span>
+								{% elif covered_by_firearms_act == "No" %}
+									No
+								{% elif covered_by_firearms_act == "Unsure" %}
+									I don't know
 								{% endif %}
-							{% elif covered_by_firearms_act == "No" %}
-								No
-							{% elif covered_by_firearms_act == "Unsure" %}
-								I don't know
-							{% endif %}
 							{% endwith %}
 						</dd>
 						<dd class="govuk-summary-list__actions">

--- a/unit_tests/exporter/goods/test_views.py
+++ b/unit_tests/exporter/goods/test_views.py
@@ -1,7 +1,7 @@
 import pytest
-from django.template import Context, Template
+
+from bs4 import BeautifulSoup
 from django.urls import reverse
-from unittest import mock
 
 from core import client
 
@@ -61,6 +61,40 @@ def good():
     }
 
 
+@pytest.fixture(scope="session")
+def organisation_documents():
+    return [
+        {
+            "document": "812bd3ee-e045-4e38-bbcd-2632f9664b7e",
+            "expiry_date": "2025-01-01",
+            "document_type": "section-one-certificate",
+            "organisation": "16091f44-cd03-4839-9505-613fb5f13686",
+            "reference_code": "FR-SECTION1-12345",
+        },
+        {
+            "document": "259c4538-e093-49bc-8e36-d8047a1bf852",
+            "expiry_date": "2024-12-31",
+            "document_type": "section-two-certificate",
+            "organisation": "16091f44-cd03-4839-9505-613fb5f13686",
+            "reference_code": "FR-SECTION2-12345",
+        },
+        {
+            "document": "21b6e69f-d770-4eb3-99e9-69c65a8d338b",
+            "expiry_date": "2025-05-05",
+            "document_type": "section-five-certificate",
+            "organisation": "16091f44-cd03-4839-9505-613fb5f13686",
+            "reference_code": "FR-SECTION5-12345",
+        },
+        {
+            "document": "2ef7deeb-d72e-4321-ad70-efd07c1a66f3",
+            "expiry_date": "2025-03-31",
+            "document_type": "rfd-certificate",
+            "organisation": "16091f44-cd03-4839-9505-613fb5f13686",
+            "reference_code": "FR-RFD-1234",
+        },
+    ]
+
+
 def test_get_good_detail_doesnot_contain_application_specific_details(authorized_client, requests_mock, good):
     requests_mock.get(client._build_absolute_uri("/goods/e0a485d0-156e-4152-bec9-4798c9f2871e/"), json={"good": good})
     requests_mock.get(client._build_absolute_uri("/goods/e0a485d0-156e-4152-bec9-4798c9f2871e/documents/"), json={})
@@ -74,3 +108,64 @@ def test_get_good_detail_doesnot_contain_application_specific_details(authorized
     assert ("Controlled" in response_html) == True
     assert ("Year of manufacture" in response_html) == False
     assert ("Identification markings" in response_html) == False
+
+
+def test_firearms_act_on_good_detail_page_section5_uploaded(authorized_client, requests_mock, good):
+    """
+    Test to ensure correct details for Section5 are shown when the form is uploaded by the user.
+
+    This is usually the first instance where a product covered under section5 is added, there after
+    the system remembers it for future products.
+    """
+    good["firearm_details"]["is_covered_by_firearm_act_section_one_two_or_five"] = "Yes"
+    good["firearm_details"]["firearms_act_section"] = "firearms_act_section5"
+    good["firearm_details"]["section_certificate_missing"] = False
+    good["firearm_details"]["section_certificate_number"] = "FX123/45"
+    good["firearm_details"]["section_certificate_date_of_expiry"] = "2025-12-31"
+    requests_mock.get(client._build_absolute_uri("/goods/e0a485d0-156e-4152-bec9-4798c9f2871e/"), json={"good": good})
+    requests_mock.get(client._build_absolute_uri("/goods/e0a485d0-156e-4152-bec9-4798c9f2871e/documents/"), json={})
+
+    url = reverse("goods:good_detail", kwargs={"pk": "e0a485d0-156e-4152-bec9-4798c9f2871e", "type": "case-notes"})
+    response = authorized_client.get(url)
+    assert response.status_code == 200
+    soup = BeautifulSoup(response.content.decode("utf-8"), "html.parser")
+    section_details = soup.find(id="covered-by-firearms-act-value").text
+    section_details = section_details.replace("\t", "").replace("\n", " ").strip().split("  ")
+    covered_by_firearms_act = section_details[0]
+    expiry_date = section_details[1].strip()
+    certificate_number = section_details[2].strip()
+
+    assert covered_by_firearms_act == "Yes"
+    assert certificate_number == "Reference FX123/45"
+    assert expiry_date == "Expires 31 December 2025"
+
+
+def test_firearms_act_on_good_detail_page_section5_upload_is_skipped(
+    authorized_client, requests_mock, good, organisation_documents
+):
+    """
+    Test to ensure section5 details are still shown correctly when the upload is skipped
+
+    This is the case when the system determines that there is a valid section5 for this organisation
+    and skips the upload.
+    """
+    good["firearm_details"]["is_covered_by_firearm_act_section_one_two_or_five"] = "Yes"
+    good["firearm_details"]["firearms_act_section"] = "firearms_act_section5"
+    good["firearm_details"]["section_certificate_missing"] = False
+    good["organisation_documents"] = organisation_documents
+    requests_mock.get(client._build_absolute_uri("/goods/e0a485d0-156e-4152-bec9-4798c9f2871e/"), json={"good": good})
+    requests_mock.get(client._build_absolute_uri("/goods/e0a485d0-156e-4152-bec9-4798c9f2871e/documents/"), json={})
+
+    url = reverse("goods:good_detail", kwargs={"pk": "e0a485d0-156e-4152-bec9-4798c9f2871e", "type": "case-notes"})
+    response = authorized_client.get(url)
+    assert response.status_code == 200
+    soup = BeautifulSoup(response.content.decode("utf-8"), "html.parser")
+    section_details = soup.find(id="covered-by-firearms-act-value").text
+    section_details = section_details.replace("\t", "").replace("\n", " ").strip().split("  ")
+    covered_by_firearms_act = section_details[0]
+    expiry_date = section_details[1].strip()
+    certificate_number = section_details[2].strip()
+
+    assert covered_by_firearms_act == "Yes"
+    assert certificate_number == "Reference FR-SECTION5-12345"
+    assert expiry_date == "Expires 5 May 2025"


### PR DESCRIPTION
## Change description

When user adds a product that is covered under section5 for the first time then
we provide a form to upload the certificate, thereafter if another product is
added under section5 the system identifies that there is a valid section5
certificate and skips the upload form. Because of this the product detail page
shows the certificate details as empty/None eventhough there is a valid certificate.
It cannot show this information because it is not saved in the firearm details and
have no access to the organisation documents (RFD, section1/2/5 certificates).

This is fixed by exposing these documents and displaying the details correctly if
there is a valid section5 certificate.