### PR TITLE
LTD-1505-1507: Add missing footnote and correct refusal criteria link

### DIFF
--- a/caseworker/advice/forms.py
+++ b/caseworker/advice/forms.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from django import forms
 from django.forms.formsets import BaseFormSet
 from django.forms.formsets import formset_factory
+from django.utils.html import format_html
 
 from crispy_forms_gds.helper import FormHelper
 from crispy_forms_gds.layout import Layout, Submit, HTML
@@ -88,11 +89,16 @@ class RefusalAdviceForm(forms.Form):
 
     def __init__(self, denial_reasons, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        refusal_criteria_link = (
+            "https://publications.parliament.uk/pa/cm201314/cmhansrd/cm140325/wmstext/140325m0001.htm#14032566000018"
+        )
         choices = self._group_denial_reasons(denial_reasons)
         self.fields["denial_reasons"] = forms.MultipleChoiceField(
             choices=choices,
             widget=GridmultipleSelect(),
-            label='Select all <a href="/">refusal criteria</a> that apply',
+            label=format_html(
+                f'Select all <a href={refusal_criteria_link} target="_blank">refusal criteria</a> that apply'
+            ),
         )
         self.fields["refusal_reasons"] = forms.CharField(
             label="What are your reasons for this refusal?",

--- a/caseworker/advice/templates/advice/advice_details.html
+++ b/caseworker/advice/templates/advice/advice_details.html
@@ -113,6 +113,13 @@
                             <p class="govuk-body">{{ advice.0.note }}</p>
                         </div>
                         {% endif %}
+
+                        {% if advice.0.footnote %}
+                        <h2 class="govuk-heading-m">Reporting footnote</h2>
+                        <div class="govuk-cookie-banner__content">
+                            <p class="govuk-body">{{ advice.0.footnote }}</p>
+                        </div>
+                        {% endif %}
                     </div>
                 </div>
             </div>

--- a/caseworker/advice/templates/advice/approve-advice-details.html
+++ b/caseworker/advice/templates/advice/approve-advice-details.html
@@ -84,6 +84,13 @@
                     <p class="govuk-body">{{ advice.note }}</p>
                 </div>
                 {% endif %}
+
+                {% if advice.footnote %}
+                <h2 class="govuk-heading-m">Reporting footnote</h2>
+                <div class="govuk-cookie-banner__content">
+                    <p class="govuk-body">{{ advice.footnote }}</p>
+                </div>
+                {% endif %}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Change description

Two simple bug fixes,
- Footnote added when giving advice is not displayed when viewing the advice
  It is also included when reviewing and viewing the countersigned advice
- Update dummy refusal criteria link with the correct link