### PR TITLE
LTD-1107: Provide GoodOnApplication id as key when reviewing the product

### DIFF
--- a/caseworker/cases/views/goods.py
+++ b/caseworker/cases/views/goods.py
@@ -102,7 +102,9 @@ class AbstractReviewGoodWizardView(SessionWizardView):
         )
 
     def process_step(self, form):
-        data = {**form.cleaned_data, "objects": [self.object_pk]}
+        if self.case["case_type"]["reference"]["key"] != "siel":
+            raise ValueError("Only SIEL licences are supported")
+        data = {**form.cleaned_data, "objects": [self.object["good"]["id"]]}
         del data["does_not_have_control_list_entries"]
         post_review_good(self.request, case_id=self.kwargs["pk"], data=data)
         return super().process_step(form)
@@ -122,7 +124,7 @@ class ReviewStandardApplicationGoodWizardView(AbstractReviewGoodWizardView):
 
     @property
     def object(self):
-        return next(item for item in self.case.goods if item["good"]["id"] == self.object_pk)
+        return next(item for item in self.case.goods if item["id"] == self.object_pk)
 
     def get_form_initial(self, step):
         # if the good was reviewed at application level then use that as source of truth, otherwise use the export

--- a/caseworker/templates/case/slices/goods.html
+++ b/caseworker/templates/case/slices/goods.html
@@ -58,8 +58,8 @@
 						{% if not hide_checkboxes %}
 							<td class="govuk-table__cell govuk-table__cell--checkbox {% if show_advice %}lite-!-no-border{% endif %}">
 								<div>
-									<input class="govuk-checkboxes__input" type="checkbox" name="goods" value="{{ good.good.id }}" id="{{ good.id }}">
-									<label class="govuk-label govuk-checkboxes__label" for="{{ good.good.id }}">{{ forloop.counter }}</label>
+									<input class="govuk-checkboxes__input" type="checkbox" name="goods" value="{{ good.id }}" id="{{ good.id }}">
+									<label class="govuk-label govuk-checkboxes__label" for="{{ good.id }}">{{ forloop.counter }}</label>
 								</div>
 							</td>
 						{% endif %}


### PR DESCRIPTION
## Change description

When there are multiple products on an application we select the ones to be
reviewed and click "Review" button. The review page is provided the list
if ids of the underlying "Good" instance in "GoodOnApplication".

This works ok if the same Good is added once but if the user used the same
"Good" to add multiple products to the application then we are always
selecting the first "GoodOnApplication" instance that matches with the given
Good id hence displaying incorrect quantity value in the review page.