### PR TITLE
LTD-1629: Fix display of reasons provided for the advice

### DIFF
--- a/caseworker/advice/templates/advice/group-advice.html
+++ b/caseworker/advice/templates/advice/group-advice.html
@@ -67,8 +67,8 @@
                                 {% endif %}
                                 <div class="govuk-cookie-banner__content">
                                     <p class="govuk-body">
-                                    {% if advice.reason %}
-                                        {{ advice.reason }}
+                                    {% if advice.text %}
+                                        {{ advice.text }}
                                     {% else %}
                                         No criteria concerns
                                     {% endif %}


### PR DESCRIPTION
## Change description

Correct attribute was not used hence we were displaying the default message