### PR TITLE
Add no_license_required to approval types.

### DIFF
--- a/caseworker/advice/views.py
+++ b/caseworker/advice/views.py
@@ -341,7 +341,8 @@ class ReviewConsolidateView(LoginRequiredMixin, CaseContextMixin, FormView):
     template_name = "advice/review_consolidate.html"
 
     def is_advice_approve_only(self):
-        return all([a["type"]["key"] in ("approve", "proviso") for a in self.case.advice])
+        approve_advice_types = ("approve", "proviso", "no_licence_required")
+        return all([a["type"]["key"] in approve_advice_types for a in self.case.advice])
 
     def get_form(self):
         form_class = forms.ConsolidateSelectAdviceForm

--- a/unit_tests/caseworker/advice/views/test_consolidate.py
+++ b/unit_tests/caseworker/advice/views/test_consolidate.py
@@ -295,7 +295,7 @@ def consolidated_advice(current_user, team1_user):
             "id": "2f580ac6-07ec-46f0-836c-0bbb282e6886",
             "text": "Issue from LU",
             "note": "",
-            "type": {"key": "proviso", "value": "Proviso"},
+            "type": {"key": "no_licence_required", "value": "No Licence Required"},
             "level": "team",
             "proviso": "no other conditions",
             "denial_reasons": [],


### PR DESCRIPTION
This adds `no_licensen_required` to the list of advice types that are approve-like in this context.