### PR TITLE
LTD-1733: Skip inactive refusal criteria items

### DIFF
--- a/caseworker/advice/forms.py
+++ b/caseworker/advice/forms.py
@@ -134,6 +134,9 @@ class RefusalAdviceForm(forms.Form):
     def _group_denial_reasons(self, denial_reasons):
         grouped = defaultdict(list)
         for item in denial_reasons:
+            # skip the ones that are not active anymore
+            if item["deprecated"]:
+                continue
             grouped[item["id"][0]].append((item["id"], item.get("display_value") or item["id"]))
         return grouped.items()
 

--- a/unit_tests/caseworker/advice/views/test_edit_advice.py
+++ b/unit_tests/caseworker/advice/views/test_edit_advice.py
@@ -7,7 +7,7 @@ from core import client
 
 
 @pytest.fixture(autouse=True)
-def setup(mock_queue, mock_case):
+def setup(mock_queue, mock_case, mock_denial_reasons):
     yield
 
 
@@ -94,7 +94,13 @@ def test_edit_approve_advice_post(authorized_client, requests_mock, data_standar
 
 
 def test_edit_refuse_advice_post(
-    authorized_client, requests_mock, data_standard_case, standard_case_with_advice, refusal_advice, url
+    authorized_client,
+    requests_mock,
+    data_standard_case,
+    standard_case_with_advice,
+    refusal_advice,
+    url,
+    mock_denial_reasons,
 ):
     user_advice_create_url = f"/cases/{data_standard_case['case']['id']}/user-advice/"
     requests_mock.post(user_advice_create_url, json={})
@@ -106,20 +112,6 @@ def test_edit_refuse_advice_post(
     requests_mock.get(
         client._build_absolute_uri(f"/gov_users/{data_standard_case['case']['id']}"),
         json={"user": {"id": "58e62718-e889-4a01-b603-e676b794b394"}},
-    )
-    requests_mock.get(
-        client._build_absolute_uri("/static/denial-reasons/"),
-        json={
-            "denial_reasons": [
-                {"id": "1"},
-                {"id": "2"},
-                {"id": "3"},
-                {"id": "4"},
-                {"id": "5"},
-                {"id": "5a"},
-                {"id": "5b"},
-            ]
-        },
     )
 
     data = {

--- a/unit_tests/caseworker/conftest.py
+++ b/unit_tests/caseworker/conftest.py
@@ -274,14 +274,17 @@ def mock_denial_reasons(requests_mock):
     url = client._build_absolute_uri("/static/denial-reasons/")
     data = {
         "denial_reasons": [
-            {"id": "1", "display_value": "one"},
-            {"id": "1a", "display_value": "one a"},
-            {"id": "2", "display_value": "two"},
-            {"id": "2a", "display_value": "two a"},
-            {"id": "2b", "display_value": "two b"},
-            {"id": "5a", "display_value": "five a"},
-            {"id": "5b", "display_value": "five b"},
-            {"id": "M", "display_value": "MMMM"},
+            {"id": "1", "display_value": "one", "deprecated": False},
+            {"id": "1a", "display_value": "one a", "deprecated": False},
+            {"id": "2", "display_value": "two", "deprecated": False},
+            {"id": "2a", "display_value": "two a", "deprecated": False},
+            {"id": "2b", "display_value": "two b", "deprecated": False},
+            {"id": "3", "display_value": "two", "deprecated": False},
+            {"id": "4", "display_value": "two", "deprecated": False},
+            {"id": "5", "display_value": "two", "deprecated": False},
+            {"id": "5a", "display_value": "five a", "deprecated": False},
+            {"id": "5b", "display_value": "five b", "deprecated": False},
+            {"id": "M", "display_value": "MMMM", "deprecated": False},
         ]
     }
     yield requests_mock.get(url=url, json=data)


### PR DESCRIPTION
## Change description

In the updated refusal criteria some are deprecated so skip them so that
user cannot select these items.
Previous refusal advice may be referring to these deprecated items so only
skip in the form but display them as is when viewing the advice.