### PR TITLE
[LTD-1586] Countersign move

### DIFF
--- a/caseworker/advice/templates/advice/view_countersign.html
+++ b/caseworker/advice/templates/advice/view_countersign.html
@@ -6,7 +6,22 @@
 {% block body %}
 <div class="govuk-width-container">
     <main class="govuk-main-wrapper">
+        {% for error in form.non_field_errors %}
+        <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+          <h2 class="govuk-error-summary__title" id="error-summary-title">
+            There is a problem
+          </h2>
+          <div class="govuk-error-summary__body">
+            <ul class="govuk-list govuk-error-summary__list">
+              <li>
+                {{ error }}
+              </li>
+            </ul>
+          </div>
+        </div>
+        {% endfor %}
         <div class="govuk-grid-row">
+            <br>
             <div class="govuk-grid-column-two-thirds">
                 {% if can_edit %}
                 <a role="button" draggable="false" class="govuk-button govuk-button--secondary" href="{% url 'cases:countersign_edit' queue_pk case.id %}">
@@ -21,12 +36,7 @@
             </div>
             <div class="govuk-grid-column-one-quarter">
                 {% if advice_to_countersign %}
-                <a role="button" draggable="false" class="govuk-button" href="#move-forward">
-                    Move case forward
-                    <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="13" height="15" viewBox="0 0 33 43" aria-hidden="true" focusable="false">
-                        <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
-                    </svg>
-                </a>
+                    {% crispy form %}
                 {% endif %}
             </div>
         </div>

--- a/caseworker/advice/templates/advice/view_countersign.html
+++ b/caseworker/advice/templates/advice/view_countersign.html
@@ -8,9 +8,11 @@
     <main class="govuk-main-wrapper">
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
+                {% if can_edit %}
                 <a role="button" draggable="false" class="govuk-button govuk-button--secondary" href="{% url 'cases:countersign_edit' queue_pk case.id %}">
                     Edit recommendation
                 </a>
+                {% endif %}
                 {% for advice in advice_to_countersign %}
                     <br><br>
                     {% include "advice/advice_details.html" %}

--- a/caseworker/advice/views.py
+++ b/caseworker/advice/views.py
@@ -276,7 +276,7 @@ class ReviewCountersignView(LoginRequiredMixin, CaseContextMixin, TemplateView):
         return reverse("cases:countersign_view", kwargs=self.kwargs)
 
 
-class ViewCountersignedAdvice(LoginRequiredMixin, CaseContextMixin, TemplateView):
+class ViewCountersignedAdvice(AdviceDetailView):
     template_name = "advice/view_countersign.html"
 
     def can_edit(self, advice_to_countersign):
@@ -290,8 +290,8 @@ class ViewCountersignedAdvice(LoginRequiredMixin, CaseContextMixin, TemplateView
                     countersigned_by.add(advice["countersigned_by"]["id"])
         return self.caseworker_id in countersigned_by
 
-    def get_context(self, **kwargs):
-        context = super().get_context()
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
         advice_to_countersign = services.get_advice_to_countersign(self.case.advice, self.caseworker)
         context["advice_to_countersign"] = advice_to_countersign.values()
         context["can_edit"] = self.can_edit(advice_to_countersign)


### PR DESCRIPTION
Small one. It does 2 things on the `/countersign` screen -

1) It only shows the `Edit recommendation` button if you wrote the recommendation. This is a bit gnarly because of multiple advice objects etc. I have tried to get around this by using sets.

2) It puts the `move-case-forward` machinery in here. I have no idea how or why it was missing up until now.