### PR TITLE
LTD-1502: Fix the tag for displaying PV grading value in Review good page

### DIFF
--- a/caseworker/templates/case/review-good-standard.html
+++ b/caseworker/templates/case/review-good-standard.html
@@ -48,7 +48,7 @@
             <tr class="govuk-table__row app-table__row">
                 <th scope="row" class="govuk-table__header">Security graded</th>
                 <td class="govuk-table__cell">
-                    {{ object.good.is_pv_graded|yesno|title }}
+                    {{ object.good.is_pv_graded|title }}
                     {% if object.good.grading_comment %}
                         - {{ object.good.grading_comment }}
                     {% endif %}


### PR DESCRIPTION
## Change description

This attribute is not a boolean, it has three choices so yesno is
not the correct tag for this. Currently any value other than False
is displayed as grading required which is not correct. Fix by
removing the yesno tag.