### PR TITLE
Forward Zipkin headers to API.

### DIFF
--- a/core/client.py
+++ b/core/client.py
@@ -28,6 +28,8 @@ def _get_headers(request, sender=None, content_type=None):
     if "user_token" in request.session:
         headers[settings.LITE_API_AUTH_HEADER_NAME] = request.session["user_token"]
     headers["ORGANISATION-ID"] = request.session.get("organisation", "None")
+    headers["x-b3-traceid"] = request.headers.get("x-b3-traceid")
+    headers["x-b3-spanid"] = request.headers.get("x-b3-spanid")
     return headers
 
 

--- a/unit_tests/core/test_api_client.py
+++ b/unit_tests/core/test_api_client.py
@@ -1,0 +1,21 @@
+from unittest.mock import Mock
+
+from core import client
+
+
+def test_zipkin_headers():
+    request = Mock(headers={"x-b3-traceid": "123", "x-b3-spanid": "456"}, session={})
+    request.requests_session = Mock()
+    request.requests_session.request = Mock()
+    client.get(request, "/foo/")
+    request.requests_session.request.assert_called_once_with(
+        headers={
+            "content-type": "application/json",
+            "ORGANISATION-ID": "None",
+            "x-b3-traceid": "123",
+            "x-b3-spanid": "456",
+        },
+        json={},
+        method="GET",
+        url="http://127.0.0.1:8100/foo/",
+    )


### PR DESCRIPTION
So we PaaS attached Zipkin headers to all requests hitting a service. Unless these headers are already there.

So when a user e.g. browser to a Case in the FE, we get the headers for free. What is left is to attach these headers onto the API calls so that we can trace each request as it makes its way through the services.

