### PR TITLE
Add memory or temp upload handlers as defaults in env

### DIFF
--- a/example.caseworker.env
+++ b/example.caseworker.env
@@ -50,3 +50,5 @@ LITE_API_SEARCH_ENABLED=True
 NOTIFY_KEY="super-secret-gov-uk-api-key-that-is-quite-long-and-hence-this-text"
 NOTIFY_FEEDBACK_TEMPLATE_ID="11111111-2222-3333-4444-555555555555"
 NOTIFY_FEEDBACK_EMAIL="feedback@lite"
+
+FILE_UPLOAD_HANDLERS="django.core.files.uploadhandler.MemoryFileUploadHandler,django.core.files.uploadhandler.TemporaryFileUploadHandler"

--- a/example.exporter.env
+++ b/example.exporter.env
@@ -44,3 +44,5 @@ REDIS_URL=redis://127.0.0.1:6379/exporter
 NOTIFY_KEY="super-secret-gov-uk-api-key-that-is-quite-long-and-hence-this-text"
 NOTIFY_FEEDBACK_TEMPLATE_ID="11111111-2222-3333-4444-555555555555"
 NOTIFY_FEEDBACK_EMAIL="feedback@lite"
+
+FILE_UPLOAD_HANDLERS="django.core.files.uploadhandler.MemoryFileUploadHandler,django.core.files.uploadhandler.TemporaryFileUploadHandler"


### PR DESCRIPTION
This is to stop the tests or local development from connecting to s3 when uploading files