### PR TITLE
LTD-1526: Fix back link in select advice page

### DIFF
--- a/caseworker/advice/templates/advice/select_advice.html
+++ b/caseworker/advice/templates/advice/select_advice.html
@@ -3,7 +3,7 @@
 
 {% block body %}
 <div class="govuk-width-container">
-    <a href="#" class="govuk-back-link">Back</a>
+    <a href="{% url 'cases:advice_view' queue_pk case.id %}" class="govuk-back-link">Back</a>
     <main class="govuk-main-wrapper">
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
## Change description

Fix it to take it to advice overview page, currently it is behaving as
browser back button so user is stuck in a loop