### PR TITLE
Ltd 855 expiry validation 2

### DIFF
--- a/exporter/applications/helpers/date_fields.py
+++ b/exporter/applications/helpers/date_fields.py
@@ -4,9 +4,11 @@ import re
 def format_date(data, date_field):
     year = data.get(date_field + "year", "")
     month = data.get(date_field + "month", "")
+    day = data.get(date_field + "day", "")
+    if not year or not month or not day:
+        return None
     if len(month) == 1:
         month = "0" + month
-    day = data.get(date_field + "day", "")
     if len(day) == 1:
         day = "0" + day
     return f"{year}-{month}-{day}"

--- a/exporter/core/validators.py
+++ b/exporter/core/validators.py
@@ -1,5 +1,9 @@
 from http import HTTPStatus
+from datetime import date
+from django.utils import timezone
+from dateutil.relativedelta import relativedelta
 
+from exporter.applications.helpers.date_fields import format_date
 from lite_content.lite_exporter_frontend.core import RegisterAnOrganisation
 
 
@@ -16,3 +20,22 @@ def validate_register_organisation_triage(_, json):
         return {"errors": errors}, HTTPStatus.BAD_REQUEST
 
     return json, HTTPStatus.OK
+
+
+def validate_expiry_date(request, field_name):
+    """ Validate that the section certificate expiry date is
+    not in the past or > 5y in the future.
+    """
+    iso_date = format_date(request.POST, field_name)
+    # Absence of ISO date is dealt with by the API
+    if not iso_date:
+        return ["Enter the certificate expiry date and include a day, month and year"]
+
+    expiry_date = date.fromisoformat(iso_date)
+    today = timezone.now().date()
+    # Date of expiry has to be in the future
+    if expiry_date < today:
+        return ["Expiry date must be in the future"]
+    else:
+        if relativedelta(expiry_date, today).years >= 5:
+            return ["Expiry date is too far in the future"]

--- a/exporter/goods/services.py
+++ b/exporter/goods/services.py
@@ -57,9 +57,8 @@ def add_section_certificate_details(firearm_details, json):
         certificate_missing = json.get("section_certificate_missing", False)
         if not certificate_missing:
             firearm_details["section_certificate_number"] = json.get("section_certificate_number")
-            formatted_section_certificate_date = format_date(json, "section_certificate_date_of_expiry")
-            firearm_details["section_certificate_date_of_expiry"] = (
-                formatted_section_certificate_date if formatted_section_certificate_date != "--" else None
+            firearm_details["section_certificate_date_of_expiry"] = format_date(
+                json, "section_certificate_date_of_expiry"
             )
             firearm_details["section_certificate_missing"] = False
             firearm_details["section_certificate_missing_reason"] = ""

--- a/exporter/organisation/views.py
+++ b/exporter/organisation/views.py
@@ -10,6 +10,7 @@ from exporter.core.objects import Tab
 from exporter.core.services import get_organisation
 from lite_content.lite_exporter_frontend.organisation import Tabs
 from lite_forms.helpers import conditional
+from exporter.core.validators import validate_expiry_date
 from exporter.organisation.roles.services import get_user_permissions
 from exporter.goods.forms import attach_firearm_dealer_certificate_form
 from exporter.organisation import forms
@@ -91,6 +92,11 @@ class AbstractOrganisationUpload(LoginRequiredMixin, TemplateView):
             "reference_code": self.request.POST["reference_code"],
             "document_type": self.document_type,
         }
+
+        errors = validate_expiry_date(request, "expiry_date_")
+        if errors:
+            form = self.form_function(back_url=reverse("organisation:details"))
+            return form_page(request, form, data=request.POST, errors={"expiry_date": errors})
 
         file = request.FILES.get("file")
         if file:

--- a/ui_tests/exporter/features/siel_firearm_application.feature
+++ b/ui_tests/exporter/features/siel_firearm_application.feature
@@ -76,7 +76,7 @@ Feature: I want to be able to submit SIEL firearm applications
     And I specify firearms act sections apply as "Yes"
     And I select firearms act section "2"
     And I upload firearms certificate file "file_for_doc_upload_test_1.txt"
-    And I enter certificate number as "FR2468/1234/1" with expiry date "12-10-2030"
+    And I enter certificate number as "FR2468/1234/1" with expiry date "12-10-2025"
     And I see summary screen for "Firearms" product with name "Rifle" and "continue"
     And I select "Yes" to document available question
     And I select "No" to document is above official sensitive question

--- a/unit_tests/exporter/applications/views/test_goods.py
+++ b/unit_tests/exporter/applications/views/test_goods.py
@@ -1,3 +1,4 @@
+import pytest
 from exporter.applications.views import goods
 
 
@@ -29,3 +30,27 @@ def test_is_firearm_certificate_needed_not_section_five_selected():
     )
 
     assert actual is True
+
+
+@pytest.mark.parametrize(
+    "expiry_date,error",
+    (
+        ("2020-01-01", ["Expiry date must be in the future"]),  # Past
+        ("2050-01-01", ["Expiry date is too far in the future"]),  # Too far in the future
+    ),
+)
+def test_upload_firearm_registered_dealer_certificate_error(authorized_client, expiry_date, error):
+    # How do I write this?
+    pass
+
+
+@pytest.mark.parametrize(
+    "expiry_date,error",
+    (
+        ("2020-01-01", ["Expiry date must be in the future"]),  # Past
+        ("2050-01-01", ["Expiry date is too far in the future"]),  # Too far in the future
+    ),
+)
+def test_upload_firearm_section_five_certificate_error(authorized_client, expiry_date, error):
+    # How do I write this?
+    pass


### PR DESCRIPTION
Hello team. I need your help with this. Here is the situation -

**Context:**

In this ticket, we wanted to ensure that the expiry date entered as part of the firearm certificate was (1) not in the past and (2) not > 5y into the future. @eadpearce had a run at it and decided that we should put this validation in the FE. 

(This has repercussions that I don't want to get into here so DM if you want to chat about this)

There are 4 different views that ask users to upload a firearm certificate. So I chose to put the validation logic in a [function](https://github.com/uktrade/lite-frontend/pull/225/commits/04ceb4eda8cc36d80072fe8da49853668e1be146) and call it in these [4 views](https://github.com/uktrade/lite-frontend/pull/225/commits/c3057c4cb22ca60eb659cd864f9f4429ee7813ad).

**Problem**
It was relatively simple to add the expiry date validation to the 2 views that allow a user to upload a firearm certificate for the organization. 

It was also simple to [add tests for these views](https://github.com/uktrade/lite-frontend/pull/225/commits/6434c7bf26de7cbfb191fb11e8bad6776de474a5).

Unfortunately, the other views use what is called a `FromGroup`. This is part of the `lite-forms` and basically implements multi-step forms (aka "Wizards"). 

The wizards are implemented by carrying the state through each form in the session. At the end of the wizard, if everything adds up, they hit the API with a POST request that contains combined data from all the forms. Things are made a little more complex IRL because of careless use of [`cached_property`](https://github.com/uktrade/lite-frontend/blob/011bd960e986962f3124895b902fc0e486e9e4c3/exporter/applications/views/goods.py#L7)

I find these wizards un-testable (or at least very difficult to write tests for) because of this carried state. In that, unsurprisingly, I found 0 tests in this repository for any of the views that render a `FormGroup`.

In addition, when Colin tried testing this on `devkoala`, he ended up running into 100 different problems that were unrelated to this ticket specifically but point to the underlying problems that I have detailed including the carried state in sessions and the caching.

(I have tested this manually and it works for me. But I used the end-to-end tests to create a fresh user and a fresh org and only did the manual testing starting from that clean slate.)

I am writing this because (1) please share ideas that might help us progress this in the short term, (2) we need to discuss how to solve this in the medium-long term 

**Update**
Ash did some testing at the end of which, we have (1) go-ahead for this and (2) a bunch of tickets having to do with fixing the wizards.


