### PR TITLE
LTD-1508: Remove dummy back link on View advice page

### DIFF
--- a/caseworker/advice/templates/advice/view_my_advice.html
+++ b/caseworker/advice/templates/advice/view_my_advice.html
@@ -3,7 +3,6 @@
 
 {% block body %}
 <div class="govuk-width-container">
-    <a href="#" class="govuk-back-link">Back</a>
     <main class="govuk-main-wrapper">
         {% for error in form.non_field_errors %}
         <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
@@ -20,6 +19,7 @@
         </div>
         {% endfor %}
         <div class="govuk-grid-row">
+          <br>
             <div class="govuk-grid-column-three-quarters">
               <h1 class="govuk-heading-xl">View Advice</h1>
               {% if my_advice|length %}


### PR DESCRIPTION
Also it is not required as per design.