### PR TITLE
LTD-1055: Remove System flags from being selected when creating a routing rule

### DIFF
--- a/caseworker/cases/services.py
+++ b/caseworker/cases/services.py
@@ -277,7 +277,9 @@ def get_flags_for_team_of_level(request, level, team_id, include_system_flags=Fa
         + "&disable_pagination=True&include_flagging_rules=True",
     )
     response.raise_for_status()
-    return response.json()
+
+    # Remove system flags from selection while creating routing rules
+    return [flag for flag in response.json() if flag["team"]["id"] != "00000000-0000-0000-0000-000000000001"]
 
 
 def put_flag_assignments(request, json):

--- a/ui_tests/caseworker/features/routing_rules.feature
+++ b/ui_tests/caseworker/features/routing_rules.feature
@@ -37,7 +37,6 @@ Feature: I want to have cases be automatically routed to relevant work queues an
     And I filter by my routing rule queue
     Then I see the routing rule in the list as "Deactivated" and tier "1"
 
-    @workflow
     Scenario: Move case along in workflow
       Given I sign in to SSO or am signed into SSO
       And I create standard application or standard application has been previously created


### PR DESCRIPTION
## Change description

System flags are applied/removed by the system depending on the case attributes so
defining a routing rule using these flags results in inconsistent behaviour.
To avoid this remove these flags from being selected by the user.