### PR TITLE
LTD-1238: Add option to return to advisor when countersign is refused

### DIFF
--- a/caseworker/advice/forms.py
+++ b/caseworker/advice/forms.py
@@ -126,15 +126,23 @@ class CountersignAdviceForm(forms.Form):
         label="Explain why this recommendation needs to be sent back to the advisor",
     )
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, queues, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.helper = FormHelper()
         self.helper.form_tag = False
+
+        choices = [("", "")] + [(q[0], q[1]) for q in queues]
+        self.fields["queue_to_return"] = forms.ChoiceField(
+            required=False, label="Choose where to return this recommendation", choices=choices
+        )
 
     def clean(self):
         cleaned_data = super().clean()
         option_selected = cleaned_data.get("agree_with_recommendation")
         if option_selected == "yes" and cleaned_data.get("approval_reasons") == "":
             self.add_error("approval_reasons", "Enter your reasons for agreeing with the recommendation")
-        if option_selected == "no" and cleaned_data.get("refusal_reasons") == "":
-            self.add_error("refusal_reasons", "Enter why you do not agree with the recommendation")
+        if option_selected == "no":
+            if cleaned_data.get("refusal_reasons") == "":
+                self.add_error("refusal_reasons", "Enter why you do not agree with the recommendation")
+            if cleaned_data.get("queue_to_return") == "":
+                self.add_error("queue_to_return", "Select where you want to return this recommendation")

--- a/caseworker/teams/services.py
+++ b/caseworker/teams/services.py
@@ -18,10 +18,11 @@ def get_teams(request, converted_to_options=False):
 
 
 def get_users_team_queues(request, user, convert_to_options=True):
-    data = client.get(request, f"/users/{user}/team-queues/").json()
+    data = client.get(request, f"/users/{user}/team-queues/")
     if convert_to_options:
+        data = data.json()
         return [Option(key=queue[0], value=queue[1], description=None) for queue in data["queues"]]
-    return data, data.status_code
+    return data.json(), data.status_code
 
 
 def post_teams(request, json):

--- a/unit_tests/caseworker/advice/views/test_countersign.py
+++ b/unit_tests/caseworker/advice/views/test_countersign.py
@@ -38,6 +38,9 @@ def test_countersign_approve_all_put(
     requests_mock.get(
         client._build_absolute_uri(f"/gov_users/{mock_gov_user['user']['id']}"), json=mock_gov_user,
     )
+    requests_mock.get(
+        client._build_absolute_uri(f"/users/{mock_gov_user['user']['id']}/"), json={},
+    )
 
     user_team_advice = services.filter_advice_by_users_team(advice_for_countersign, mock_gov_user["user"])
     advice_to_countersign = services.filter_advice_by_level(user_team_advice, ["user"])
@@ -49,16 +52,20 @@ def test_countersign_approve_all_put(
         "form-MAX_NUM_FORMS": [f"{len(advice_to_countersign)}"],
         "submit": ["Submit"],
     }
-    for index, item in enumerate(advice_for_countersign):
+    for index, item in enumerate(advice_to_countersign):
         data[f"form-{index}-agree_with_recommendation"] = ["yes"]
         data[f"form-{index}-approval_reasons"] = [f"reason{index + 1}"]
+        requests_mock.get(
+            client._build_absolute_uri(f"/users/{item['user']['id']}/team-queues/"), json={"queues": []},
+        )
 
     response = authorized_client.post(url, data=data)
     assert response.status_code == 302
-    history = requests_mock.request_history
-    assert countersign_advice_url in history[5].url
-    assert history[5].method == "PUT"
-    assert history[5].json() == [
+    history = [item for item in requests_mock.request_history if countersign_advice_url in item.url]
+    assert len(history) == 1
+    history = history[0]
+    assert history.method == "PUT"
+    assert history.json() == [
         {
             "id": "b32d7dfa-a90d-4b37-adac-db231d4b83be",
             "countersigned_by": "2a43805b-c082-47e7-9188-c8b3e1a83cb0",
@@ -70,3 +77,78 @@ def test_countersign_approve_all_put(
             "countersign_comments": "reason2",
         },
     ]
+
+
+def test_countersign_refuse_all_put(
+    authorized_client,
+    requests_mock,
+    data_standard_case,
+    standard_case_with_advice,
+    advice_for_countersign,
+    mock_gov_user,
+    url,
+):
+    countersign_advice_url = f"/cases/{data_standard_case['case']['id']}/countersign-advice/"
+    case_queues_url = f"/cases/{data_standard_case['case']['id']}/queues/"
+    requests_mock.put(client._build_absolute_uri(countersign_advice_url), json={})
+    case_data = deepcopy(data_standard_case)
+    case_data["case"]["data"]["goods"] = standard_case_with_advice["data"]["goods"]
+    case_data["case"]["advice"] = advice_for_countersign
+
+    requests_mock.get(client._build_absolute_uri(f"/cases/{data_standard_case['case']['id']}"), json=case_data)
+    requests_mock.get(
+        client._build_absolute_uri(f"/gov_users/{mock_gov_user['user']['id']}"), json=mock_gov_user,
+    )
+    requests_mock.get(
+        client._build_absolute_uri(f"/users/{mock_gov_user['user']['id']}/"), json={},
+    )
+    requests_mock.put(
+        client._build_absolute_uri(case_queues_url), json={},
+    )
+
+    user_team_advice = services.filter_advice_by_users_team(advice_for_countersign, mock_gov_user["user"])
+    advice_to_countersign = services.filter_advice_by_level(user_team_advice, ["user"])
+    queues = [(item["id"], f"Queue {index}") for index, item in enumerate(advice_to_countersign, start=1)]
+
+    data = {
+        "form-TOTAL_FORMS": [f"{len(advice_to_countersign)}"],
+        "form-INITIAL_FORMS": ["0"],
+        "form-MIN_NUM_FORMS": [f"{len(advice_to_countersign)}"],
+        "form-MAX_NUM_FORMS": [f"{len(advice_to_countersign)}"],
+        "submit": ["Submit"],
+    }
+    for index, item in enumerate(advice_to_countersign):
+        data[f"form-{index}-agree_with_recommendation"] = ["no"]
+        data[f"form-{index}-refusal_reasons"] = [f"reason{index + 1}"]
+        data[f"form-{index}-queue_to_return"] = [item["id"]]  # item id is used as queue identifier
+        requests_mock.get(
+            client._build_absolute_uri(f"/users/{item['user']['id']}/team-queues/"), json={"queues": queues},
+        )
+
+    response = authorized_client.post(url, data=data)
+    assert response.status_code == 302
+    history = [item for item in requests_mock.request_history if countersign_advice_url in item.url]
+    assert len(history) == 1
+    history = history[0]
+    assert history.method == "PUT"
+    assert history.json() == [
+        {
+            "id": "b32d7dfa-a90d-4b37-adac-db231d4b83be",
+            "countersigned_by": "2a43805b-c082-47e7-9188-c8b3e1a83cb0",
+            "countersign_comments": "reason1",
+        },
+        {
+            "id": "c9a96d84-6a6b-421d-bbbb-b12b9577d46e",
+            "countersigned_by": "2a43805b-c082-47e7-9188-c8b3e1a83cb0",
+            "countersign_comments": "reason2",
+        },
+    ]
+
+    # assert requests are made to update case queues
+    history = [item for item in requests_mock.request_history if case_queues_url in item.url]
+    assert len(history) == 1
+    history = history[0]
+    assert history.method == "PUT"
+    assert history.json() == {
+        "queues": ["b32d7dfa-a90d-4b37-adac-db231d4b83be", "c9a96d84-6a6b-421d-bbbb-b12b9577d46e"]
+    }


### PR DESCRIPTION
Update form to select the queue to be returned to in case countersign
is refused. Case gets moved to the selected queue if countersigning is
refused.