### PR TITLE
LTD-1276: Fix product flags form to provide good id to assign flags correctly

### DIFF
--- a/caseworker/cases/helpers/advice.py
+++ b/caseworker/cases/helpers/advice.py
@@ -39,17 +39,7 @@ def get_param_destinations(request, case: Case):
 def get_param_goods(request, case: Case):
     selected_goods_ids = request.GET.getlist("goods", request.GET.getlist("goods_types"))
     goods = case.data.get("goods", case.data.get("goods_types"))
-    return_values = []
-
-    for good in goods:
-        if "good" in good:
-            if good["good"]["id"] in selected_goods_ids:
-                return_values.append(good)
-        else:
-            if good["id"] in selected_goods_ids:
-                return_values.append(good)
-
-    return return_values
+    return [good for good in goods if good["id"] in selected_goods_ids]
 
 
 def same_value(dicts, key):

--- a/caseworker/flags/views.py
+++ b/caseworker/flags/views.py
@@ -274,7 +274,10 @@ class ChangeFlaggingRuleStatus(LoginRequiredMixin, SingleFormView):
         return super(ChangeFlaggingRuleStatus, self).post(request, **kwargs)
 
 
-def perform_action(level, request, pk, json):
+def perform_action(case, level, request, pk, json):
+    selected_goods_ids = request.GET.getlist("goods", request.GET.getlist("goods_types"))
+    goods = case.data.get("goods", case.data.get("goods_types"))
+    product_ids = [item["good"]["id"] for item in goods if item["id"] in selected_goods_ids]
     data = {
         "level": level,
         "objects": [
@@ -282,7 +285,7 @@ def perform_action(level, request, pk, json):
             for x in [
                 request.GET.get("case"),
                 request.GET.get("organisation"),
-                *request.GET.getlist("goods"),
+                *product_ids,
                 *request.GET.getlist("goods_types"),
                 *request.GET.getlist("countries"),
                 request.GET.get("end_user"),
@@ -358,7 +361,7 @@ class AssignFlags(LoginRequiredMixin, SingleFormView):
             return get_destination_flags(self.request)
 
     def get_action(self):
-        return functools.partial(perform_action, self.level)
+        return functools.partial(perform_action, self.case, self.level)
 
     def get_success_url(self):
         if self.request.GET.get("return_to"):

--- a/unit_tests/caseworker/flags/test_views.py
+++ b/unit_tests/caseworker/flags/test_views.py
@@ -26,7 +26,7 @@ def test_assign_flags_view_destination(authorized_client, queue_pk, open_case_pk
 
 def test_assign_flags_form_goods(authorized_client, data_standard_case, queue_pk, standard_case_pk):
 
-    good_pk = data_standard_case["case"]["data"]["goods"][0]["good"]["id"]
+    good_pk = data_standard_case["case"]["data"]["goods"][0]["id"]
 
     url = reverse("cases:assign_flags", kwargs={"queue_pk": queue_pk, "pk": standard_case_pk}) + f"?goods={good_pk}"
     response = authorized_client.get(url)


### PR DESCRIPTION
## Change description

This form allows user to assign specific flags to a product on application and it
receives a list of ids. These were product ids (Good model) but when we fixed an
issue with review goods form this has changed to ids of GoodOnApplication.

Because of this the backend is not able to find relevant object and throwing
'not found' error as response. Fix this by extracting the relevant Good ids
in the form.