### PR TITLE
LTD-1595: Post advice for NLR items also

### DIFF
--- a/caseworker/advice/services.py
+++ b/caseworker/advice/services.py
@@ -159,7 +159,20 @@ def post_approval_advice(request, case, data, level="user-advice"):
         }
         for subject_name, subject_id in get_advice_subjects(case, data.get("countries"))
     ]
-    response = client.post(request, f"/cases/{case['id']}/{level}/", json)
+    json_nlr_products = [
+        {
+            "type": "no_licence_required",
+            "text": "",
+            "proviso": "",
+            "note": "",
+            "footnote_required": False,
+            "footnote": "",
+            "good": good["id"],
+            "denial_reasons": [],
+        }
+        for good in filter_nlr_products(case["data"]["goods"])
+    ]
+    response = client.post(request, f"/cases/{case['id']}/{level}/", json + json_nlr_products)
     response.raise_for_status()
     return response.json(), response.status_code
 

--- a/unit_tests/caseworker/advice/views/test_consolidate.py
+++ b/unit_tests/caseworker/advice/views/test_consolidate.py
@@ -298,6 +298,26 @@ def test_consolidate_review_approve(requests_mock, authorized_client, data_stand
             "third_party": "95c2d6b7-5cfd-47e8-b3c8-dc76e1ac9747",
             "denial_reasons": [],
         },
+        {
+            "denial_reasons": [],
+            "footnote": "",
+            "footnote_required": False,
+            "good": "0bedd1c3-cf97-4aad-b711-d5c9a9f4586e",
+            "note": "",
+            "proviso": "",
+            "text": "",
+            "type": "no_licence_required",
+        },
+        {
+            "denial_reasons": [],
+            "footnote": "",
+            "footnote_required": False,
+            "good": "6daad1c3-cf97-4aad-b711-d5c9a9f4586e",
+            "note": "",
+            "proviso": "",
+            "text": "",
+            "type": "no_licence_required",
+        },
     ]
 
 

--- a/unit_tests/caseworker/advice/views/test_consolidate_edit.py
+++ b/unit_tests/caseworker/advice/views/test_consolidate_edit.py
@@ -81,6 +81,16 @@ def test_edit_approve_advice_post(authorized_client, requests_mock, data_standar
             "text": "meets the requirements updated",
             "type": "approve",
         },
+        {
+            "denial_reasons": [],
+            "footnote": "",
+            "footnote_required": False,
+            "good": "d4feac1e-851d-41a5-b833-eb28addb8547",
+            "note": "",
+            "proviso": "",
+            "text": "",
+            "type": "no_licence_required",
+        },
     ]
 
 

--- a/unit_tests/caseworker/advice/views/test_edit_advice.py
+++ b/unit_tests/caseworker/advice/views/test_edit_advice.py
@@ -82,6 +82,16 @@ def test_edit_approve_advice_post(authorized_client, requests_mock, data_standar
             "text": "meets the requirements updated",
             "type": "approve",
         },
+        {
+            "denial_reasons": [],
+            "footnote": "",
+            "footnote_required": False,
+            "good": "d4feac1e-851d-41a5-b833-eb28addb8547",
+            "note": "",
+            "proviso": "",
+            "text": "",
+            "type": "no_licence_required",
+        },
     ]
 
 


### PR DESCRIPTION
## Change description

If the licence is being issued for an application and it contains
NLR items then we have to generate NLR letter besides the main licence
document. The NLR letter is only generated if there is a final advice
for NLR items also.

To keep it consistent with Advice1.0, post NLR advice for other
advice levels as well.