### PR TITLE
LTD-1698: Add missing tab navigation

### DIFF
--- a/caseworker/advice/templates/advice/view_my_advice.html
+++ b/caseworker/advice/templates/advice/view_my_advice.html
@@ -1,6 +1,10 @@
 {% extends 'layouts/case.html' %}
 {% load crispy_forms_tags %}
 
+{% block header_tabs %}
+	{% include "advice/case-tabs.html" with case=case queue=queue %}
+{% endblock %}
+
 {% block body %}
 <div class="govuk-width-container">
     <main class="govuk-main-wrapper">


### PR DESCRIPTION
Adds the navigation menu to the view recommendations screen.

![image](https://user-images.githubusercontent.com/1295116/150372954-b6ae49b1-c514-48cb-97d9-361d0b7d9631.png)
