### PR TITLE
LTD-1591: Show MOD-ECJU advice also for LU consolidation

### DIFF
--- a/caseworker/advice/services.py
+++ b/caseworker/advice/services.py
@@ -119,10 +119,12 @@ def get_advice_to_consolidate(advice, user_team_id):
     teams - which is the only difference between this function and
     `get_advice_to_countersign`.
     """
-    user_advice = filter_advice_by_level(advice, ["user"])
     if user_team_id == LICENSING_UNIT_TEAM:
-        advice_from_teams = filter_advice_by_teams(user_advice, LU_CONSOLIDATE_TEAMS)
+        # LU needs to review the consolidated advice given by MOD which is at team level
+        user_team_advice = filter_advice_by_level(advice, ["user", "team"])
+        advice_from_teams = filter_advice_by_teams(user_team_advice, LU_CONSOLIDATE_TEAMS)
     elif user_team_id == MOD_ECJU_TEAM:
+        user_advice = filter_advice_by_level(advice, ["user"])
         advice_from_teams = filter_advice_by_teams(user_advice, MOD_CONSOLIDATE_TEAMS)
     else:
         raise Exception(f"Consolidate/combine operation not allowed for team {user_team_id}")

--- a/unit_tests/caseworker/advice/views/test_consolidate.py
+++ b/unit_tests/caseworker/advice/views/test_consolidate.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 
 from core import client
 from caseworker.advice import forms
-from caseworker.advice.services import LICENSING_UNIT_TEAM
+from caseworker.advice.services import FCDO_TEAM, LICENSING_UNIT_TEAM, MOD_CONSOLIDATE_TEAMS, MOD_ECJU_TEAM
 
 
 @pytest.fixture
@@ -55,6 +55,108 @@ def advice(current_user):
             "user": current_user,
         }
         for good_id in ("0bedd1c3-cf97-4aad-b711-d5c9a9f4586e", "6daad1c3-cf97-4aad-b711-d5c9a9f4586e")
+    ]
+
+
+@pytest.fixture
+def advice_to_consolidate(MOD_team1_user, MOD_team2_user, MOD_ECJU_team_user, FCDO_team_user):
+    return [
+        {
+            "consignee": None,
+            "countersign_comments": "",
+            "countersigned_by": None,
+            "created_at": "2022-01-05T11:18:57.172872Z",
+            "denial_reasons": [],
+            "end_user": "76de33f4-7834-4eb7-871a-66be3270fb59",
+            "footnote": "",
+            "good": None,
+            "goods_type": None,
+            "id": "ee47632b-5dd0-474b-a95d-86e975a95503",
+            "level": "user",
+            "note": "",
+            "proviso": "licence condition ABC",
+            "text": "approve no issues",
+            "third_party": None,
+            "type": {"key": "proviso", "value": "Proviso"},
+            "ultimate_end_user": None,
+            "user": MOD_team1_user,
+        },
+        {
+            "consignee": None,
+            "countersign_comments": "",
+            "countersigned_by": None,
+            "country": None,
+            "created_at": "2022-01-05T11:23:35.473052Z",
+            "denial_reasons": [],
+            "end_user": "76de33f4-7834-4eb7-871a-66be3270fb59",
+            "footnote": "Here is a reporting footnote",
+            "good": None,
+            "goods_type": None,
+            "id": "ebd57168-562f-455d-aa89-59e2f5df0367",
+            "level": "user",
+            "note": "Here is an exporter instruction",
+            "proviso": "No other licence conditions",
+            "text": "Approve from our team",
+            "third_party": None,
+            "type": {"key": "proviso", "value": "Proviso"},
+            "ultimate_end_user": None,
+            "user": MOD_team2_user,
+        },
+        {
+            "consignee": None,
+            "countersign_comments": "",
+            "countersigned_by": None,
+            "country": None,
+            "created_at": "2022-01-05T11:20:52.959163Z",
+            "denial_reasons": [],
+            "end_user": "76de33f4-7834-4eb7-871a-66be3270fb59",
+            "footnote": "",
+            "good": None,
+            "goods_type": None,
+            "id": "de9c95ad-b2e4-46fa-968f-1f2daf289327",
+            "level": "team",
+            "note": "",
+            "proviso": "Meets the criteria",
+            "text": "Meets the criteria for issuing the licence",
+            "third_party": None,
+            "type": {"key": "proviso", "value": "Proviso"},
+            "ultimate_end_user": None,
+            "user": MOD_ECJU_team_user,
+        },
+        {
+            "consignee": None,
+            "countersign_comments": "Agree with the recommendation",
+            "countersigned_by": {
+                "email": "countersigner@example.com",
+                "first_name": "Countersigner",
+                "id": "fad1db47-c5e1-4788-af3d-aea87523826b",
+                "last_name": "Team",
+                "role_name": "Super User",
+                "status": "Active",
+                "team": {
+                    "id": "809eba0f-f197-4f0f-949b-9af309a844fb",
+                    "is_ogd": True,
+                    "name": "FCO",
+                    "part_of_ecju": True,
+                },
+            },
+            "country": None,
+            "created_at": "2022-01-05T11:25:11.545878Z",
+            "denial_reasons": [],
+            "end_user": "76de33f4-7834-4eb7-871a-66be3270fb59",
+            "footnote": "",
+            "good": None,
+            "goods_type": None,
+            "id": "217e7264-7f28-46ff-bf01-dc64f4432786",
+            "level": "user",
+            "note": "",
+            "proviso": None,
+            "text": "Approve from our team",
+            "third_party": None,
+            "type": {"key": "approve", "value": "Approve"},
+            "ultimate_end_user": None,
+            "user": FCDO_team_user,
+        },
     ]
 
 
@@ -230,28 +332,44 @@ def consolidated_refusal_outcome(consolidated_advice):
 
 
 @pytest.mark.parametrize(
-    "path, form_class",
+    "path, form_class, team_id, team_name",
     (
-        ("", forms.ConsolidateApprovalForm),
-        ("approve/", forms.ConsolidateApprovalForm),
-        ("refuse/", forms.RefusalAdviceForm),
+        ("", forms.ConsolidateApprovalForm, LICENSING_UNIT_TEAM, "LU Team"),
+        ("", forms.ConsolidateApprovalForm, MOD_ECJU_TEAM, "MOD Team"),
+        ("approve/", forms.ConsolidateApprovalForm, LICENSING_UNIT_TEAM, "LU Team"),
+        ("refuse/", forms.RefusalAdviceForm, LICENSING_UNIT_TEAM, "LU Team"),
+        ("approve/", forms.ConsolidateApprovalForm, MOD_ECJU_TEAM, "MOD Team"),
+        ("refuse/", forms.RefusalAdviceForm, MOD_ECJU_TEAM, "MOD Team"),
     ),
 )
-def test_consolidate_review(requests_mock, authorized_client, data_standard_case, url, advice, path, form_class):
-    data_standard_case["case"]["advice"] = advice
+def test_consolidate_review(
+    requests_mock,
+    authorized_client,
+    data_standard_case,
+    url,
+    advice_to_consolidate,
+    path,
+    form_class,
+    team_id,
+    team_name,
+):
+    data_standard_case["case"]["advice"] = advice_to_consolidate
     requests_mock.get(
         client._build_absolute_uri("/gov-users/2a43805b-c082-47e7-9188-c8b3e1a83cb0"),
-        json={
-            "user": {
-                "id": "2a43805b-c082-47e7-9188-c8b3e1a83cb0",
-                "team": {"id": LICENSING_UNIT_TEAM, "name": "Licensing Unit"},
-            }
-        },
+        json={"user": {"id": "2a43805b-c082-47e7-9188-c8b3e1a83cb0", "team": {"id": team_id, "name": team_name},}},
     )
     response = authorized_client.get(url + path)
     assert response.status_code == 200
     form = response.context["form"]
     assert isinstance(form, form_class)
+
+    advice_to_review = list(response.context["advice_to_consolidate"])
+    advice_teams = {item[0]["user"]["team"]["id"] for item in advice_to_review}
+
+    if team_id == LICENSING_UNIT_TEAM:
+        assert advice_teams == {FCDO_TEAM, MOD_ECJU_TEAM}
+    elif team_id == MOD_ECJU_TEAM:
+        assert bool(advice_teams.intersection(MOD_CONSOLIDATE_TEAMS)) == True
 
 
 @pytest.mark.parametrize("recommendation, redirect", [("approve", "approve"), ("refuse", "refuse")])

--- a/unit_tests/caseworker/conftest.py
+++ b/unit_tests/caseworker/conftest.py
@@ -8,6 +8,7 @@ from django.test import Client
 
 from core import client
 from core.helpers import convert_value_to_query_param
+from caseworker.advice.services import LICENSING_UNIT_TEAM
 
 application_id = "094eed9a-23cc-478a-92ad-9a05ac17fad0"
 second_application_id = "08e69b60-8fbd-4111-b6ae-096b565fe4ea"
@@ -304,6 +305,78 @@ def team1_user():
         "role_name": "Super User",
         "status": "Active",
         "team": {"id": "12345678-42c8-499f-a58d-94f945411234", "name": "Team1", "part_of_ecju": True, "is_ogd": False,},
+    }
+
+
+@pytest.fixture
+def MOD_team1_user():
+    return {
+        "email": "mod.team1@example.com",
+        "first_name": "MoD Team1",
+        "id": "6543213c-e938-4d4f-a71b-12345678e855",
+        "last_name": "User",
+        "role_name": "Super User",
+        "status": "Active",
+        "team": {
+            "id": "2e5fab3c-4599-432e-9540-74ccfafb18ee",
+            "name": "MoD Team1",
+            "part_of_ecju": False,
+            "is_ogd": True,
+        },
+    }
+
+
+@pytest.fixture
+def MOD_team2_user():
+    return {
+        "email": "mod.team2@example.com",
+        "first_name": "MoD Team2",
+        "id": "4523453c-e938-4d4f-a71b-12345678e855",
+        "last_name": "User",
+        "role_name": "Super User",
+        "status": "Active",
+        "team": {
+            "id": "809eba0f-f197-4f0f-949b-9af309a844fb",
+            "name": "MoD Team2",
+            "part_of_ecju": False,
+            "is_ogd": True,
+        },
+    }
+
+
+@pytest.fixture
+def MOD_ECJU_team_user():
+    return {
+        "email": "mod.ecju.team@example.com",
+        "first_name": "MoD ECJU",
+        "id": "9123453c-e938-4d4f-a71b-12345678e855",
+        "last_name": "User",
+        "role_name": "Super User",
+        "status": "Active",
+        "team": {
+            "id": "b7640925-2577-4c24-8081-b85bd635b62a",
+            "name": "MoD ECJU",
+            "part_of_ecju": False,
+            "is_ogd": True,
+        },
+    }
+
+
+@pytest.fixture
+def FCDO_team_user():
+    return {
+        "email": "fcdo.team@example.com",
+        "first_name": "FCDO Team",
+        "id": "123453c-e938-4d4f-a71b-12345678e8559",
+        "last_name": "User",
+        "role_name": "Super User",
+        "status": "Active",
+        "team": {
+            "id": "67b9a4a3-6f3d-4511-8a19-23ccff221a74",
+            "name": "FCDO Team",
+            "part_of_ecju": False,
+            "is_ogd": True,
+        },
     }
 
 


### PR DESCRIPTION
## Change description

When LU consolidates they need to review advice given by OGDs, in this
case FCDO and MOD-ECJU. Currently we first filter them by "user" level
and filter according to the teams but the consolidated advice given by
MOD will be at "team" level hence not available for review by LU.

Fix this by including the "team" level advice if LU is consolidating.