### PR TITLE
[LTD-1342] Move case forward

### DIFF
--- a/caseworker/advice/forms.py
+++ b/caseworker/advice/forms.py
@@ -181,3 +181,10 @@ class FCDORefusalAdviceForm(RefusalAdviceForm):
             label="Select countries for which you want to give advice",
         )
         self.helper.layout = Layout("countries", "denial_reasons", "refusal_reasons", Submit("submit", "Submit"))
+
+
+class MoveCaseForwardForm(forms.Form):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper = FormHelper()
+        self.helper.layout = Layout(Submit("submit", "Move case forward"))

--- a/caseworker/advice/services.py
+++ b/caseworker/advice/services.py
@@ -1,4 +1,3 @@
-
 from requests.exceptions import HTTPError
 
 from core import client
@@ -51,7 +50,11 @@ def get_advice_subjects(case, countries=None):
             if dest["country"]["id"] not in countries:
                 continue
         destinations.append((dest["type"], dest["id"]))
-    goods = [("good", good["id"]) for good in case.goods if good["is_good_controlled"]["key"] == "True"]
+    goods = [
+        ("good", good["id"])
+        for good in case.goods
+        if (good.get("is_good_controlled") or {"key": None})["key"] == "True"
+    ]
     return destinations + goods
 
 

--- a/caseworker/advice/services.py
+++ b/caseworker/advice/services.py
@@ -1,3 +1,6 @@
+
+from requests.exceptions import HTTPError
+
 from core import client
 from caseworker.cases.services import put_case_queues
 
@@ -124,3 +127,15 @@ def countersign_advice(request, case, caseworker, formset_data):
         put_case_queues(request, case_pk, json={"queues": queues})
 
     return response.json(), response.status_code
+
+
+def move_case_forward(request, case_id, queue_id):
+    """This utility function calls the /assigned-queues/ endpoint in the API.
+    In turn, /assigned-queues/ runs the routing rules and moves the case forward.
+    """
+    response = client.put(request, f"/cases/{case_id}/assigned-queues/", {"queues": [queue_id]})
+    try:
+        response.raise_for_status()
+    except HTTPError as e:
+        raise HTTPError(response=response) from e
+    return response.json()

--- a/caseworker/advice/templates/advice/view_my_advice.html
+++ b/caseworker/advice/templates/advice/view_my_advice.html
@@ -5,6 +5,20 @@
 <div class="govuk-width-container">
     <a href="#" class="govuk-back-link">Back</a>
     <main class="govuk-main-wrapper">
+        {% for error in form.non_field_errors %}
+        <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+          <h2 class="govuk-error-summary__title" id="error-summary-title">
+            There is a problem
+          </h2>
+          <div class="govuk-error-summary__body">
+            <ul class="govuk-list govuk-error-summary__list">
+              <li>
+                {{ error }}
+              </li>
+            </ul>
+          </div>
+        </div>
+        {% endfor %}
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-three-quarters">
               <h1 class="govuk-heading-xl">View Advice</h1>
@@ -29,13 +43,8 @@
               {% endif %}
             </div>
             <div class="govuk-grid-column-one-quarter">
-              {% if my_advice|length %}
-                <a role="button" draggable="false" class="govuk-button" href="#move-forward">
-                    Move case forward
-                    <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="13" height="15" viewBox="0 0 33 43" aria-hidden="true" focusable="false">
-                      <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
-                    </svg>
-                </a>
+              {% if my_advice|length and advice_completed %}
+                {% crispy form %}
               {% endif %}
             </div>
         </div>

--- a/caseworker/advice/views.py
+++ b/caseworker/advice/views.py
@@ -36,7 +36,7 @@ class CaseContextMixin:
 
     def unadvised_countries(self):
         """Returns a dict of countries for which advice has not been given"""
-        dest_types = ("end_user", "ultimate_end_user", "consignee", "third_parties")
+        dest_types = ("end_user", "ultimate_end_user", "consignee", "third_party")
         dests = {advice.get(dest_type) for dest_type in dest_types for advice in self.case.advice} - {None}
         return {
             dest["country"]["id"]: dest["country"]["name"] for dest in self.case.destinations if dest["id"] not in dests


### PR DESCRIPTION
We were using system flags to ensure that the case is only moved to countersigning queue when we have advice for all destinations.

While working on it, I realized - the routing is run when the user presses the `I am Done` button. What if we could hide/disable the button until we have advice for all the destinations?

If we could do this (this PR), we don’t need any routing changes or create new system flags, etc.

Just one little thing that is bothering me - when this button is disabled, we should probably display a message that tells users why it is disabled.