### PR TITLE
[LTD-989] Remove system flags from routing rule dropdown.

### DIFF
--- a/caseworker/routing_rules/forms.py
+++ b/caseworker/routing_rules/forms.py
@@ -135,7 +135,7 @@ def select_flags(request, team_id, flags_to_include, flags_to_exclude, is_editin
 
     flags_checkboxes = [
         Option(flag["id"], flag["name"], data_attribute=get_flag_details_html(flag))
-        for flag in get_flags_for_team_of_level(request, level="", team_id=team_id, include_system_flags=True)
+        for flag in get_flags_for_team_of_level(request, level="", team_id=team_id)
     ]
 
     return Form(


### PR DESCRIPTION
This removes the "system flags" from the dropdown when a user is trying to create a routing rule.
