### PR TITLE
LTD-1571: Fix display of security grading value in case details summary

### DIFF
--- a/caseworker/advice/templates/advice/case_detail.html
+++ b/caseworker/advice/templates/advice/case_detail.html
@@ -99,7 +99,7 @@
                 <p class="govuk-body"><strong>Security grading</strong></p>
             </div>
             <div class="govuk-grid-column-one-half">
-                <p class="govuk-body">{{ case.goods | get_security_grading | join:', ' }}<br></p>
+                <p class="govuk-body">{{ case.goods | get_security_grading | join:', ' | title }}<br></p>
             </div>
             <div class="govuk-grid-column-one-half">
                 <p class="govuk-body"><strong>Total value</strong></p>

--- a/caseworker/advice/templatetags/advice_tags.py
+++ b/caseworker/advice/templatetags/advice_tags.py
@@ -17,7 +17,7 @@ def get_case_value(goods):
 
 @register.filter()
 def get_security_grading(goods):
-    gradings = {good.get("good", {}).get("pv_grading_details") for good in goods}
+    gradings = {good.get("good", {}).get("is_pv_graded") for good in goods}
     return sorted(gradings - {None})
 
 

--- a/unit_tests/caseworker/advice/templatetags/test_advice_tags.py
+++ b/unit_tests/caseworker/advice/templatetags/test_advice_tags.py
@@ -55,15 +55,25 @@ def test_get_clc(goods, expected_value):
     "goods, expected_value",
     (
         # Base case
-        ([{"good": {"pv_grading_details": "a"}}, {"good": {"pv_grading_details": "b"}}], ["a", "b"],),
-        # One of the pv_grading_details is None
-        ([{"good": {"pv_grading_details": "a"}}, {"good": {"pv_grading_details": None}}], ["a"],),
+        (
+            [
+                {"good": {"is_pv_graded": "yes", "pv_grading_details": "a"}},
+                {"good": {"is_pv_graded": "no", "pv_grading_details": "b"}},
+            ],
+            ["no", "yes"],
+        ),
         # Same pv_grading_details
-        ([{"good": {"pv_grading_details": "a"}}, {"good": {"pv_grading_details": "a"}}], ["a"],),
+        (
+            [
+                {"good": {"is_pv_graded": "yes", "pv_grading_details": "a"}},
+                {"is_pv_graded": "yes", "good": {"pv_grading_details": "a"}},
+            ],
+            ["yes"],
+        ),
         # Missing pv_grading_details key
-        ([{"good": {"pv_grading_details": "a"}}, {"good": {}}], ["a"],),
+        ([{"good": {"is_pv_graded": "no", "pv_grading_details": "a"}}, {"good": {}}], ["no"],),
         # Missing good key
-        ([{"good": {"pv_grading_details": "a"}}, {}], ["a"],),
+        ([{"good": {"is_pv_graded": "yes", "pv_grading_details": "a"}}, {}], ["yes"],),
     ),
 )
 def test_get_security_grading(goods, expected_value):


### PR DESCRIPTION
## Change description

Currently when displaying security grading we are looking for pv_grading_details
which is actually a dict, we should be using is_pv_graded which is a string and
the values of all products are joined and displayed as a comma separated value.

If the product is security graded we should also display the actual grading
instead of yes/no so a follow up is required to display more details.