### PR TITLE
LTD-920-921-922: Add UI test that verifies the End use, Locations and Route of goods sections in application

### DIFF
--- a/ui_tests/exporter/conftest.py
+++ b/ui_tests/exporter/conftest.py
@@ -203,9 +203,19 @@ def add_new_party(driver, type, name, website, address, country, context):  # no
     functions.click_submit(driver)
 
 
-@when(parsers.parse('I click on the "{section}" section'))  # noqa
-def go_to_task_list_section(driver, section):  # noqa
-    TaskListPage(driver).click_on_task_list_section(section)
+@when(parsers.parse('I click on the "{section_name}" section'))  # noqa
+def go_to_task_list_section(driver, section_name):  # noqa
+    section = driver.find_element_by_link_text(section_name)
+    section_id = section.get_attribute("id")
+    TaskListPage(driver).click_on_task_list_section(section_id)
+
+
+@then(parsers.parse('the section "{section_name}" is now saved'))  # noqa
+def verify_section_is_saved(driver, section_name):  # noqa
+    section = driver.find_element_by_link_text(section_name)
+    section_id = section.get_attribute("id")
+    saved_status_element = driver.find_element_by_id(f"{section_id}-status")
+    assert saved_status_element.text == "SAVED"
 
 
 @when(parsers.parse("I provide details of the intended end use of the products"))  # noqa
@@ -245,13 +255,15 @@ def suspected_wmd_end_use_details(driver, choice):  # noqa
     functions.click_submit(driver)
 
 
-@when(parsers.parse('I answer "{choice}" for shipping air waybill or lading'))  # noqa
+@when(parsers.parse('I answer "{choice}" for shipping air waybill or lading and Save'))  # noqa
 def route_of_goods(driver, choice):  # noqa
     route_of_goods = RouteOfGoodsFormPage(driver)
     if choice == "No":
         route_of_goods.answer_route_of_goods_question(True, "Not shipped air waybill.")
     else:
         route_of_goods.answer_route_of_goods_question(False)
+
+    driver.find_element_by_css_selector("button[type='submit']").click()
 
 
 @when(parsers.parse("I save and continue on the summary page"))  # noqa

--- a/ui_tests/exporter/conftest.py
+++ b/ui_tests/exporter/conftest.py
@@ -263,7 +263,7 @@ def route_of_goods(driver, choice):  # noqa
     else:
         route_of_goods.answer_route_of_goods_question(False)
 
-    driver.find_element_by_css_selector("button[type='submit']").click()
+    functions.click_submit(driver)
 
 
 @when(parsers.parse("I save and continue on the summary page"))  # noqa

--- a/ui_tests/exporter/features/siel_firearm_application.feature
+++ b/ui_tests/exporter/features/siel_firearm_application.feature
@@ -19,7 +19,7 @@ Feature: I want to be able to submit SIEL firearm applications
   Scenario: Add a new Firearm product of type firearms, ammunition, components of ammunition to the application
     Given I signin and go to exporter homepage and choose Test Org
     When I create a standard application of a "permanent" export type
-    When I click on the "goods" section
+    When I click on the "Products" section
     And I choose to add a new product
     And I select product category "firearms"
     And I select product type "firearm"
@@ -42,4 +42,15 @@ Feature: I want to be able to submit SIEL firearm applications
     And I upload file "file_for_doc_upload_test_1.txt" with description "File uploaded for firearms product."
     And I enter product details with value "20,000" and deactivated "No" and Save
     Then the product with name "Rifle" is added to the application
+    And I logout
+
+
+  Scenario: Enter details for the Route of goods section in the application
+    Given I signin and go to exporter homepage and choose Test Org
+    When I create a standard application of a "permanent" export type
+    And I am on the application overview page entitled "Standard Individual Export Licence"
+    When I click on the "Route of goods" section
+    And I answer "Yes" for shipping air waybill or lading and Save
+    Then I should be taken to the application overview page entitled "Standard Individual Export Licence"
+    And the section "Route of goods" is now saved
     And I logout

--- a/ui_tests/exporter/features/siel_firearm_application.feature
+++ b/ui_tests/exporter/features/siel_firearm_application.feature
@@ -70,3 +70,17 @@ Feature: I want to be able to submit SIEL firearm applications
     Then I should be taken to the application overview page entitled "Standard Individual Export Licence"
     And the section "Route of goods" is now saved
     And I logout
+
+
+  Scenario: Enter details for the Location section in the application
+    Given I signin and go to exporter homepage and choose Test Org
+    When I create a standard application of a "permanent" export type
+    And I am on the application overview page entitled "Standard Individual Export Licence"
+    When I click on the "Locations" section
+    And I select "organisation" for where my goods are located
+    And I select the site at position "1"
+    And I click continue
+    And I click the back link
+    Then I should be taken to the application overview page entitled "Standard Individual Export Licence"
+    And the section "Locations" is now saved
+    And I logout

--- a/ui_tests/exporter/features/siel_firearm_application.feature
+++ b/ui_tests/exporter/features/siel_firearm_application.feature
@@ -45,6 +45,22 @@ Feature: I want to be able to submit SIEL firearm applications
     And I logout
 
 
+  Scenario: Enter details for the End use details section in the application
+    Given I signin and go to exporter homepage and choose Test Org
+    When I create a standard application of a "permanent" export type
+    And I am on the application overview page entitled "Standard Individual Export Licence"
+    When I click on the "End use details" section
+    And I provide details of the intended end use of the products
+    And I answer "No" for informed by ECJU to apply
+    And I answer "No" for informed by ECJU about WMD use
+    And I answer "No" for suspected WMD use
+    And I answer "No" for products received under transfer licence from the EU
+    And I save and continue on the summary page
+    Then I should be taken to the application overview page entitled "Standard Individual Export Licence"
+    And the section "End use details" is now saved
+    And I logout
+
+
   Scenario: Enter details for the Route of goods section in the application
     Given I signin and go to exporter homepage and choose Test Org
     When I create a standard application of a "permanent" export type

--- a/ui_tests/exporter/step_defs/test_standard_application.py
+++ b/ui_tests/exporter/step_defs/test_standard_application.py
@@ -249,14 +249,14 @@ def i_see_the_application_overview(driver, context):  # noqa
 
 
 @when(parsers.parse('I am on the application overview page entitled "{title}"'))  # noqa
-def i_see_the_application_overview(driver, title):  # noqa
+def i_am_on_application_overview_with_title(driver, title):  # noqa
     heading = driver.find_element_by_xpath("//h1").text
     assert heading == title
 
 
 @then(parsers.parse('I should be taken to the application overview page entitled "{title}"'))  # noqa
 def taken_to_application_overview_page(driver, title):
-    i_see_the_application_overview(driver, title)
+    i_am_on_application_overview_with_title(driver, title)
 
 
 @when("I delete the application")  # noqa

--- a/ui_tests/exporter/step_defs/test_standard_application.py
+++ b/ui_tests/exporter/step_defs/test_standard_application.py
@@ -248,6 +248,17 @@ def i_see_the_application_overview(driver, context):  # noqa
     context.app_id = app_id
 
 
+@when(parsers.parse('I am on the application overview page entitled "{title}"'))  # noqa
+def i_see_the_application_overview(driver, title):  # noqa
+    heading = driver.find_element_by_xpath("//h1").text
+    assert heading == title
+
+
+@then(parsers.parse('I should be taken to the application overview page entitled "{title}"'))  # noqa
+def taken_to_application_overview_page(driver, title):
+    i_see_the_application_overview(driver, title)
+
+
 @when("I delete the application")  # noqa
 def i_delete_the_application(driver):  # noqa
     apply = ApplyForALicencePage(driver)


### PR DESCRIPTION
## Change description

Add test scenarios that verify the filling of End use, Locations and Route of goods section in Application.
Most of the steps are reused and additional steps are added to assert things.

All of these scenarios are very similar hence included in the same PR. We could add Consignee and End user sections also but since they are related to each other they will be done as a separate PR.