### PR TITLE
LTD-1647: Restore paragraph breaks for advice fields in templates

### DIFF
--- a/caseworker/advice/templates/advice/advice_details.html
+++ b/caseworker/advice/templates/advice/advice_details.html
@@ -95,32 +95,30 @@
         <div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="Reason for approving">
             <div class="govuk-cookie-banner__message govuk-width-container">
                 <div class="govuk-grid-row">
-                    <div class="govuk-grid-column-two-thirds">
-                        <h2 class="govuk-heading-m">Reason for approving</h2>
-                        <div class="govuk-cookie-banner__content">
-                            <p class="govuk-body">{{ advice.0.text }}</p>
-                        </div>
-                        {% if advice.0.proviso %}
-                        <h2 class="govuk-heading-m">Licence condition</h2>
-                        <div class="govuk-cookie-banner__content">
-                            <p class="govuk-body">{{ advice.0.proviso }}</p>
-                        </div>
-                        {% endif %}
-
-                        {% if advice.0.note %}
-                        <h2 class="govuk-heading-m">Additional instructions</h2>
-                        <div class="govuk-cookie-banner__content">
-                            <p class="govuk-body">{{ advice.0.note }}</p>
-                        </div>
-                        {% endif %}
-
-                        {% if advice.0.footnote %}
-                        <h2 class="govuk-heading-m">Reporting footnote</h2>
-                        <div class="govuk-cookie-banner__content">
-                            <p class="govuk-body">{{ advice.0.footnote }}</p>
-                        </div>
-                        {% endif %}
+                    <h2 class="govuk-heading-m">Reason for approving</h2>
+                    <div class="govuk-cookie-banner__content">
+                        <p class="govuk-body">{{ advice.0.text|linebreaks }}</p>
                     </div>
+                    {% if advice.0.proviso %}
+                    <h2 class="govuk-heading-m">Licence condition</h2>
+                    <div class="govuk-cookie-banner__content">
+                        <p class="govuk-body">{{ advice.0.proviso|linebreaks }}</p>
+                    </div>
+                    {% endif %}
+
+                    {% if advice.0.note %}
+                    <h2 class="govuk-heading-m">Additional instructions</h2>
+                    <div class="govuk-cookie-banner__content">
+                        <p class="govuk-body">{{ advice.0.note|linebreaks }}</p>
+                    </div>
+                    {% endif %}
+
+                    {% if advice.0.footnote %}
+                    <h2 class="govuk-heading-m">Reporting footnote</h2>
+                    <div class="govuk-cookie-banner__content">
+                        <p class="govuk-body">{{ advice.0.footnote|linebreaks }}</p>
+                    </div>
+                    {% endif %}
                 </div>
             </div>
         </div>
@@ -128,11 +126,9 @@
         <div class="govuk-cookie-banner " data-nosnippet role="region" aria-label="Reason for refusing">
             <div class="govuk-cookie-banner__message govuk-width-container">
               <div class="govuk-grid-row">
-                <div class="govuk-grid-column-two-thirds">
-                    <h2 class="govuk-heading-m">Reason for refusing</h2>
-                    <div class="govuk-cookie-banner__content">
-                    <p class="govuk-body">{{ advice.0.text }}</p>
-                    </div>
+                <h2 class="govuk-heading-m">Reason for refusing</h2>
+                <div class="govuk-cookie-banner__content">
+                <p class="govuk-body">{{ advice.0.text|linebreaks }}</p>
                 </div>
               </div>
             </div>

--- a/caseworker/advice/templates/advice/group-advice.html
+++ b/caseworker/advice/templates/advice/group-advice.html
@@ -68,7 +68,7 @@
                                 <div class="govuk-cookie-banner__content">
                                     <p class="govuk-body">
                                     {% if advice.text %}
-                                        {{ advice.text }}
+                                        {{ advice.text|linebreaks }}
                                     {% else %}
                                         No criteria concerns
                                     {% endif %}
@@ -85,7 +85,7 @@
                             <div class="govuk-grid-column-full govuk-!-padding-left-1">
                                 <h3 class="govuk-heading-s">Licence condition</h3>
                                 <div class="govuk-cookie-banner__content">
-                                    <p class="govuk-body">{{ advice.proviso }}</p>
+                                    <p class="govuk-body">{{ advice.proviso|linebreaks }}</p>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## Change description

If there are multiple paragraphs in advice reason, licence condition, footnotes etc
then they are getting removed and presented as a single block of text which makes
it very difficult for the user to read and understand.