### PR TITLE
Additions to test-suite and lite forms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 ui_tests/test_results/*
+ui_tests/screenshots/*
 
 # Translations
 *.mo

--- a/README.md
+++ b/README.md
@@ -99,9 +99,10 @@ We use pytest + Selenium for end-to-end tests.
 
 Run all tests
 
-    PIPENV_DOTENV_LOCATION=exporter.env ENVIRONMENT=local pipenv run pytest ui_tests/
+    PIPENV_DOTENV_LOCATION=exporter.env ENVIRONMENT=local pipenv run pytest ui_tests/exporter
+    PIPENV_DOTENV_LOCATION=caseworker.env ENVIRONMENT=local pipenv run pytest ui_tests/caseworker
 
-> You can use the flags `--step-through` (in conjunction with `-s`) and `--step-verbose` to stop on each step. Helpful for exploration and debugging.
+> You can use the flags `--step-through` (in conjunction with `-s`) to stop on each step. Helpful for exploration and debugging.
 
 > The UI tests (a.k.a. end-to-end tests, e2e tests, browser tests or functional tests) require some local configuration
 changes before they can run. As mentioned above, you need to run `make run_caseworker` and `make run_exporter`.

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,6 @@
+DEBUG = False
+
+
+def pytest_configure(config):
+    global DEBUG  # pylint: disable=global-statement
+    DEBUG = config.option.debug

--- a/core/helpers.py
+++ b/core/helpers.py
@@ -19,3 +19,12 @@ def convert_value_to_query_param(key: str, value):
     if value is None:
         return ""
     return urlencode({key: value}, doseq=True, quote_via=dummy_quote)
+
+
+def parse_boolean(value):
+    if isinstance(value, str):
+        if value.lower() in ("yes", "true"):
+            return True
+        else:
+            return False
+    return value

--- a/core/helpers.py
+++ b/core/helpers.py
@@ -1,5 +1,4 @@
 from urllib.parse import urlencode
-from functools import lru_cache
 
 
 def dummy_quote(string, safe="", encoding=None, errors=None):
@@ -29,23 +28,3 @@ def parse_boolean(value):
         else:
             return False
     return value
-
-
-cache = lru_cache  # TODO: Remove this once we hit python3.8
-
-
-class cached_property:
-    """
-    SRC: https://stackoverflow.com/questions/4037481/caching-class-attributes-in-python
-
-    TODO: Remove this once we hit python3.8
-    """
-
-    def __init__(self, factory):
-        self._attr_name = factory.__name__
-        self._factory = factory
-
-    def __get__(self, instance, owner):
-        attr = self._factory(instance)
-        setattr(instance, self._attr_name, attr)
-        return attr

--- a/core/helpers.py
+++ b/core/helpers.py
@@ -1,4 +1,5 @@
 from urllib.parse import urlencode
+from functools import lru_cache
 
 
 def dummy_quote(string, safe="", encoding=None, errors=None):
@@ -28,3 +29,23 @@ def parse_boolean(value):
         else:
             return False
     return value
+
+
+cache = lru_cache  # TODO: Remove this once we hit python3.8
+
+
+class cached_property:
+    """
+    SRC: https://stackoverflow.com/questions/4037481/caching-class-attributes-in-python
+
+    TODO: Remove this once we hit python3.8
+    """
+
+    def __init__(self, factory):
+        self._attr_name = factory.__name__
+        self._factory = factory
+
+    def __get__(self, instance, owner):
+        attr = self._factory(instance)
+        setattr(instance, self._attr_name, attr)
+        return attr

--- a/core/tests/test_helpers.py
+++ b/core/tests/test_helpers.py
@@ -1,0 +1,12 @@
+from core.helpers import parse_boolean
+
+
+def test_parse_boolean():
+    assert parse_boolean(True) == True
+    assert parse_boolean(False) == False
+    assert parse_boolean("yes") == True
+    assert parse_boolean("no") == False
+    assert parse_boolean("YES") == True
+    assert parse_boolean("NO") == False
+    assert parse_boolean("true") == True
+    assert parse_boolean("false") == False

--- a/exporter/applications/services.py
+++ b/exporter/applications/services.py
@@ -6,6 +6,7 @@ from django.http import StreamingHttpResponse
 from django.conf import settings
 
 from core import client
+from core.helpers import parse_boolean
 from exporter.applications.helpers.date_fields import (
     format_date_fields,
     format_date,

--- a/exporter/applications/services.py
+++ b/exporter/applications/services.py
@@ -6,7 +6,6 @@ from django.http import StreamingHttpResponse
 from django.conf import settings
 
 from core import client
-from core.helpers import parse_boolean
 from exporter.applications.helpers.date_fields import (
     format_date_fields,
     format_date,

--- a/lite_forms/components.py
+++ b/lite_forms/components.py
@@ -3,9 +3,7 @@ from enum import Enum
 from django.conf import settings
 from typing import List, Optional, Dict, Set
 
-from core.helpers import cached_property, cache
 from lite_forms.styles import ButtonStyle
-from lite_forms.exceptions import NoMatchingForm
 
 
 class _Component:

--- a/lite_forms/exceptions.py
+++ b/lite_forms/exceptions.py
@@ -1,0 +1,4 @@
+class NoMatchingForm(Exception):
+    """ Raised when form can't be retrieved for some reason"""
+
+    pass  # noqa

--- a/lite_forms/tests.py
+++ b/lite_forms/tests.py
@@ -32,20 +32,6 @@ from lite_forms.helpers import (
 )
 from lite_forms.templatetags import custom_tags
 from lite_forms.templatetags.custom_tags import prefix_dots
-from lite_forms.views import FormView
-
-
-class FormViewTests(TestCase):
-    def test_parse_boolean(self):
-        parse_boolean = FormView().parse_boolean
-        assert parse_boolean(True) == True
-        assert parse_boolean(False) == False
-        assert parse_boolean("yes") == True
-        assert parse_boolean("no") == False
-        assert parse_boolean("YES") == True
-        assert parse_boolean("NO") == False
-        assert parse_boolean("true") == True
-        assert parse_boolean("false") == False
 
 
 class FormTests(TestCase):

--- a/lite_forms/views.py
+++ b/lite_forms/views.py
@@ -1,5 +1,4 @@
 import copy
-from core.helpers import cached_property, cache
 from abc import ABC
 from typing import List
 
@@ -21,7 +20,6 @@ from lite_forms.helpers import (
     validate_data_unknown,
 )
 from lite_forms.submitters import submit_paged_form
-from lite_forms.exceptions import NoMatchingForm
 
 ACTION = "_action"
 VALIDATE_ONLY = "validate_only"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,8 @@ target-version = ['py36', 'py37', 'py38']
 include = '\.pyi?$'
 exclude = '''
 /(
-    \.eggs
-  | \.git
+    \.eggs        # exclude a few common directories in the
+  | \.git         # root of the project
   | \.hg
   | \.mypy_cache
   | \.tox
@@ -20,5 +20,6 @@ exclude = '''
   | build
   | dist
 )/
+|  tests_.*/
+|  .*_tests/
 '''
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,4 @@ exclude = '''
   | build
   | dist
 )/
-|  tests_.*/
-|  .*_tests/
 '''

--- a/tests_common/api_client/api_client.py
+++ b/tests_common/api_client/api_client.py
@@ -63,23 +63,28 @@ class ApiClient:
         if not response.ok:
             MAX_PAGE_DUMP = 1000
             if len(response.text) > MAX_PAGE_DUMP:
-                i1 = MAX_PAGE_DUMP//2
+                i1 = MAX_PAGE_DUMP // 2
                 i2 = -i1
                 trimmed_body = (
-                    response.text[:i1] +
-                    "\n. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .\n" +
-                    response.text[i2:]
+                    response.text[:i1]
+                    + "\n. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .\n"
+                    + response.text[i2:]
                 )
             else:
                 trimmed_body = response.text
-            error_message = f"{response.status_code} @ {response.request.method} {response.request.url}\n\n{trimmed_body}"
+            error_message = (
+                f"{response.status_code} @ {response.request.method} {response.request.url}\n\n{trimmed_body}"
+            )
 
             from conftest import DEBUG  # noqa
             from ui_tests.conftest import print_scenario_history_last_entry
+
             if DEBUG:
                 print_scenario_history_last_entry()
                 print(f"\n***** ERROR: {__file__} {error_message}")
-                import IPython; IPython.embed(using=False)
+                import IPython
+
+                IPython.embed(using=False)
 
             raise Exception(error_message)
         return response

--- a/tests_common/tools/wait.py
+++ b/tests_common/tools/wait.py
@@ -9,6 +9,9 @@ FUNCTION_RETRY_INTERVAL = 1  # How frequently in seconds the function should be 
 
 
 def wait_for_function(callback_function, **kwargs):
+    """
+    Will call the function until it returns True
+    """
     time_no = 0
     while time_no < TIMEOUT_LIMIT:
         if callback_function(**kwargs):

--- a/ui_tests/conftest.py
+++ b/ui_tests/conftest.py
@@ -38,7 +38,7 @@ def pytest_bdd_before_step_call(request, feature, scenario, step, step_func, ste
     if feature not in SCENARIO_HISTORY:
         if STEP_VERBOSE or STEP_THROUGH:
             print()
-            print("*"*FEATURE_DIVIDER_LEN)
+            print("*" * FEATURE_DIVIDER_LEN)
             print()
             print(f"FEATURE: {scenario.feature.description}")
         SCENARIO_HISTORY[feature] = {}
@@ -93,9 +93,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--step-verbose", action="store_true", default=STEP_VERBOSE, help="Print each step before executing it"
     )
-    parser.addoption(
-        "--step-delay", action="store", default=STEP_DELAY, help="Delay in secs between steps"
-    )
+    parser.addoption("--step-delay", action="store", default=STEP_DELAY, help="Delay in secs between steps")
     if env == "local":
         parser.addoption(
             "--exporter_url", action="store", default=f"http://localhost:{str(os.environ.get('PORT'))}/", help="url"

--- a/ui_tests/conftest.py
+++ b/ui_tests/conftest.py
@@ -3,7 +3,7 @@ from time import sleep
 from collections import OrderedDict
 
 import tests_common.tools.helpers as utils
-from ui_tests.step_defs import *
+from ui_tests.step_defs import *  # noqa
 
 
 STEP_THROUGH = False  # Gives a prompt for every step in the terminal

--- a/ui_tests/step_defs.py
+++ b/ui_tests/step_defs.py
@@ -1,0 +1,71 @@
+import os.path
+from os.path import abspath, relpath, dirname
+
+from pytest_bdd import given, when, then, parsers
+
+RESOURCES_PATH = os.path.join(dirname(__file__), "resources")
+
+
+def get_elements_by_visible_text(driver, text):
+    return driver.find_elements_by_xpath(f"//*[contains(text(),'{text}')]")
+
+
+def get_element_by_visible_text(driver, text):
+    found_elements = get_elements_by_visible_text(driver, text)
+    if not found_elements:
+        raise Exception(f"No element found with text '{text}'")
+    if len(found_elements) > 1:
+        raise Exception(f"Too many elements found with text '{text}'. Be more specific")
+    element = found_elements[0]
+    assert element.text == text
+    return element
+
+
+def get_child_by_visible_text(driver, parent_visible_text, child_visible_text):
+    xpath = f"//*[contains(text(), '{parent_visible_text}')]/parent::*//*[contains(text(), '{child_visible_text}')]"
+    found_elements = driver.find_elements_by_xpath(xpath)
+    if not found_elements:
+        raise Exception(f"No element found with xpath '{xpath}'")
+    if len(found_elements) > 1:
+        raise Exception(f"Too many elements found with xpath '{xpath}'. Be more specific")
+    element = found_elements[0]
+    assert element.text == child_visible_text
+    return element
+
+
+# ------------------------------------------------ Steps ---------------------------------------------------------------
+
+
+@then("debug")
+def then_debug(context):
+    import IPython; IPython.embed(using=False)
+
+
+@when("debug")
+def when_debug(context):
+    import IPython; IPython.embed(using=False)
+
+
+@when(parsers.parse("I select \"{selection_text}\" when asked \"{question_text}\""))
+def select_from_radio(selection_text, question_text, driver, context):
+    element = get_child_by_visible_text(driver, question_text, selection_text)
+    element.click()
+
+
+@when(parsers.parse("I attach \"{file_name}\" into \"{element_id}\""))
+def attach_file(file_name, element_id, driver, context):
+    element = driver.find_element_by_id(element_id)
+    file_path = os.path.join(RESOURCES_PATH, file_name)
+    element.send_keys(file_path)
+
+
+@when(parsers.parse("I click \"{text}\""))
+def click_element(text, driver, context):
+    element = get_element_by_visible_text(driver, text)
+    element.click()
+
+
+@then(parsers.parse("I see \"{text}\""))
+def see_text(text, driver, context):
+    if not get_elements_by_visible_text(driver, text):
+        raise Exception(f"Expected at least one element with text '{text}', got 0.")

--- a/ui_tests/step_defs.py
+++ b/ui_tests/step_defs.py
@@ -38,34 +38,38 @@ def get_child_by_visible_text(driver, parent_visible_text, child_visible_text):
 
 @then("debug")
 def then_debug(context):
-    import IPython; IPython.embed(using=False)
+    import IPython
+
+    IPython.embed(using=False)
 
 
 @when("debug")
 def when_debug(context):
-    import IPython; IPython.embed(using=False)
+    import IPython
+
+    IPython.embed(using=False)
 
 
-@when(parsers.parse("I select \"{selection_text}\" when asked \"{question_text}\""))
+@when(parsers.parse('I select "{selection_text}" when asked "{question_text}"'))
 def select_from_radio(selection_text, question_text, driver, context):
     element = get_child_by_visible_text(driver, question_text, selection_text)
     element.click()
 
 
-@when(parsers.parse("I attach \"{file_name}\" into \"{element_id}\""))
+@when(parsers.parse('I attach "{file_name}" into "{element_id}"'))
 def attach_file(file_name, element_id, driver, context):
     element = driver.find_element_by_id(element_id)
     file_path = os.path.join(RESOURCES_PATH, file_name)
     element.send_keys(file_path)
 
 
-@when(parsers.parse("I click \"{text}\""))
+@when(parsers.parse('I click "{text}"'))
 def click_element(text, driver, context):
     element = get_element_by_visible_text(driver, text)
     element.click()
 
 
-@then(parsers.parse("I see \"{text}\""))
+@then(parsers.parse('I see "{text}"'))
 def see_text(text, driver, context):
     if not get_elements_by_visible_text(driver, text):
         raise Exception(f"Expected at least one element with text '{text}', got 0.")

--- a/ui_tests/step_defs.py
+++ b/ui_tests/step_defs.py
@@ -1,7 +1,7 @@
 import os.path
-from os.path import abspath, relpath, dirname
+from os.path import dirname
 
-from pytest_bdd import given, when, then, parsers
+from pytest_bdd import when, then, parsers
 
 RESOURCES_PATH = os.path.join(dirname(__file__), "resources")
 


### PR DESCRIPTION
Test-suite additions

* Add `--step-delay` to delay between steps
* `--step-verbose` now prints out properly which feature/scenario/step is executed
* More concise output of a page when a test fails
* `--debug` can be used now to throw directly to the debugger on failure
* Add generic steps to make writing tests faster
* Add step `debug` to get directly to debugger as a step

LITE-form additions

* Each form in FormGroup now has `next` and `prev` to swich between forms
* A Form can now take `alias` to be used with `FormGroup.get_form()` and `MultiFormView.get_form()`
* A Form can now take `url`
* FormGroup gets `last` and `first` properties
* FormGroup is now *iterable*