### PR TITLE
LTD-1529: Retain case queues when countersigning is refused

### DIFF
--- a/caseworker/advice/templates/advice/advice_details.html
+++ b/caseworker/advice/templates/advice/advice_details.html
@@ -51,7 +51,7 @@
             {% endwith %}
             {% endif %}
             {% if item.third_party %}
-            {% with third_party=case.data.third_party %}
+            {% for third_party in case.data.third_parties %}
             <tr class="govuk-table__row">
                 <td class="govuk-table__cell">{{ third_party.country.name }}</td>
                 <td class="govuk-table__cell">{{ third_party.type|sentence_case }}</td>
@@ -61,7 +61,7 @@
                 <td class="govuk-table__cell">{{ item.denial_reasons|join:", "}}</td>
                 {% endif %}
             </tr>
-            {% endwith %}
+            {% endfor %}
             {% endif %}
             {% if item.ultimate_end_users %}
             {% for ultimate_end_user in case.data.ultimate_end_users %}

--- a/unit_tests/caseworker/advice/views/test_countersign.py
+++ b/unit_tests/caseworker/advice/views/test_countersign.py
@@ -84,9 +84,9 @@ def test_countersign_approve_all_put(
     assert len(history) == 1
     history = history.pop()
     assert history.method == "PUT"
-    assert history.json() == {
-        "queues": ["1b926457-5c9e-4916-8497-51886e51863a", "c270b79b-370c-4c5e-b8b6-4d5210a58956"]
-    }
+    assert set(history.json()["queues"]) == set(
+        ["1b926457-5c9e-4916-8497-51886e51863a", "c270b79b-370c-4c5e-b8b6-4d5210a58956"]
+    )
 
 
 def test_countersign_refuse_all_put(
@@ -159,6 +159,6 @@ def test_countersign_refuse_all_put(
     assert len(history) == 1
     history = history.pop()
     assert history.method == "PUT"
-    assert history.json() == {
-        "queues": ["1b926457-5c9e-4916-8497-51886e51863a", "c270b79b-370c-4c5e-b8b6-4d5210a58956", queue_pk]
-    }
+    assert set(history.json()["queues"]) == set(
+        ["1b926457-5c9e-4916-8497-51886e51863a", "c270b79b-370c-4c5e-b8b6-4d5210a58956", queue_pk]
+    )

--- a/unit_tests/caseworker/advice/views/test_countersign.py
+++ b/unit_tests/caseworker/advice/views/test_countersign.py
@@ -44,6 +44,9 @@ def test_countersign_approve_all_put(
 
     advice_to_countersign = services.get_advice_to_countersign(advice_for_countersign, mock_gov_user["user"])
 
+    case_queues_url = client._build_absolute_uri(f"/cases/{case_id}/queues/")
+    requests_mock.put(case_queues_url, json={})
+
     data = {
         "form-TOTAL_FORMS": [f"{len(advice_to_countersign)}"],
         "form-INITIAL_FORMS": ["0"],
@@ -76,6 +79,14 @@ def test_countersign_approve_all_put(
             "countersign_comments": "reason0",
         },
     ]
+
+    history = [item for item in requests_mock.request_history if case_queues_url in item.url]
+    assert len(history) == 1
+    history = history.pop()
+    assert history.method == "PUT"
+    assert history.json() == {
+        "queues": ["1b926457-5c9e-4916-8497-51886e51863a", "c270b79b-370c-4c5e-b8b6-4d5210a58956"]
+    }
 
 
 def test_countersign_refuse_all_put(
@@ -148,4 +159,6 @@ def test_countersign_refuse_all_put(
     assert len(history) == 1
     history = history.pop()
     assert history.method == "PUT"
-    assert history.json() == {"queues": [queue_pk]}
+    assert history.json() == {
+        "queues": ["1b926457-5c9e-4916-8497-51886e51863a", "c270b79b-370c-4c5e-b8b6-4d5210a58956", queue_pk]
+    }


### PR DESCRIPTION
## Change description

When the countersigner doesn't agree with the recommendation the case is
sent back to advisor along with the queue it needs to go back but this
was unassigning the case from it's current set of queues. We only want
it to be unassigned from the countersigning queue and it fixes this.
