### PR TITLE
Fix countersign review.

### DIFF
--- a/caseworker/advice/services.py
+++ b/caseworker/advice/services.py
@@ -60,8 +60,8 @@ def group_advice_by_user(advice):
     return result
 
 
-def get_advice_to_countersign(case, caseworker):
-    advice_by_team = filter_advice_by_users_team(case.advice, caseworker)
+def get_advice_to_countersign(advice, caseworker):
+    advice_by_team = filter_advice_by_users_team(advice, caseworker)
     user_advice = filter_advice_by_level(advice_by_team, ["user"])
     grouped_user_advice = group_advice_by_user(user_advice)
     return grouped_user_advice
@@ -139,7 +139,7 @@ def countersign_advice(request, case, caseworker, formset_data):
     case_pk = case["id"]
     advice_to_countersign = get_advice_to_countersign(case.advice, caseworker)
 
-    for index, advice in enumerate(advice_to_countersign):
+    for index, (_, user_advice) in enumerate(advice_to_countersign.items()):
         form_data = formset_data[index]
         comments = ""
         if form_data["agree_with_recommendation"] == "yes":
@@ -148,8 +148,8 @@ def countersign_advice(request, case, caseworker, formset_data):
             comments = form_data["refusal_reasons"]
             if form_data["queue_to_return"] not in queues:
                 queues.append(form_data["queue_to_return"])
-
-        data.append({"id": advice["id"], "countersigned_by": caseworker["id"], "countersign_comments": comments})
+        for advice in user_advice:
+            data.append({"id": advice["id"], "countersigned_by": caseworker["id"], "countersign_comments": comments})
 
     response = client.put(request, f"/cases/{case_pk}/countersign-advice/", data)
     response.raise_for_status()

--- a/caseworker/advice/services.py
+++ b/caseworker/advice/services.py
@@ -137,7 +137,7 @@ def countersign_advice(request, case, caseworker, formset_data):
     data = []
     queues = []
     case_pk = case["id"]
-    advice_to_countersign = get_advice_to_countersign(case, caseworker)
+    advice_to_countersign = get_advice_to_countersign(case.advice, caseworker)
 
     for index, advice in enumerate(advice_to_countersign):
         form_data = formset_data[index]

--- a/caseworker/advice/services.py
+++ b/caseworker/advice/services.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 from requests.exceptions import HTTPError
 
 from core import client
@@ -34,9 +36,35 @@ def filter_advice_by_users_team(all_advice, caseworker):
     return [advice for advice in all_advice if advice["user"]["team"]["id"] == caseworker["team"]["id"]]
 
 
+def group_advice_by_user(advice):
+    """E.g. A case with 2 destinations and 2 goods, has 4 distinct
+    advice-subjects. As a result, `post_approval_advice` &
+    `post_refusal_advice` would create 4 advice records - one for
+    each advice-subject and send it to the API.
+    The flip side to this is that e.g. the countersigner will need
+    to process each advice individually whereas according to the
+    designs, he should process the advice from a given advisor
+    as a whole.
+    This function groups the advice by users so that e.g. for
+    countersigning views etc. we can render this in a single block.
+    TODO: This is functionally similar to `group_user_advice`
+    method in `AdviceView`. We should delete that method and
+    move to this one.
+    TODO: This will break when we do approve-some-refuse-some.
+    In that case, we will need to group approve & refuse advice
+    from the same user separately i.e. group-by user & decision.
+    """
+    result = defaultdict(list)
+    for item in advice:
+        result[item["user"]["id"]].append(item)
+    return result
+
+
 def get_advice_to_countersign(case, caseworker):
-    advice_by_team = filter_advice_by_users_team(case["advice"], caseworker)
-    return filter_advice_by_level(advice_by_team, ["user"])
+    advice_by_team = filter_advice_by_users_team(case.advice, caseworker)
+    user_advice = filter_advice_by_level(advice_by_team, ["user"])
+    grouped_user_advice = group_advice_by_user(user_advice)
+    return grouped_user_advice
 
 
 def get_advice_subjects(case, countries=None):

--- a/caseworker/advice/templates/advice/advice_details.html
+++ b/caseworker/advice/templates/advice/advice_details.html
@@ -1,0 +1,140 @@
+{% with user=advice.0.user decision=advice.0.type.key %}
+<table id="table-licenceable-products-approve-all" class="govuk-table">
+    {% if decision == 'approve' or decision == 'proviso' %}
+    <h2 class="app-bg-colour--green govuk-heading-m govuk-!-padding-2">
+        Approved by {{ user|full_name }}
+    </h2>
+    {% elif decision == 'refuse' %}
+    <h2 class="govuk-heading-m app-bg-colour--red govuk-!-padding-2">
+        Refused by {{ user|full_name }}
+    </h2>
+    {% endif %}
+    <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Country</th>
+            <th scope="col" class="govuk-table__header">Type</th>
+            <th scope="col" class="govuk-table__header">Name</th>
+            <th scope="col" class="govuk-table__header">Approved products</th>
+        </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+        {% for item in advice %}
+            {% if item.consignee %}
+            {% with consignee=case.data.consignee %}
+            <tr class="govuk-table__row">
+                <td class="govuk-table__cell">{{ consignee.country.name }}</td>
+                <td class="govuk-table__cell">{{ consignee.type|sentence_case }}</td>
+                <td class="govuk-table__cell">{{ consignee.name }}</td>
+                <td class="govuk-table__cell">All</td>
+            </tr>
+            {% endwith %}
+            {% endif %}
+            {% if item.end_user %}
+            {% with end_user=case.data.end_user %}
+            <tr class="govuk-table__row">
+                <td class="govuk-table__cell">{{ end_user.country.name }}</td>
+                <td class="govuk-table__cell">{{ end_user.type|sentence_case }}</td>
+                <td class="govuk-table__cell">{{ end_user.name }}</td>
+                <td class="govuk-table__cell">All</td>
+            </tr>
+            {% endwith %}
+            {% endif %}
+            {% if item.third_party %}
+            {% with third_party=case.data.third_party %}
+            <tr class="govuk-table__row">
+                <td class="govuk-table__cell">{{ third_party.country.name }}</td>
+                <td class="govuk-table__cell">{{ third_party.type|sentence_case }}</td>
+                <td class="govuk-table__cell">{{ third_party.name }}</td>
+                <td class="govuk-table__cell">All</td>
+            </tr>
+            {% endwith %}
+            {% endif %}
+            {% if item.ultimate_end_users %}
+            {% for ultimate_end_user in case.data.ultimate_end_users %}
+            <tr class="govuk-table__row">
+                <td class="govuk-table__cell">{{ ultimate_end_user.country.name }}</td>
+                <td class="govuk-table__cell">{{ ultimate_end_user.type|sentence_case }}</td>
+                <td class="govuk-table__cell">{{ ultimate_end_user.name }}</td>
+                <td class="govuk-table__cell">All</td>
+            </tr>
+            {% endfor %}
+            {% endif %}
+        {% endfor %}
+    </tbody>
+</table>
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-three-quarters">
+        {% if advice.0.countersigned_by %}
+        <div class="govuk-!-padding-4 govuk-!-margin-bottom-2" style="border: 1px solid black;">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-three-quarters">
+                    <h2 class="govuk-heading-m">Countersigned by {{ advice.0.countersigned_by|full_name }}</h2>
+                    <p class="govuk-body">{{ advice.0.countersign_comments }}</p>
+                </div>
+            </div>
+        </div>
+        {% endif %}
+        {% if decision == 'approve' or decision == 'proviso' %}
+        <div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="Reason for approving">
+            <div class="govuk-cookie-banner__message govuk-width-container">
+                <div class="govuk-grid-row">
+                    <div class="govuk-grid-column-two-thirds">
+                        <h2 class="govuk-heading-m">Reason for approving</h2>
+                        <div class="govuk-cookie-banner__content">
+                            <p class="govuk-body">{{ advice.0.text }}</p>
+                        </div>
+                        {% if advice.0.proviso %}
+                        <h2 class="govuk-heading-m">Licence condition</h2>
+                        <div class="govuk-cookie-banner__content">
+                            <p class="govuk-body">{{ advice.0.proviso }}</p>
+                        </div>
+                        {% endif %}
+
+                        {% if advice.0.note %}
+                        <h2 class="govuk-heading-m">Additional instructions</h2>
+                        <div class="govuk-cookie-banner__content">
+                            <p class="govuk-body">{{ advice.0.note }}</p>
+                        </div>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+        </div>
+        {% elif decision == 'refuse' %}
+        <div class="govuk-cookie-banner " data-nosnippet role="region" aria-label="Reason for refusing">
+            <div class="govuk-cookie-banner__message govuk-width-container">
+              <div class="govuk-grid-row">
+                <div class="govuk-grid-column-two-thirds">
+                    <h2 class="govuk-heading-m">Reason for refusing</h2>
+                    <div class="govuk-cookie-banner__content">
+                    <p class="govuk-body">{{ advice.0.text }}</p>
+                    </div>
+                </div>
+              </div>
+            </div>
+        </div>
+        {% endif %}
+        <br><br>
+        {% if nlr_products %}
+        <table id="table-nlr-products" class="govuk-table">
+            <caption class="govuk-table__caption govuk-table__caption--m">No licence required products</caption>
+            <thead class="govuk-table__head">
+                <tr class="govuk-table__row">
+                    <th scope="col" class="govuk-table__header">Product name</th>
+                </tr>
+            </thead>
+            <tbody class="govuk-table__body">
+                {% for product in nlr_products %}
+                <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">{{ product.good.name }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% else %}
+        <h2 class="govuk-heading-m">No licence required products</h2>
+        <label class="govuk-label">None</label>
+        {% endif %}
+    </div>
+</div>
+{% endwith %}

--- a/caseworker/advice/templates/advice/advice_details.html
+++ b/caseworker/advice/templates/advice/advice_details.html
@@ -14,7 +14,12 @@
             <th scope="col" class="govuk-table__header">Country</th>
             <th scope="col" class="govuk-table__header">Type</th>
             <th scope="col" class="govuk-table__header">Name</th>
+            {% if decision == 'approve' or decision == 'proviso' %}
             <th scope="col" class="govuk-table__header">Approved products</th>
+            {% elif decision == 'refuse' %}
+            <th scope="col" class="govuk-table__header">Refused products</th>
+            <th scope="col" class="govuk-table__header">Refusal criteria</th>
+            {% endif %}
         </tr>
     </thead>
     <tbody class="govuk-table__body">
@@ -26,6 +31,9 @@
                 <td class="govuk-table__cell">{{ consignee.type|sentence_case }}</td>
                 <td class="govuk-table__cell">{{ consignee.name }}</td>
                 <td class="govuk-table__cell">All</td>
+                {% if decision == 'refuse' %}
+                <td class="govuk-table__cell">{{ item.denial_reasons|join:", "}}</td>
+                {% endif %}
             </tr>
             {% endwith %}
             {% endif %}
@@ -36,6 +44,9 @@
                 <td class="govuk-table__cell">{{ end_user.type|sentence_case }}</td>
                 <td class="govuk-table__cell">{{ end_user.name }}</td>
                 <td class="govuk-table__cell">All</td>
+                {% if decision == 'refuse' %}
+                <td class="govuk-table__cell">{{ item.denial_reasons|join:", "}}</td>
+                {% endif %}
             </tr>
             {% endwith %}
             {% endif %}
@@ -46,6 +57,9 @@
                 <td class="govuk-table__cell">{{ third_party.type|sentence_case }}</td>
                 <td class="govuk-table__cell">{{ third_party.name }}</td>
                 <td class="govuk-table__cell">All</td>
+                {% if decision == 'refuse' %}
+                <td class="govuk-table__cell">{{ item.denial_reasons|join:", "}}</td>
+                {% endif %}
             </tr>
             {% endwith %}
             {% endif %}
@@ -56,6 +70,9 @@
                 <td class="govuk-table__cell">{{ ultimate_end_user.type|sentence_case }}</td>
                 <td class="govuk-table__cell">{{ ultimate_end_user.name }}</td>
                 <td class="govuk-table__cell">All</td>
+                {% if decision == 'refuse' %}
+                <td class="govuk-table__cell">{{ item.denial_reasons|join:", "}}</td>
+                {% endif %}
             </tr>
             {% endfor %}
             {% endif %}

--- a/caseworker/advice/templates/advice/review_countersign.html
+++ b/caseworker/advice/templates/advice/review_countersign.html
@@ -4,7 +4,6 @@
 {% load static advice_tags %}
 {% load crispy_forms_tags %}
 
-
 {% block body %}
 <div class="govuk-width-container">
     {% if form.has_changed %}
@@ -15,66 +14,23 @@
     <main class="govuk-main-wrapper">
         <div class="govuk-grid-row">
             <div {% if review %} class="govuk-grid-column-two-thirds" {% else %} class="govuk-grid-column-three-quarters" {% endif %}>
-                {% if review %}
                     <h2 class="govuk-heading-xl">{{ subtitle|default:"Review and countersign" }}</h2>
                     <form action="." method="POST">
                         {{ formset.management_form|crispy }}
-                        {% if advice_to_countersign|length %}
-                            {% for advice in advice_to_countersign %}
-                                {% with form=formset|index:forloop.counter0 %}
-                                    <!-- custom layout for each form -->
-                                    {% if advice.type.key in 'approve,proviso' %}
-                                        {% include "advice/approve-advice-details.html" with display_countersign=False user=advice.user|full_name %}
-                                    {% elif advice.type.key == "refuse" %}
-                                        {% include "advice/refuse-advice-details.html" with display_countersign=False user=advice.user|full_name %}
-                                    {% endif %}
-
-                                    <br><br>
-
-                                    <!-- Render the form -->
-                                    {% crispy form %}
-
-                                    <br>
-
-                                {% endwith %}
-                            {% endfor %}
-                        {% endif %}
+                        {% for advice in advice_to_countersign %}
+                        {% include "advice/advice_details.html" %}
+                        <br><br>
+                        {% with form=formset|index:forloop.counter0 %}
+                        {% crispy form %}
+                        {% endwith %}
+                        <br>
+                        {% endfor %}
                         <div class="form-actions"> <input type="submit" name="submit" value="Submit" class="govuk-button" id="submit-id-submit"> </div>
                     </form>
-                {% else %}
-                    <a role="button" draggable="false" class="govuk-button govuk-button--secondary" href="#">
-                        Edit recommendation
-                    </a>
-                    {% if advice_to_countersign|length %}
-                        {% for advice in advice_to_countersign %}
-                            <br><br>
-                            {% if advice.type.key in 'approve,proviso' %}
-                                {% include "advice/approve-advice-details.html" with display_countersign=True user=advice.countersigned_by.team.name %}
-                            {% elif advice.type.key == "refuse" %}
-                                {% include "advice/refuse-advice-details.html" with display_countersign=True user=advice.countersigned_by.team.name %}
-                            {% endif %}
-                            <br>
-                        {% endfor %}
-                    {% endif %}
-                {% endif %}
             </div>
-
-            {% if review %}
-                <div class="govuk-grid-column-one-thirds">
-                    {% include "advice/case_detail.html" %}
-                </div>
-            {% else %}
-                <div class="govuk-grid-column-one-quarter">
-                    {% if advice_to_countersign|length %}
-                    <a role="button" draggable="false" class="govuk-button" href="#move-forward">
-                        Move case forward
-                        <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="13" height="15" viewBox="0 0 33 43" aria-hidden="true" focusable="false">
-                            <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
-                        </svg>
-                    </a>
-                    {% endif %}
-                </div>
-            {% endif %}
+            <div class="govuk-grid-column-one-thirds">
+                {% include "advice/case_detail.html" %}
+            </div>
         </div>
     </main>
 </div>

--- a/caseworker/advice/templates/advice/view_countersign.html
+++ b/caseworker/advice/templates/advice/view_countersign.html
@@ -1,0 +1,38 @@
+{% extends 'layouts/case.html' %}
+{% load static custom_tags %}
+{% load static advice_tags %}
+{% load crispy_forms_tags %}
+
+{% block body %}
+<div class="govuk-width-container">
+    {% if form.has_changed %}
+        <a href="{% url 'cases:view_my_advice' queue_pk case.id %}" class="govuk-back-link">Back</a>
+    {% else %}
+        <a href="{% url 'cases:select_advice' queue_pk case.id %}" class="govuk-back-link">Back</a>
+    {% endif %}
+    <main class="govuk-main-wrapper">
+        <div class="govuk-grid-row">
+            <div {% if review %} class="govuk-grid-column-two-thirds" {% else %} class="govuk-grid-column-three-quarters" {% endif %}>
+                <a role="button" draggable="false" class="govuk-button govuk-button--secondary" href="#">
+                    Edit recommendation
+                </a>
+                {% for advice in advice_to_countersign %}
+                    <br><br>
+                    {% include "advice/advice_details.html" %}
+                    <br>
+                {% endfor %}
+            </div>
+            <div class="govuk-grid-column-one-quarter">
+                {% if advice_to_countersign %}
+                <a role="button" draggable="false" class="govuk-button" href="#move-forward">
+                    Move case forward
+                    <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="13" height="15" viewBox="0 0 33 43" aria-hidden="true" focusable="false">
+                        <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+                    </svg>
+                </a>
+                {% endif %}
+            </div>
+        </div>
+    </main>
+</div>
+{% endblock %}

--- a/caseworker/advice/urls.py
+++ b/caseworker/advice/urls.py
@@ -14,6 +14,6 @@ urlpatterns = [
     path("countersign/", views.CountersignAdviceView.as_view(), name="countersign_advice_view"),
     path("countersign/review-advice/", views.ReviewCountersignView.as_view(), name="countersign_review"),
     path("countersign/view-advice/", views.ViewCountersignedAdvice.as_view(), name="countersign_view"),
-    path("countersign/edit-advice", views.CountersignEditAdviceView.as_view(), name="countersign_edit"),
+    path("countersign/edit-advice/", views.CountersignEditAdviceView.as_view(), name="countersign_edit"),
     path("consolidate/", views.ConsolidateAdviceView.as_view(), name="consolidate_advice_view"),
 ]

--- a/caseworker/advice/views.py
+++ b/caseworker/advice/views.py
@@ -344,17 +344,14 @@ class ReviewCountersignView(LoginRequiredMixin, CaseContextMixin, TemplateView):
 
 
 class ViewCountersignedAdvice(LoginRequiredMixin, CaseContextMixin, TemplateView):
-    template_name = "advice/review_countersign.html"
+    template_name = "advice/view_countersign.html"
 
     def get_context(self, **kwargs):
         context = super().get_context()
-        case = kwargs.get("case")
-        caseworker = self.caseworker
-
-        advice_to_countersign = services.get_advice_to_countersign(case, caseworker)
-        context["advice_to_countersign"] = advice_to_countersign
+        advice_to_countersign = services.get_advice_to_countersign(self.case, self.caseworker)
+        context["advice_to_countersign"] = advice_to_countersign.values()
         context["review"] = False
-        context["subtitle"] = f"Approved by {caseworker['team']['name']}"
+        context["subtitle"] = f"Approved by {self.caseworker['team']['name']}"
         return context
 
 

--- a/caseworker/advice/views.py
+++ b/caseworker/advice/views.py
@@ -305,19 +305,16 @@ class ReviewCountersignView(LoginRequiredMixin, CaseContextMixin, TemplateView):
 
     def get_context(self, **kwargs):
         context = super().get_context()
-        case = kwargs.get("case").__dict__
-        caseworker = self.caseworker
-
-        advice_to_countersign = services.get_advice_to_countersign(case, caseworker)
-        advice_users_pks = [item["user"]["id"] for item in advice_to_countersign]
-        num_advice = len(advice_to_countersign)
+        advice_to_countersign = services.get_advice_to_countersign(self.case, self.caseworker)
+        advice_users_pks = list(advice_to_countersign.keys())
+        num_advice = len(advice_users_pks)
         CountersignAdviceFormsetFactory = formset_factory(
             self.form_class, formset=CountersignAdviceFormSet, extra=num_advice, min_num=num_advice, max_num=num_advice
         )
         context["formset"] = CountersignAdviceFormsetFactory(
             form_kwargs={"request": self.request, "user_pks": advice_users_pks}
         )
-        context["advice_to_countersign"] = advice_to_countersign
+        context["advice_to_countersign"] = advice_to_countersign.values()
         context["user_pks"] = advice_users_pks
         context["review"] = True
         return context

--- a/caseworker/advice/views.py
+++ b/caseworker/advice/views.py
@@ -305,7 +305,7 @@ class ReviewCountersignView(LoginRequiredMixin, CaseContextMixin, TemplateView):
 
     def get_context(self, **kwargs):
         context = super().get_context()
-        advice_to_countersign = services.get_advice_to_countersign(self.case, self.caseworker)
+        advice_to_countersign = services.get_advice_to_countersign(self.case.advice, self.caseworker)
         advice_users_pks = list(advice_to_countersign.keys())
         num_advice = len(advice_users_pks)
         CountersignAdviceFormsetFactory = formset_factory(
@@ -345,7 +345,7 @@ class ViewCountersignedAdvice(LoginRequiredMixin, CaseContextMixin, TemplateView
 
     def get_context(self, **kwargs):
         context = super().get_context()
-        advice_to_countersign = services.get_advice_to_countersign(self.case, self.caseworker)
+        advice_to_countersign = services.get_advice_to_countersign(self.case.advice, self.caseworker)
         context["advice_to_countersign"] = advice_to_countersign.values()
         context["review"] = False
         context["subtitle"] = f"Approved by {self.caseworker['team']['name']}"

--- a/core/builtins/custom_tags.py
+++ b/core/builtins/custom_tags.py
@@ -902,7 +902,8 @@ def divide(value, other):
 
 @register.filter
 def full_name(user):
-    return f"{user['first_name']} {user['last_name']}"
+    user = user or {}
+    return f"{user.get('first_name', '')} {user.get('last_name', '')}"
 
 
 @register.filter

--- a/unit_tests/caseworker/advice/views/test_countersign.py
+++ b/unit_tests/caseworker/advice/views/test_countersign.py
@@ -28,22 +28,21 @@ def test_countersign_approve_all_put(
     mock_gov_user,
     url,
 ):
-    countersign_advice_url = f"/cases/{data_standard_case['case']['id']}/countersign-advice/"
-    requests_mock.put(client._build_absolute_uri(countersign_advice_url), json={})
-    case_data = deepcopy(data_standard_case)
-    case_data["case"]["data"]["goods"] = standard_case_with_advice["data"]["goods"]
-    case_data["case"]["advice"] = advice_for_countersign
+    case_id = data_standard_case["case"]["id"]
+    user_id = mock_gov_user["user"]["id"]
 
-    requests_mock.get(client._build_absolute_uri(f"/cases/{data_standard_case['case']['id']}"), json=case_data)
-    requests_mock.get(
-        client._build_absolute_uri(f"/gov_users/{mock_gov_user['user']['id']}"), json=mock_gov_user,
-    )
-    requests_mock.get(
-        client._build_absolute_uri(f"/users/{mock_gov_user['user']['id']}/"), json={},
-    )
+    # Set up advice on the case
+    data_standard_case["case"]["data"]["goods"] = standard_case_with_advice["data"]["goods"]
+    data_standard_case["case"]["advice"] = advice_for_countersign
 
-    user_team_advice = services.filter_advice_by_users_team(advice_for_countersign, mock_gov_user["user"])
-    advice_to_countersign = services.filter_advice_by_level(user_team_advice, ["user"])
+    # Setup mock API requests
+    countersign_advice_url = client._build_absolute_uri(f"/cases/{case_id}/countersign-advice/")
+    requests_mock.put(countersign_advice_url, json={})
+    requests_mock.get(client._build_absolute_uri(f"/cases/{case_id}"), json=data_standard_case)
+    requests_mock.get(client._build_absolute_uri(f"/gov_users/{user_id}"), json=mock_gov_user)
+    requests_mock.get(client._build_absolute_uri(f"/users/{mock_gov_user['user']['id']}/"), json={})
+
+    advice_to_countersign = services.get_advice_to_countersign(advice_for_countersign, mock_gov_user["user"])
 
     data = {
         "form-TOTAL_FORMS": [f"{len(advice_to_countersign)}"],
@@ -52,29 +51,29 @@ def test_countersign_approve_all_put(
         "form-MAX_NUM_FORMS": [f"{len(advice_to_countersign)}"],
         "submit": ["Submit"],
     }
-    for index, item in enumerate(advice_to_countersign):
+
+    for index, item in enumerate(advice_to_countersign.keys()):
         data[f"form-{index}-agree_with_recommendation"] = ["yes"]
-        data[f"form-{index}-approval_reasons"] = [f"reason{index + 1}"]
-        requests_mock.get(
-            client._build_absolute_uri(f"/users/{item['user']['id']}/team-queues/"), json={"queues": []},
-        )
+        data[f"form-{index}-approval_reasons"] = [f"reason{index}"]
+        requests_mock.get(client._build_absolute_uri(f"/users/{item}/team-queues/"), json={"queues": []})
 
     response = authorized_client.post(url, data=data)
     assert response.status_code == 302
+
     history = [item for item in requests_mock.request_history if countersign_advice_url in item.url]
     assert len(history) == 1
-    history = history[0]
+    history = history.pop()
     assert history.method == "PUT"
     assert history.json() == [
         {
             "id": "b32d7dfa-a90d-4b37-adac-db231d4b83be",
             "countersigned_by": "2a43805b-c082-47e7-9188-c8b3e1a83cb0",
-            "countersign_comments": "reason1",
+            "countersign_comments": "reason0",
         },
         {
             "id": "c9a96d84-6a6b-421d-bbbb-b12b9577d46e",
             "countersigned_by": "2a43805b-c082-47e7-9188-c8b3e1a83cb0",
-            "countersign_comments": "reason2",
+            "countersign_comments": "reason0",
         },
     ]
 
@@ -86,30 +85,30 @@ def test_countersign_refuse_all_put(
     standard_case_with_advice,
     advice_for_countersign,
     mock_gov_user,
+    queue_pk,
     url,
 ):
-    countersign_advice_url = f"/cases/{data_standard_case['case']['id']}/countersign-advice/"
-    case_queues_url = f"/cases/{data_standard_case['case']['id']}/queues/"
-    requests_mock.put(client._build_absolute_uri(countersign_advice_url), json={})
-    case_data = deepcopy(data_standard_case)
-    case_data["case"]["data"]["goods"] = standard_case_with_advice["data"]["goods"]
-    case_data["case"]["advice"] = advice_for_countersign
+    case_id = data_standard_case["case"]["id"]
+    user_id = mock_gov_user["user"]["id"]
 
-    requests_mock.get(client._build_absolute_uri(f"/cases/{data_standard_case['case']['id']}"), json=case_data)
-    requests_mock.get(
-        client._build_absolute_uri(f"/gov_users/{mock_gov_user['user']['id']}"), json=mock_gov_user,
-    )
-    requests_mock.get(
-        client._build_absolute_uri(f"/users/{mock_gov_user['user']['id']}/"), json={},
-    )
-    requests_mock.put(
-        client._build_absolute_uri(case_queues_url), json={},
-    )
+    # Set up advice on the case
+    data_standard_case["case"]["data"]["goods"] = standard_case_with_advice["data"]["goods"]
+    data_standard_case["case"]["advice"] = advice_for_countersign
 
-    user_team_advice = services.filter_advice_by_users_team(advice_for_countersign, mock_gov_user["user"])
-    advice_to_countersign = services.filter_advice_by_level(user_team_advice, ["user"])
-    queues = [(item["id"], f"Queue {index}") for index, item in enumerate(advice_to_countersign, start=1)]
+    # Setup mock API requests
+    countersign_advice_url = client._build_absolute_uri(f"/cases/{case_id}/countersign-advice/")
+    requests_mock.put(countersign_advice_url, json={})
 
+    case_queues_url = client._build_absolute_uri(f"/cases/{case_id}/queues/")
+    requests_mock.put(case_queues_url, json={})
+
+    requests_mock.get(client._build_absolute_uri(f"/cases/{case_id}"), json=data_standard_case)
+    requests_mock.get(client._build_absolute_uri(f"/gov_users/{user_id}"), json=mock_gov_user)
+    requests_mock.get(client._build_absolute_uri(f"/users/{user_id}/"), json={})
+
+    advice_to_countersign = services.get_advice_to_countersign(advice_for_countersign, mock_gov_user["user"])
+
+    # Fill up the formset - starting with management form
     data = {
         "form-TOTAL_FORMS": [f"{len(advice_to_countersign)}"],
         "form-INITIAL_FORMS": ["0"],
@@ -119,36 +118,34 @@ def test_countersign_refuse_all_put(
     }
     for index, item in enumerate(advice_to_countersign):
         data[f"form-{index}-agree_with_recommendation"] = ["no"]
-        data[f"form-{index}-refusal_reasons"] = [f"reason{index + 1}"]
-        data[f"form-{index}-queue_to_return"] = [item["id"]]  # item id is used as queue identifier
+        data[f"form-{index}-refusal_reasons"] = [f"reason{index}"]
+        data[f"form-{index}-queue_to_return"] = [queue_pk]
         requests_mock.get(
-            client._build_absolute_uri(f"/users/{item['user']['id']}/team-queues/"), json={"queues": queues},
+            client._build_absolute_uri(f"/users/{item}/team-queues/"), json={"queues": [(queue_pk, "Queue")]}
         )
 
     response = authorized_client.post(url, data=data)
     assert response.status_code == 302
+
     history = [item for item in requests_mock.request_history if countersign_advice_url in item.url]
     assert len(history) == 1
-    history = history[0]
+    history = history.pop()
     assert history.method == "PUT"
     assert history.json() == [
         {
             "id": "b32d7dfa-a90d-4b37-adac-db231d4b83be",
             "countersigned_by": "2a43805b-c082-47e7-9188-c8b3e1a83cb0",
-            "countersign_comments": "reason1",
+            "countersign_comments": "reason0",
         },
         {
             "id": "c9a96d84-6a6b-421d-bbbb-b12b9577d46e",
             "countersigned_by": "2a43805b-c082-47e7-9188-c8b3e1a83cb0",
-            "countersign_comments": "reason2",
+            "countersign_comments": "reason0",
         },
     ]
 
-    # assert requests are made to update case queues
     history = [item for item in requests_mock.request_history if case_queues_url in item.url]
     assert len(history) == 1
-    history = history[0]
+    history = history.pop()
     assert history.method == "PUT"
-    assert history.json() == {
-        "queues": ["b32d7dfa-a90d-4b37-adac-db231d4b83be", "c9a96d84-6a6b-421d-bbbb-b12b9577d46e"]
-    }
+    assert history.json() == {"queues": [queue_pk]}


### PR DESCRIPTION
A case with e.g. 2 destinations and 2 goods, has 4 distinct **advice-subjects**. 

As a result, when we save `approval-all` or `refuse-all` advice, we create 4 advice records - one for each subject and send it to the API. 

P.S. This is important and will come in handy when we tackle variable advice.

The flip side to this is that e.g. the countersigner is having to process advice for each subject separately whereas according to the designs, he/she should be able to process the advice from a given advisor as a whole.

What we need to do is to somehow group advice from the same user but different destinations and products into the same block for the purpose of countersigning.

This PR fixes this & hopefully improves on a few other minor things E.g. -

* I have put in a new template `advice_details` that does both approvals and refusals. I am hoping that in another PR, I will be able to get rid of `approval-advice-details` & `refusal-advice-details` entirely.
* I have put in a different template for `countersign_view`. Before this PR, `countersign_review` was being used for this but looking at the code, it seemed like not much was common.
