### PR TITLE
[LTD-1386] Country Select for FCDO users

### DIFF
--- a/caseworker/advice/forms.py
+++ b/caseworker/advice/forms.py
@@ -146,3 +146,38 @@ class CountersignAdviceForm(forms.Form):
                 self.add_error("refusal_reasons", "Enter why you do not agree with the recommendation")
             if cleaned_data.get("queue_to_return") == "":
                 self.add_error("queue_to_return", "Select where you want to return this recommendation")
+
+
+class FCDOApprovalAdviceForm(GiveApprovalAdviceForm):
+    def __init__(self, countries, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["countries"] = forms.MultipleChoiceField(
+            choices=countries.items(),
+            widget=GridmultipleSelect(),
+            label="Select countries for which you want to give advice",
+        )
+        self.helper = FormHelper()
+        self.helper.layout = Layout(
+            "countries",
+            "proviso",
+            "approval_reasons",
+            "instructions_to_exporter",
+            "footnote_details",
+            HTML.details(
+                "What is a footnote?",
+                "Footnotes explain why products to a destination have been approved or refused. "
+                "They will be publicly available in reports and data tables.",
+            ),
+            Submit("submit", "Submit"),
+        )
+
+
+class FCDORefusalAdviceForm(RefusalAdviceForm):
+    def __init__(self, denial_reasons, countries, *args, **kwargs):
+        super().__init__(denial_reasons, *args, **kwargs)
+        self.fields["countries"] = forms.MultipleChoiceField(
+            choices=countries.items(),
+            widget=GridmultipleSelect(),
+            label="Select countries for which you want to give advice",
+        )
+        self.helper.layout = Layout("countries", "denial_reasons", "refusal_reasons", Submit("submit", "Submit"))

--- a/caseworker/advice/services.py
+++ b/caseworker/advice/services.py
@@ -48,7 +48,7 @@ def get_advice_subjects(case, countries=None):
             if dest["country"]["id"] not in countries:
                 continue
         destinations.append((dest["type"], dest["id"]))
-    goods = [("good", good["id"]) for good in case.goods if good["is_good_controlled"]]
+    goods = [("good", good["id"]) for good in case.goods if good["is_good_controlled"]["key"] == "True"]
     return destinations + goods
 
 

--- a/caseworker/advice/services.py
+++ b/caseworker/advice/services.py
@@ -2,10 +2,6 @@ from core import client
 from caseworker.cases.services import put_case_queues
 
 
-def filter_licenceable_products(products):
-    return [product for product in products if product["is_good_controlled"]["key"] == "True"]
-
-
 def filter_nlr_products(products):
     return [
         product
@@ -65,12 +61,11 @@ def post_approval_advice(request, case, data):
             "note": data["instructions_to_exporter"],
             "footnote_required": True if data["footnote_details"] else False,
             "footnote": data["footnote_details"],
-            "good": product["id"],
+            subject_name: subject_id,
             "denial_reasons": [],
         }
-        for product in filter_licenceable_products(case["data"]["goods"])
+        for subject_name, subject_id in get_advice_subjects(case, data.get("countries"))
     ]
-
     response = client.post(request, f"/cases/{case['id']}/user-advice/", json)
     response.raise_for_status()
     return response.json(), response.status_code
@@ -82,12 +77,11 @@ def post_refusal_advice(request, case, data):
             "type": "refuse",
             "text": data["refusal_reasons"],
             "footnote_required": False,
-            "good": product["id"],
+            subject_name: subject_id,
             "denial_reasons": data["denial_reasons"],
         }
-        for product in filter_licenceable_products(case["data"]["goods"])
+        for subject_name, subject_id, in get_advice_subjects(case, data.get("countries"))
     ]
-
     response = client.post(request, f"/cases/{case['id']}/user-advice/", json)
     response.raise_for_status()
     return response.json(), response.status_code

--- a/caseworker/advice/services.py
+++ b/caseworker/advice/services.py
@@ -41,11 +41,22 @@ def get_advice_to_countersign(case, caseworker):
     return filter_advice_by_level(advice_by_team, ["user"])
 
 
+def get_advice_subjects(case, countries=None):
+    """The "advice subject" is an item on a case (eg a good, end user, consignee etc)
+    that can have advice related to it. See lite-api/api/cases/models.py for foreign
+    key fields on the Advice model.
+    """
+    destinations = []
+    for dest in case.destinations:
+        if countries is not None:
+            if dest["country"]["id"] not in countries:
+                continue
+        destinations.append((dest["type"], dest["id"]))
+    goods = [("good", good["id"]) for good in case.goods if good["is_good_controlled"]]
+    return destinations + goods
+
+
 def post_approval_advice(request, case, data):
-    if "country" in data:
-        # This means that the advice is being given for a specific destination and not for the entire case.
-        # What should send to the API to make this happen?
-        pass
     json = [
         {
             "type": "proviso" if data["proviso"] else "approve",

--- a/caseworker/advice/services.py
+++ b/caseworker/advice/services.py
@@ -42,6 +42,10 @@ def get_advice_to_countersign(case, caseworker):
 
 
 def post_approval_advice(request, case, data):
+    if "country" in data:
+        # This means that the advice is being given for a specific destination and not for the entire case.
+        # What should send to the API to make this happen?
+        pass
     json = [
         {
             "type": "proviso" if data["proviso"] else "approve",

--- a/caseworker/advice/views.py
+++ b/caseworker/advice/views.py
@@ -30,7 +30,16 @@ class CaseContextMixin:
     @property
     def caseworker(self):
         user_id = str(self.request.session["lite_api_user_id"])
-        return get_gov_user(self.request, user_id)[0]
+        data, _ = get_gov_user(self.request, user_id)
+        return data["user"]
+
+    def unadvised_countries(self):
+        """Returns a dict of countries for which advice has not been given"""
+        dest_types = ("end_user", "ultimate_end_user", "consignee")
+        dests = {advice.get(dest_type) for dest_type in dest_types for advice in self.case.advice} - {None}
+        return {
+            dest["country"]["id"]: dest["country"]["name"] for dest in self.case.destinations if dest["id"] not in dests
+        }
 
     def get_context(self, **kwargs):
         return {}
@@ -77,8 +86,13 @@ class GiveApprovalAdviceView(LoginRequiredMixin, CaseContextMixin, FormView):
     Form to recommend approval advice for all products on the application
     """
 
-    form_class = forms.GiveApprovalAdviceForm
     template_name = "advice/give-approval-advice.html"
+
+    def get_form(self):
+        if self.caseworker["team"]["name"] == "FCO":
+            return forms.FCDOApprovalAdviceForm(self.unadvised_countries(), **self.get_form_kwargs())
+        else:
+            return forms.GiveApprovalAdviceForm(**self.get_form_kwargs())
 
     def form_valid(self, form):
         services.post_approval_advice(self.request, self.case, form.cleaned_data)
@@ -90,15 +104,13 @@ class GiveApprovalAdviceView(LoginRequiredMixin, CaseContextMixin, FormView):
 
 class RefusalAdviceView(LoginRequiredMixin, CaseContextMixin, FormView):
     template_name = "advice/refusal_advice.html"
-    form_class = forms.RefusalAdviceForm
 
-    def get_form_kwargs(self):
-        """Overriding this so that I can pass denial_reasons
-        to the form.
-        """
-        kwargs = super().get_form_kwargs()
-        kwargs["denial_reasons"] = get_denial_reasons(self.request)
-        return kwargs
+    def get_form(self):
+        denial_reasons = get_denial_reasons(self.request)
+        if self.caseworker["team"]["name"] == "FCO":
+            return forms.FCDORefusalAdviceForm(denial_reasons, self.unadvised_countries(), **self.get_form_kwargs())
+        else:
+            return forms.RefusalAdviceForm(denial_reasons, **self.get_form_kwargs())
 
     def form_valid(self, form):
         services.post_refusal_advice(self.request, self.case, form.cleaned_data)

--- a/caseworker/advice/views.py
+++ b/caseworker/advice/views.py
@@ -289,7 +289,7 @@ class ReviewCountersignView(LoginRequiredMixin, CaseContextMixin, TemplateView):
     def get_context(self, **kwargs):
         context = super().get_context()
         case = kwargs.get("case").__dict__
-        caseworker = self.caseworker["user"]
+        caseworker = self.caseworker
 
         advice_to_countersign = services.get_advice_to_countersign(case, caseworker)
         advice_users_pks = [item["user"]["id"] for item in advice_to_countersign]
@@ -308,7 +308,7 @@ class ReviewCountersignView(LoginRequiredMixin, CaseContextMixin, TemplateView):
     def post(self, request, *args, **kwargs):
         context = self.get_context_data()
         case = context["case"]
-        caseworker = self.caseworker["user"]
+        caseworker = self.caseworker
         num_advice = len(context["user_pks"])
         CountersignAdviceFormsetFactory = formset_factory(
             self.form_class, formset=CountersignAdviceFormSet, extra=num_advice, min_num=num_advice, max_num=num_advice
@@ -332,7 +332,7 @@ class ViewCountersignedAdvice(LoginRequiredMixin, CaseContextMixin, TemplateView
     def get_context(self, **kwargs):
         context = super().get_context()
         case = kwargs.get("case")
-        caseworker = self.caseworker["user"]
+        caseworker = self.caseworker
 
         advice_to_countersign = services.get_advice_to_countersign(case, caseworker)
         context["advice_to_countersign"] = advice_to_countersign

--- a/caseworker/advice/views.py
+++ b/caseworker/advice/views.py
@@ -35,7 +35,7 @@ class CaseContextMixin:
 
     def unadvised_countries(self):
         """Returns a dict of countries for which advice has not been given"""
-        dest_types = ("end_user", "ultimate_end_user", "consignee")
+        dest_types = ("end_user", "ultimate_end_user", "consignee", "third_parties")
         dests = {advice.get(dest_type) for dest_type in dest_types for advice in self.case.advice} - {None}
         return {
             dest["country"]["id"]: dest["country"]["name"] for dest in self.case.destinations if dest["id"] not in dests

--- a/core/forms/templates/forms/checkbox_option.html
+++ b/core/forms/templates/forms/checkbox_option.html
@@ -1,5 +1,5 @@
 <div class="govuk-checkboxes__item">
-    <input class="govuk-checkboxes__input" id="{{ widget.attrs.id }}" name="{{ widget.name }}" type="checkbox" value="{{ widget.label }}" {% if widget.selected %}checked{% endif %}>
+    <input class="govuk-checkboxes__input" id="{{ widget.attrs.id }}" name="{{ widget.name }}" type="checkbox" value="{{ widget.value }}" {% if widget.selected %}checked{% endif %}>
     <label class="govuk-label govuk-checkboxes__label" for="{{ widget.attrs.id }}">
         {{ widget.label }}
     </label>

--- a/unit_tests/caseworker/advice/views/test_edit_advice.py
+++ b/unit_tests/caseworker/advice/views/test_edit_advice.py
@@ -43,14 +43,54 @@ def test_edit_approve_advice_post(authorized_client, requests_mock, data_standar
     assert history.method == "POST"
     assert history.json() == [
         {
-            "type": "approve",
-            "text": "meets the requirements updated",
-            "proviso": None,
-            "note": "no specific instructions",
-            "footnote_required": False,
-            "footnote": None,
-            "good": "9fbffa7f-ef50-402e-93ac-2f3f37d09030",
-            "denial_reasons": [],
+            'denial_reasons': [],
+            'end_user': '95d3ea36-6ab9-41ea-a744-7284d17b9cc5',
+            'footnote': None,
+            'footnote_required': False,
+            'note': 'no specific instructions',
+            'proviso': None,
+            'text': 'meets the requirements updated',
+            'type': 'approve'
+        },
+        {
+            'consignee': 'cd2263b4-a427-4f14-8552-505e1d192bb8',
+            'denial_reasons': [],
+            'footnote': None,
+            'footnote_required': False,
+            'note': 'no specific instructions',
+            'proviso': None,
+            'text': 'meets the requirements updated',
+            'type': 'approve'
+        },
+        {
+            'denial_reasons': [],
+            'footnote': None,
+            'footnote_required': False,
+            'note': 'no specific instructions',
+            'proviso': None,
+            'text': 'meets the requirements updated',
+            'third_party': '95c2d6b7-5cfd-47e8-b3c8-dc76e1ac9747',
+            'type': 'approve'
+        },
+        {
+            'denial_reasons': [],
+            'footnote': None,
+            'footnote_required': False,
+            'good': '9fbffa7f-ef50-402e-93ac-2f3f37d09030',
+            'note': 'no specific instructions',
+            'proviso': None,
+            'text': 'meets the requirements updated',
+            'type': 'approve'
+        },
+        {
+            'denial_reasons': [],
+            'footnote': None,
+            'footnote_required': False,
+            'good': 'd4feac1e-851d-41a5-b833-eb28addb8547',
+            'note': 'no specific instructions',
+            'proviso': None,
+            'text': 'meets the requirements updated',
+            'type': 'approve'
         }
     ]
 
@@ -90,16 +130,43 @@ def test_edit_refuse_advice_post(
     }
     response = authorized_client.post(url, data=data)
     assert response.status_code == 302
-    history = [item for item in requests_mock.request_history if user_advice_create_url in item.url]
-    assert len(history) == 1
-    history = history[0]
-    assert history.method == "POST"
-    assert history.json() == [
+    history = requests_mock.request_history
+    assert user_advice_create_url in history[5].url
+    assert history[5].method == "POST"
+    assert history[5].json() == [
         {
-            "type": "refuse",
-            "text": "doesn't meet the requirement",
-            "footnote_required": False,
-            "good": "9fbffa7f-ef50-402e-93ac-2f3f37d09030",
-            "denial_reasons": ["3", "4", "5", "5a", "5b"],
+            'denial_reasons': ['3', '4', '5', '5a', '5b'],
+            'end_user': '95d3ea36-6ab9-41ea-a744-7284d17b9cc5',
+            'footnote_required': False,
+            'text': "doesn't meet the requirement",
+            'type': 'refuse'
+        },
+        {
+            'consignee': 'cd2263b4-a427-4f14-8552-505e1d192bb8',
+            'denial_reasons': ['3', '4', '5', '5a', '5b'],
+            'footnote_required': False,
+            'text': "doesn't meet the requirement",
+            'type': 'refuse'
+        },
+        {
+            'denial_reasons': ['3', '4', '5', '5a', '5b'],
+            'footnote_required': False,
+            'text': "doesn't meet the requirement",
+            'third_party': '95c2d6b7-5cfd-47e8-b3c8-dc76e1ac9747',
+            'type': 'refuse'
+        },
+        {
+            'denial_reasons': ['3', '4', '5', '5a', '5b'],
+            'footnote_required': False,
+            'good': '9fbffa7f-ef50-402e-93ac-2f3f37d09030',
+            'text': "doesn't meet the requirement",
+            'type': 'refuse'
+        },
+        {
+            'denial_reasons': ['3', '4', '5', '5a', '5b'],
+            'footnote_required': False,
+            'good': 'd4feac1e-851d-41a5-b833-eb28addb8547',
+            'text': "doesn't meet the requirement",
+            'type': 'refuse'
         }
     ]

--- a/unit_tests/caseworker/advice/views/test_edit_advice.py
+++ b/unit_tests/caseworker/advice/views/test_edit_advice.py
@@ -82,16 +82,6 @@ def test_edit_approve_advice_post(authorized_client, requests_mock, data_standar
             "text": "meets the requirements updated",
             "type": "approve",
         },
-        {
-            "denial_reasons": [],
-            "footnote": None,
-            "footnote_required": False,
-            "good": "d4feac1e-851d-41a5-b833-eb28addb8547",
-            "note": "no specific instructions",
-            "proviso": None,
-            "text": "meets the requirements updated",
-            "type": "approve",
-        },
     ]
 
 
@@ -130,10 +120,10 @@ def test_edit_refuse_advice_post(
     }
     response = authorized_client.post(url, data=data)
     assert response.status_code == 302
-    history = requests_mock.request_history
-    assert user_advice_create_url in history[5].url
-    assert history[5].method == "POST"
-    assert history[5].json() == [
+    history = requests_mock.request_history.pop()
+    assert user_advice_create_url in history.url
+    assert history.method == "POST"
+    assert history.json() == [
         {
             "denial_reasons": ["3", "4", "5", "5a", "5b"],
             "end_user": "95d3ea36-6ab9-41ea-a744-7284d17b9cc5",
@@ -159,13 +149,6 @@ def test_edit_refuse_advice_post(
             "denial_reasons": ["3", "4", "5", "5a", "5b"],
             "footnote_required": False,
             "good": "9fbffa7f-ef50-402e-93ac-2f3f37d09030",
-            "text": "doesn't meet the requirement",
-            "type": "refuse",
-        },
-        {
-            "denial_reasons": ["3", "4", "5", "5a", "5b"],
-            "footnote_required": False,
-            "good": "d4feac1e-851d-41a5-b833-eb28addb8547",
             "text": "doesn't meet the requirement",
             "type": "refuse",
         },

--- a/unit_tests/caseworker/advice/views/test_edit_advice.py
+++ b/unit_tests/caseworker/advice/views/test_edit_advice.py
@@ -43,55 +43,55 @@ def test_edit_approve_advice_post(authorized_client, requests_mock, data_standar
     assert history.method == "POST"
     assert history.json() == [
         {
-            'denial_reasons': [],
-            'end_user': '95d3ea36-6ab9-41ea-a744-7284d17b9cc5',
-            'footnote': None,
-            'footnote_required': False,
-            'note': 'no specific instructions',
-            'proviso': None,
-            'text': 'meets the requirements updated',
-            'type': 'approve'
+            "denial_reasons": [],
+            "end_user": "95d3ea36-6ab9-41ea-a744-7284d17b9cc5",
+            "footnote": None,
+            "footnote_required": False,
+            "note": "no specific instructions",
+            "proviso": None,
+            "text": "meets the requirements updated",
+            "type": "approve",
         },
         {
-            'consignee': 'cd2263b4-a427-4f14-8552-505e1d192bb8',
-            'denial_reasons': [],
-            'footnote': None,
-            'footnote_required': False,
-            'note': 'no specific instructions',
-            'proviso': None,
-            'text': 'meets the requirements updated',
-            'type': 'approve'
+            "consignee": "cd2263b4-a427-4f14-8552-505e1d192bb8",
+            "denial_reasons": [],
+            "footnote": None,
+            "footnote_required": False,
+            "note": "no specific instructions",
+            "proviso": None,
+            "text": "meets the requirements updated",
+            "type": "approve",
         },
         {
-            'denial_reasons': [],
-            'footnote': None,
-            'footnote_required': False,
-            'note': 'no specific instructions',
-            'proviso': None,
-            'text': 'meets the requirements updated',
-            'third_party': '95c2d6b7-5cfd-47e8-b3c8-dc76e1ac9747',
-            'type': 'approve'
+            "denial_reasons": [],
+            "footnote": None,
+            "footnote_required": False,
+            "note": "no specific instructions",
+            "proviso": None,
+            "text": "meets the requirements updated",
+            "third_party": "95c2d6b7-5cfd-47e8-b3c8-dc76e1ac9747",
+            "type": "approve",
         },
         {
-            'denial_reasons': [],
-            'footnote': None,
-            'footnote_required': False,
-            'good': '9fbffa7f-ef50-402e-93ac-2f3f37d09030',
-            'note': 'no specific instructions',
-            'proviso': None,
-            'text': 'meets the requirements updated',
-            'type': 'approve'
+            "denial_reasons": [],
+            "footnote": None,
+            "footnote_required": False,
+            "good": "9fbffa7f-ef50-402e-93ac-2f3f37d09030",
+            "note": "no specific instructions",
+            "proviso": None,
+            "text": "meets the requirements updated",
+            "type": "approve",
         },
         {
-            'denial_reasons': [],
-            'footnote': None,
-            'footnote_required': False,
-            'good': 'd4feac1e-851d-41a5-b833-eb28addb8547',
-            'note': 'no specific instructions',
-            'proviso': None,
-            'text': 'meets the requirements updated',
-            'type': 'approve'
-        }
+            "denial_reasons": [],
+            "footnote": None,
+            "footnote_required": False,
+            "good": "d4feac1e-851d-41a5-b833-eb28addb8547",
+            "note": "no specific instructions",
+            "proviso": None,
+            "text": "meets the requirements updated",
+            "type": "approve",
+        },
     ]
 
 
@@ -135,38 +135,38 @@ def test_edit_refuse_advice_post(
     assert history[5].method == "POST"
     assert history[5].json() == [
         {
-            'denial_reasons': ['3', '4', '5', '5a', '5b'],
-            'end_user': '95d3ea36-6ab9-41ea-a744-7284d17b9cc5',
-            'footnote_required': False,
-            'text': "doesn't meet the requirement",
-            'type': 'refuse'
+            "denial_reasons": ["3", "4", "5", "5a", "5b"],
+            "end_user": "95d3ea36-6ab9-41ea-a744-7284d17b9cc5",
+            "footnote_required": False,
+            "text": "doesn't meet the requirement",
+            "type": "refuse",
         },
         {
-            'consignee': 'cd2263b4-a427-4f14-8552-505e1d192bb8',
-            'denial_reasons': ['3', '4', '5', '5a', '5b'],
-            'footnote_required': False,
-            'text': "doesn't meet the requirement",
-            'type': 'refuse'
+            "consignee": "cd2263b4-a427-4f14-8552-505e1d192bb8",
+            "denial_reasons": ["3", "4", "5", "5a", "5b"],
+            "footnote_required": False,
+            "text": "doesn't meet the requirement",
+            "type": "refuse",
         },
         {
-            'denial_reasons': ['3', '4', '5', '5a', '5b'],
-            'footnote_required': False,
-            'text': "doesn't meet the requirement",
-            'third_party': '95c2d6b7-5cfd-47e8-b3c8-dc76e1ac9747',
-            'type': 'refuse'
+            "denial_reasons": ["3", "4", "5", "5a", "5b"],
+            "footnote_required": False,
+            "text": "doesn't meet the requirement",
+            "third_party": "95c2d6b7-5cfd-47e8-b3c8-dc76e1ac9747",
+            "type": "refuse",
         },
         {
-            'denial_reasons': ['3', '4', '5', '5a', '5b'],
-            'footnote_required': False,
-            'good': '9fbffa7f-ef50-402e-93ac-2f3f37d09030',
-            'text': "doesn't meet the requirement",
-            'type': 'refuse'
+            "denial_reasons": ["3", "4", "5", "5a", "5b"],
+            "footnote_required": False,
+            "good": "9fbffa7f-ef50-402e-93ac-2f3f37d09030",
+            "text": "doesn't meet the requirement",
+            "type": "refuse",
         },
         {
-            'denial_reasons': ['3', '4', '5', '5a', '5b'],
-            'footnote_required': False,
-            'good': 'd4feac1e-851d-41a5-b833-eb28addb8547',
-            'text': "doesn't meet the requirement",
-            'type': 'refuse'
-        }
+            "denial_reasons": ["3", "4", "5", "5a", "5b"],
+            "footnote_required": False,
+            "good": "d4feac1e-851d-41a5-b833-eb28addb8547",
+            "text": "doesn't meet the requirement",
+            "type": "refuse",
+        },
     ]

--- a/unit_tests/caseworker/advice/views/test_give_approval_advice_view.py
+++ b/unit_tests/caseworker/advice/views/test_give_approval_advice_view.py
@@ -1,9 +1,11 @@
+from unittest import mock
+
 import pytest
 
 from django.urls import reverse
 
 from core import client
-from unit_tests.caseworker.conftest import standard_case_pk
+from unit_tests.caseworker.conftest import mock_gov_user, standard_case_pk
 
 
 @pytest.fixture(autouse=True)
@@ -27,3 +29,48 @@ def test_select_advice_post(authorized_client, requests_mock, data_standard_case
     data = {"approval_reasons": "meets the requirements", "instructions_to_exporter": "no specific instructions"}
     response = authorized_client.post(url, data=data)
     assert response.status_code == 302
+
+
+@mock.patch("caseworker.advice.views.get_gov_user")
+def test_fco_give_approval_advice_get(mock_get_gov_user, authorized_client, url):
+    mock_get_gov_user.return_value = ({"user": {"team": {"name": "FCO"}}}, None)
+    response = authorized_client.get(url)
+    assert response.status_code == 200
+    assert "countries" in response.context_data["form"].fields
+    assert response.context_data["form"].fields["countries"].choices == [
+        ("GB", "United Kingdom"),
+        ("AE-AZ", "Abu Dhabi"),
+    ]
+
+
+@pytest.mark.parametrize(
+    "countries, approval_reasons, expected_status_code",
+    [
+        # Valid form
+        (["GB"], "test", 302),
+        # Valid form with 2 countries
+        (["GB", "AE-AZ"], "test", 302),
+        # Invalid form - missing countries
+        ([], "test", 200),
+        # Invalid form - missing approval_reasons
+        (["GB"], "", 200),
+        # Invalid form - missing countries & approval_reasons
+        ([], "", 200),
+    ],
+)
+@mock.patch("caseworker.advice.views.get_gov_user")
+def test_fco_give_approval_advice_post(
+    mock_get_gov_user,
+    authorized_client,
+    requests_mock,
+    data_standard_case,
+    url,
+    countries,
+    approval_reasons,
+    expected_status_code,
+):
+    mock_get_gov_user.return_value = ({"user": {"team": {"name": "FCO"}}}, None)
+    requests_mock.post(f"/cases/{data_standard_case['case']['id']}/user-advice/", json={})
+    data = {"approval_reasons": approval_reasons, "countries": countries}
+    response = authorized_client.post(url, data=data)
+    assert response.status_code == expected_status_code

--- a/unit_tests/caseworker/advice/views/test_refusal_advice_view.py
+++ b/unit_tests/caseworker/advice/views/test_refusal_advice_view.py
@@ -1,3 +1,4 @@
+from unittest import mock
 import pytest
 
 from django.urls import reverse
@@ -35,4 +36,49 @@ def test_refuse_all_get(authorized_client, url):
 )
 def test_refuse_all_post(authorized_client, url, denial_reasons, refusal_reasons, expected_status_code):
     response = authorized_client.post(url, data={"denial_reasons": denial_reasons, "refusal_reasons": refusal_reasons})
+    assert response.status_code == expected_status_code
+
+
+@mock.patch("caseworker.advice.views.get_gov_user")
+def test_fco_give_refusal_advice_get(mock_get_gov_user, authorized_client, url):
+    mock_get_gov_user.return_value = ({"user": {"team": {"name": "FCO"}}}, None)
+    response = authorized_client.get(url)
+    assert response.status_code == 200
+    assert "countries" in response.context_data["form"].fields
+    assert response.context_data["form"].fields["countries"].choices == [
+        ("GB", "United Kingdom"),
+        ("AE-AZ", "Abu Dhabi"),
+    ]
+
+
+@pytest.mark.parametrize(
+    "countries, refusal_reasons, expected_status_code",
+    [
+        # Valid form
+        (["GB"], "test", 302),
+        # Valid form with 2 countries
+        (["GB", "AE-AZ"], "test", 302),
+        # Invalid form - missing countries
+        ([], "test", 200),
+        # Invalid form - missing approval_reasons
+        (["GB"], "", 200),
+        # Invalid form - missing countries & approval_reasons
+        ([], "", 200),
+    ],
+)
+@mock.patch("caseworker.advice.views.get_gov_user")
+def test_fco_give_approval_advice_post(
+    mock_get_gov_user,
+    authorized_client,
+    requests_mock,
+    data_standard_case,
+    url,
+    countries,
+    refusal_reasons,
+    expected_status_code,
+):
+    mock_get_gov_user.return_value = ({"user": {"team": {"name": "FCO"}}}, None)
+    requests_mock.post(f"/cases/{data_standard_case['case']['id']}/user-advice/", json={})
+    data = {"denial_reasons": ["1"], "refusal_reasons": refusal_reasons, "countries": countries}
+    response = authorized_client.post(url, data=data)
     assert response.status_code == expected_status_code


### PR DESCRIPTION
This one does a bunch of interesting things. E.g. -

1. Checks for `FCO` users and renders a different form for them by overriding the `get_form` method.
2. It adds a method to `CaseMixin` that returns the list of countries for which advice has not been given (yet).

