### PR TITLE
[LTD-1665] Mixed advice renders the wrong consolidate form

### DIFF
--- a/caseworker/advice/views.py
+++ b/caseworker/advice/views.py
@@ -404,7 +404,7 @@ class ConsolidateEditView(ReviewConsolidateView):
         sentry_sdk.set_context("advice", {"advice": self.case.advice})
         self.advice = services.filter_advice_by_team(team_advice, self.caseworker["team"]["id"])[0]
         self.advice_type = self.advice["type"]["key"]
-        self.kwargs["advice_type"] = self.advice_type
+        self.kwargs["advice_type"] = "refuse" if self.advice_type == "refuse" else "approve"
 
     def get_approval_data(self):
         return {

--- a/unit_tests/caseworker/advice/views/test_consolidate_edit.py
+++ b/unit_tests/caseworker/advice/views/test_consolidate_edit.py
@@ -151,9 +151,14 @@ def test_edit_refuse_advice_post(
     ]
 
 
+@pytest.mark.parametrize(
+    "team, advice_level", ((services.LICENSING_UNIT_TEAM, "final"), (services.MOD_ECJU_TEAM, "team")),
+)
 @patch("caseworker.advice.views.get_gov_user")
 def test_edit_advice_get(
     mock_get_gov_user,
+    team,
+    advice_level,
     authorized_client,
     requests_mock,
     data_standard_case,
@@ -161,15 +166,15 @@ def test_edit_advice_get(
     refusal_advice,
     url,
 ):
-    mock_get_gov_user.return_value = ({"user": {"team": {"id": services.LICENSING_UNIT_TEAM}}}, None)
+    mock_get_gov_user.return_value = ({"user": {"team": {"id": team}}}, None)
     case_data = data_standard_case
     case_data["case"]["data"]["goods"] = standard_case_with_advice["data"]["goods"]
     # Add conflicting user advice
     case_data["case"]["advice"] = standard_case_with_advice["advice"] + refusal_advice
     # Add final advice
     for advice in standard_case_with_advice["advice"]:
-        advice["level"] = "final"
-        advice["user"]["team"]["id"] = services.LICENSING_UNIT_TEAM
+        advice["level"] = advice_level
+        advice["user"]["team"]["id"] = team
     case_data["case"]["advice"] += standard_case_with_advice["advice"]
 
     response = authorized_client.get(url)

--- a/unit_tests/caseworker/advice/views/test_consolidate_edit.py
+++ b/unit_tests/caseworker/advice/views/test_consolidate_edit.py
@@ -1,13 +1,28 @@
 import pytest
+from unittest.mock import patch
 
 from copy import deepcopy
 from django.urls import reverse
 
 from core import client
 
+from caseworker.advice import forms, services
+
+
+@pytest.fixture
+def mock_post_team_advice(requests_mock, standard_case_pk):
+    url = client._build_absolute_uri(f"/cases/{standard_case_pk}/team-advice/")
+    yield requests_mock.post(url=url, json={})
+
+
+@pytest.fixture
+def mock_get_team_advice(requests_mock, standard_case_pk):
+    url = client._build_absolute_uri(f"/cases/{standard_case_pk}/team-advice/")
+    yield requests_mock.get(url=url, json={})
+
 
 @pytest.fixture(autouse=True)
-def setup(mock_queue, mock_case):
+def setup(mock_queue, mock_case, mock_denial_reasons, mock_post_team_advice, mock_get_team_advice):
     yield
 
 
@@ -19,24 +34,16 @@ def url(data_queue, data_standard_case):
 
 
 def test_edit_approve_advice_post(authorized_client, requests_mock, data_standard_case, standard_case_with_advice, url):
-    team_advice_create_url = f"/cases/{data_standard_case['case']['id']}/team-advice/"
-    requests_mock.post(team_advice_create_url, json={})
     case_data = data_standard_case
     case_data["case"]["data"]["goods"] = standard_case_with_advice["data"]["goods"]
     case_data["case"]["advice"] = standard_case_with_advice["advice"]
     for advice in case_data["case"]["advice"]:
         advice["level"] = "team"
 
-    requests_mock.get(client._build_absolute_uri(f"/cases/{data_standard_case['case']['id']}"), json=case_data)
-    requests_mock.get(
-        client._build_absolute_uri(f"/gov_users/{data_standard_case['case']['id']}"),
-        json={"user": {"id": "58e62718-e889-4a01-b603-e676b794b394"}},
-    )
-
     data = {"approval_reasons": "meets the requirements updated"}
     response = authorized_client.post(url, data=data)
     assert response.status_code == 302
-    history = [item for item in requests_mock.request_history if team_advice_create_url in item.url]
+    history = [item for item in requests_mock.request_history if "team-advice" in item.url]
     assert len(history) == 1
     history = history[0]
     assert history.method == "POST"
@@ -97,46 +104,24 @@ def test_edit_approve_advice_post(authorized_client, requests_mock, data_standar
 def test_edit_refuse_advice_post(
     authorized_client, requests_mock, data_standard_case, standard_case_with_advice, refusal_advice, url
 ):
-    team_advice_create_url = f"/cases/{data_standard_case['case']['id']}/team-advice/"
-    requests_mock.post(team_advice_create_url, json={})
     case_data = data_standard_case
     case_data["case"]["data"]["goods"] = standard_case_with_advice["data"]["goods"]
     case_data["case"]["advice"] = refusal_advice
     for advice in case_data["case"]["advice"]:
         advice["level"] = "team"
 
-    requests_mock.get(client._build_absolute_uri(f"/cases/{data_standard_case['case']['id']}"), json=case_data)
-    requests_mock.get(
-        client._build_absolute_uri(f"/gov_users/{data_standard_case['case']['id']}"),
-        json={"user": {"id": "58e62718-e889-4a01-b603-e676b794b394"}},
-    )
-    requests_mock.get(
-        client._build_absolute_uri("/static/denial-reasons/"),
-        json={
-            "denial_reasons": [
-                {"id": "1"},
-                {"id": "2"},
-                {"id": "3"},
-                {"id": "4"},
-                {"id": "5"},
-                {"id": "5a"},
-                {"id": "5b"},
-            ]
-        },
-    )
-
     data = {
         "refusal_reasons": "doesn't meet the requirement",
-        "denial_reasons": ["3", "4", "5", "5a", "5b"],
+        "denial_reasons": ["1", "1a", "2", "2a", "2b", "M"],
     }
     response = authorized_client.post(url, data=data)
     assert response.status_code == 302
     history = requests_mock.request_history.pop()
-    assert team_advice_create_url in history.url
+    assert "team-advice" in history.url
     assert history.method == "POST"
     assert history.json() == [
         {
-            "denial_reasons": ["3", "4", "5", "5a", "5b"],
+            "denial_reasons": ["1", "1a", "2", "2a", "2b", "M"],
             "end_user": "95d3ea36-6ab9-41ea-a744-7284d17b9cc5",
             "footnote_required": False,
             "text": "doesn't meet the requirement",
@@ -144,23 +129,25 @@ def test_edit_refuse_advice_post(
         },
         {
             "consignee": "cd2263b4-a427-4f14-8552-505e1d192bb8",
-            "denial_reasons": ["3", "4", "5", "5a", "5b"],
+            "denial_reasons": ["1", "1a", "2", "2a", "2b", "M"],
             "footnote_required": False,
             "text": "doesn't meet the requirement",
             "type": "refuse",
         },
         {
-            "denial_reasons": ["3", "4", "5", "5a", "5b"],
+            "denial_reasons": ["1", "1a", "2", "2a", "2b", "M"],
             "footnote_required": False,
             "text": "doesn't meet the requirement",
             "third_party": "95c2d6b7-5cfd-47e8-b3c8-dc76e1ac9747",
             "type": "refuse",
         },
         {
-            "denial_reasons": ["3", "4", "5", "5a", "5b"],
+            "denial_reasons": ["1", "1a", "2", "2a", "2b", "M"],
             "footnote_required": False,
             "good": "9fbffa7f-ef50-402e-93ac-2f3f37d09030",
             "text": "doesn't meet the requirement",
             "type": "refuse",
         },
     ]
+
+


### PR DESCRIPTION
With conflicting user-level advice, a final proviso advice meant that `consolidate_edit` view was rendering a `ConsolidateSelectAdvice` form instead of `ConsolidateApprovalForm`.