### PR TITLE
LTD-939: Add ui test to verify caseworker viewing application document

### DIFF
--- a/ui_tests/caseworker/conftest.py
+++ b/ui_tests/caseworker/conftest.py
@@ -194,6 +194,13 @@ def i_show_filters(driver):  # noqa
     Shared(driver).try_open_filters()
 
 
+@when(parsers.parse('I click on "{tab_name}" tab'))
+def i_click_on_case_details_tab(driver, tab_name):  # noqa
+    tabs = driver.find_element_by_class_name("lite-tabs")
+    target = tabs.find_element_by_link_text(tab_name)
+    target.click()
+
+
 @when(parsers.parse('I filter by application type "{application_type}"'))
 def filter_by_application_type(driver, application_type):  # noqa
     CaseListPage(driver).select_filter_case_type_from_dropdown(application_type)

--- a/ui_tests/caseworker/features/view_standard_application.feature
+++ b/ui_tests/caseworker/features/view_standard_application.feature
@@ -22,6 +22,23 @@ Feature: I want to view the case details of a case
     | Test    | Rifle   | PL9002      | Automated End user | 1234, High street | BE      | Automated Consignee | 1234, Trade centre  | Research and development |
 
 
+  Scenario: Gov user can view product document
+    Given I sign in to SSO or am signed into SSO
+    And I create an application with <name>,<product>,<clc_rating>,<end_user_name>,<end_user_address>,<consignee_name>,<consignee_address>,<country>,<end_use>
+    And the status is set to "submitted"
+    When I go to the case list page
+    And I click on show filters
+    And I filter by application type "Standard Individual Export Licence"
+    Then I should see my case in the cases list
+    When I go to application previously created
+    And I click on "Documents" tab
+    Then I should see a link to download the document
+
+    Examples:
+    | name    | product | clc_rating  | end_user_name      | end_user_address  | country | consignee_name      | consignee_address   | end_use                  |
+    | Test    | Rifle   | PL9002      | Automated End user | 1234, High street | BE      | Automated Consignee | 1234, Trade centre  | Research and development |
+
+
   @skip @LT_1042_can_see_all_parties @regression
   Scenario: Gov user can see all parties on the case
     Given I sign in to SSO or am signed into SSO

--- a/ui_tests/caseworker/step_defs/test_view_standard_application.py
+++ b/ui_tests/caseworker/step_defs/test_view_standard_application.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 import tests_common.tools.helpers as utils
 from ui_tests.caseworker.pages.application_page import ApplicationPage
 from ui_tests.caseworker.pages.case_list_page import CaseListPage
@@ -89,3 +91,11 @@ def filter_by_application_type(driver, end_use_expected):
     end_use_table = driver.find_element_by_id("slice-end-use-details")
     end_use_text = end_use_table.find_element_by_xpath(".//tbody/tr[1]/td[3]").text
     assert end_use_text == end_use_expected
+
+
+@then("I should see a link to download the document")
+def i_see_link_to_download_document(driver):
+    docs = driver.find_elements_by_class_name("app-documents__item")
+    assert len(docs) == 1
+    link = docs[0].find_element_by_class_name("app-documents__item-details")
+    assert link.text.startswith(f"Application Form - {date.today().isoformat()}")


### PR DESCRIPTION
## Change description

When an application is submitted a document is auto generated with the
application details. This test verifies that this document is available
and that the internal caseworker can download this document.