### PR TITLE
Add views for countersign and consolidate advice.

### DIFF
--- a/caseworker/advice/templates/advice/view-advice.html
+++ b/caseworker/advice/templates/advice/view-advice.html
@@ -8,7 +8,13 @@
 
 {% block full_width %}
 {% if grouped_advice %}
-<a draggable="false" class="govuk-button govuk-button--primary" href="{% url 'cases:select_advice' queue_pk case.id %}">Give advice</a>
+  {% if countersign %}
+  <a draggable="false" class="govuk-button govuk-button--primary" href="{% url 'cases:countersign_review' queue_pk case.id %}">Review advice</a>
+  {% elif consolidate %}
+  <a draggable="false" class="govuk-button govuk-button--primary" href="#put-link-to-consolidate-view-here-when-ready">Combine advice</a>
+  {% else %}
+  <a draggable="false" class="govuk-button govuk-button--primary" href="{% url 'cases:select_advice' queue_pk case.id %}">Give advice</a>
+  {% endif %}
 
 <h2 class="govuk-heading-m">Other recommendations for this case</h2>
 

--- a/caseworker/advice/urls.py
+++ b/caseworker/advice/urls.py
@@ -11,7 +11,9 @@ urlpatterns = [
     path("view-my-advice/", views.AdviceDetailView.as_view(), name="view_my_advice"),
     path("edit-advice/", views.EditAdviceView.as_view(), name="edit_advice"),
     path("delete-advice/", views.DeleteAdviceView.as_view(), name="delete_advice"),
+    path("countersign/", views.CountersignAdviceView.as_view(), name="countersign_advice_view"),
     path("countersign/review-advice/", views.ReviewCountersignView.as_view(), name="countersign_review"),
     path("countersign/view-advice/", views.ViewCountersignedAdvice.as_view(), name="countersign_view"),
     path("countersign/edit-advice", views.CountersignEditAdviceView.as_view(), name="countersign_edit"),
+    path("consolidate/", views.ConsolidateAdviceView.as_view(), name="consolidate_advice_view"),
 ]

--- a/caseworker/advice/views.py
+++ b/caseworker/advice/views.py
@@ -350,3 +350,13 @@ class CountersignEditAdviceView(EditAdviceView):
 
     def get_context(self, **kwargs):
         return {**super().get_context(), "subtitle": self.subtitle, "edit": True}
+
+
+class CountersignAdviceView(AdviceView):
+    def get_context(self, **kwargs):
+        return {**super().get_context(**kwargs), "countersign": True}
+
+
+class ConsolidateAdviceView(AdviceView):
+    def get_context(self, **kwargs):
+        return {**super().get_context(**kwargs), "consolidate": True}

--- a/unit_tests/caseworker/advice/views/test_view_ogd_advice.py
+++ b/unit_tests/caseworker/advice/views/test_view_ogd_advice.py
@@ -155,25 +155,32 @@ def data_case_advice(
     ]
 
 
-def test_advice_view_200(mock_queue, mock_case, authorized_client, data_queue, data_standard_case):
-    url = reverse("cases:advice_view", kwargs={"queue_pk": data_queue["id"], "pk": data_standard_case["case"]["id"]})
+@pytest.fixture(params=("advice_view", "countersign_advice_view", "consolidate_advice_view"))
+def url(request, data_queue, data_standard_case):
+    return reverse(
+        f"cases:{request.param}", kwargs={"queue_pk": data_queue["id"], "pk": data_standard_case["case"]["id"]}
+    )
+
+
+def test_advice_view_200(mock_queue, mock_case, authorized_client, data_queue, data_standard_case, url):
     response = authorized_client.get(url)
     assert response.status_code == 200
 
 
-def test_advice_view_heading_no_advice(requests_mock, mock_queue, authorized_client, data_queue, data_standard_case):
+def test_advice_view_heading_no_advice(
+    requests_mock, mock_queue, authorized_client, data_queue, data_standard_case, url
+):
     case_url = client._build_absolute_uri(f"/cases/{data_standard_case['case']['id']}/")
     # data_standard_case has no advice
     requests_mock.get(url=case_url, json=data_standard_case)
 
-    url = reverse("cases:advice_view", kwargs={"queue_pk": data_queue["id"], "pk": data_standard_case["case"]["id"]})
     response = authorized_client.get(url)
     soup = BeautifulSoup(response.content, "html.parser")
     assert "There is no advice for this case yet" in soup.find("h2")
 
 
 def test_advice_view_heading_ogd_advice(
-    requests_mock, mock_queue, authorized_client, data_queue, data_standard_case, data_case_advice
+    requests_mock, mock_queue, authorized_client, data_queue, data_standard_case, data_case_advice, url
 ):
     case_url = client._build_absolute_uri(f"/cases/{data_standard_case['case']['id']}/")
     requests_mock.get(url=case_url, json=data_standard_case)
@@ -183,7 +190,6 @@ def test_advice_view_heading_ogd_advice(
     case_url = client._build_absolute_uri(f"/cases/{data_standard_case['case']['id']}/")
     requests_mock.get(url=case_url, json=case_data)
 
-    url = reverse("cases:advice_view", kwargs={"queue_pk": data_queue["id"], "pk": data_standard_case["case"]["id"]})
     response = authorized_client.get(url)
     soup = BeautifulSoup(response.content, "html.parser")
     assert "Other recommendations for this case" in soup.find("h2")
@@ -206,6 +212,7 @@ def test_advice_view_heading_ogd_advice_data(
     third_party_advice2,
     goods_advice1,
     goods_advice2,
+    url,
 ):
     case_url = client._build_absolute_uri(f"/cases/{data_standard_case['case']['id']}/")
     requests_mock.get(url=case_url, json=data_standard_case)
@@ -224,7 +231,6 @@ def test_advice_view_heading_ogd_advice_data(
     case_url = client._build_absolute_uri(f"/cases/{data_standard_case['case']['id']}/")
     requests_mock.get(url=case_url, json=case_data)
 
-    url = reverse("cases:advice_view", kwargs={"queue_pk": data_queue["id"], "pk": data_standard_case["case"]["id"]})
     response = authorized_client.get(url)
 
     exp_advice = [


### PR DESCRIPTION
Started this as `LTD-1232` but it seemed that it would be uncontroversial to address `LTD-1230` here as well.

As usual, I have taken some liberties in deviating from designs where I felt that I could keep the functionality and address the semantics in a follow-up ticket.