### PR TITLE
Some tests are skipped due to duplicate names fix

### DIFF
--- a/unit_tests/caseworker/advice/test_forms.py
+++ b/unit_tests/caseworker/advice/test_forms.py
@@ -94,7 +94,7 @@ def test_countersign_advice_form_valid(data, valid_status):
         ({"approval_reasons": "meets the requirements"}, False),
     ),
 )
-def test_give_approval_advice_form_valid(data, valid_status):
+def test_give_approval_advice_form_valid_two(data, valid_status):
     form = forms.FCDOApprovalAdviceForm(data=data, countries={"GB": "United Kingdom"})
     form.is_valid()
     assert form.is_valid() == valid_status


### PR DESCRIPTION
These tests were overriding other tests in the same file with the same name. I renamed so the tests run. Please give the tests a better name than I used. Naming is hard and I'm just a bot :)

This might result in tests failing because the affected tests were previously not running.

More details [here](https://codereview.doctor/features/python/best-practice/avoid-duplicate-unit-test-names).