### PR TITLE
Ltd 1358 serial number question updates

### DIFF
--- a/caseworker/templates/case/product-on-case.html
+++ b/caseworker/templates/case/product-on-case.html
@@ -8,389 +8,390 @@
             <a class="lite-back-link-button" id="back-link" href="{% url 'cases:case' queue_pk=queue.id pk=case.id %}">Back</a>
             <div class="govuk-!-margin-top-9 govuk-!-margin-bottom-9">
                 <h2 class="govuk-heading-xl govuk-!-margin-bottom-3">Product details</h2>
-				<div class="govuk-caption-l">{% if good_on_application.good.name %} {{ good_on_application.good.name }} {% else %} {{ good_on_application.good.description }} {% endif %}</div>
-			</div>
+                <div class="govuk-caption-l">
+                    {% if good_on_application.good.name %}
+                        {{ good_on_application.good.name }}
+                    {% else %}
+                        {{ good_on_application.good.description }}
+                    {% endif %}
+                </div>
+            </div>
 
             <div class="govuk-tabs" data-module="govuk-tabs">
+                <ul class="govuk-tabs__list">
+                    <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+                        <a class="govuk-tabs__tab" href="#full-details-tab">
+                            Full details
+                        </a>
+                    </li>
+                    <li class="govuk-tabs__list-item">
+                        <a class="govuk-tabs__tab" href="#history-tab">
+                            History
+                        </a>
+                    </li>
+                    <li class="govuk-tabs__list-item">
+                        <a class="govuk-tabs__tab" href="#related-cases-tab">
+                            Cases
+                        </a>
+                    </li>
+                </ul>
 
-              <ul class="govuk-tabs__list">
-                <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
-                  <a class="govuk-tabs__tab" href="#full-details-tab">
-                    Full details
-                  </a>
-                </li>
-                <li class="govuk-tabs__list-item">
-                  <a class="govuk-tabs__tab" href="#history-tab">
-                    History
-                  </a>
-                </li>
-                <li class="govuk-tabs__list-item">
-                  <a class="govuk-tabs__tab" href="#related-cases-tab">
-                    Cases
-                  </a>
-                </li>
-              </ul>
+                <div class="govuk-tabs__panel" id="full-details-tab">
+                    <h2 class="govuk-heading-l">Full details</h2>
+                    <table class="govuk-table app-table">
+                        <tbody class="govuk-table__body" id="tbody-placeholder">
+                            <tr class="govuk-table__row app-table__row">
+                                <th scope="row" class="govuk-table__header">Category</th>
+                                <td class="govuk-table__cell">{{ good_on_application.good.item_category.value }}</td>
+                            </tr>
+                            {% with firearm_details=good_on_application.firearm_details|default_if_none:good_on_application.good.firearm_details %}
+                                {% if firearm_details %}
+                                    <tr class="govuk-table__row app-table__row">
+                                        <th scope="row" class="govuk-table__header">Product type</th>
+                                        <td class="govuk-table__cell">{{ firearm_details.type.value }}</td>
+                                    </tr>
+                                {% else %}
+                                    <tr class="govuk-table__row app-table__row">
+                                        <th scope="row" class="govuk-table__header">Product type</th>
+                                        <td class="govuk-table__cell">
+                                            {% if good_on_application.item_type %}
+                                                {{ good_on_application.item_type }}
+                                            {% elif good_on_application.other_item_type %}
+                                                {{ good_on_application.other_item_type }}
+                                            {% else %}
+                                                N/A
+                                            {% endif %}
+                                        </td>
+                                    </tr>
+                                {% endif %}
+                                <tr class="govuk-table__row app-table__row">
+                                    <th scope="row" class="govuk-table__header">Name</th>
+                                    <td class="govuk-table__cell">
+                                        {% if good_on_application.good.name %}
+                                            {{ good_on_application.good.name }}
+                                        {% else %}
+                                            {{ good_on_application.good.description }}
+                                        {% endif %}
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row app-table__row">
+                                    <th scope="row" class="govuk-table__header">Description</th>
+                                    <td class="govuk-table__cell">{{ good_on_application.good.description }}</td>
+                                </tr>
+                                <tr class="govuk-table__row app-table__row">
+                                    <th scope="row" class="govuk-table__header">Part number</th>
+                                    <td class="govuk-table__cell">{{ good_on_application.good.part_number }}</td>
+                                </tr>
+                                <tr class="govuk-table__row app-table__row">
+                                    <th scope="row" class="govuk-table__header">Value</th>
+                                    <td class="govuk-table__cell">{{ good_on_application.value }}</td>
+                                </tr>
+                                <tr class="govuk-table__row app-table__row">
+                                    <th scope="row" class="govuk-table__header">Licensable</th>
+                                    <td class="govuk-table__cell" id="is-licensable-value">
+                                        {# when the product is reviewed by an internal user this value is set #}
+                                        {% if good_on_application.is_good_controlled is not None %}
+                                            {{ good_on_application.is_good_controlled.value }}
+                                        {# otherwise we use the value the exporter user has given #}
+                                        {% else %}
+                                            {{ good_on_application.good.is_good_controlled.value }}
+                                        {% endif %}
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row app-table__row">
+                                    <th scope="row" class="govuk-table__header">Control list entries</th>
+                                    <td id="control-list-entries-value" class="govuk-table__cell">
+                                        {% if good_on_application.is_good_controlled is None %}
+                                            {% for control_list_entry in good_on_application.good.control_list_entries %}
+                                                {{ control_list_entry.rating }}
+                                                {% if not forloop.last %}, {% endif %}
+                                            {% endfor %}
+                                        {% else %}
+                                            {% for control_list_entry in good_on_application.control_list_entries %}
+                                                {{ control_list_entry.rating }}
+                                                {% if not forloop.last %}, {% endif %}
+                                            {% endfor %}
+                                        {% endif %}
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row app-table__row">
+                                    <th scope="row" class="govuk-table__header">Security graded</th>
+                                    <td id="security-graded-value" class="govuk-table__cell">
+                                        {{ good_on_application.good.is_pv_graded|title }}
+                                        {% if good_on_application.good.grading_comment %}
+                                            - {{ good_on_application.good.grading_comment }}
+                                        {% endif %}
+                                    </td>
+                                </tr>
+                                {% if firearm_details %}
+                                    {% with firearm_types="firearms ammunition components_for_firearms components_for_ammunition" %}
+                                        {% if firearm_details.type.key in firearm_types.split %}
+                                            {% if firearm_details.type.key == "firearms" %}
+                                                <tr class="govuk-table__row app-table__row">
+                                                    <th scope="row" class="govuk-table__header">Year of manufacture</th>
+                                                    <td class="govuk-table__cell">{{ firearm_details.year_of_manufacture }}</td>
+                                                </tr>
+                                                <tr class="govuk-table__row app-table__row">
+                                                    <th scope="row" class="govuk-table__header">Replica firearm</th>
+                                                    <td class="govuk-table__cell">
+                                                        {% if firearm_details.is_replica is not None %}
+                                                            {{ firearm_details.is_replica|friendly_boolean }} {% if firearm_details.replica_description %}, {{ firearm_details.replica_description }} {% endif %}
+                                                        {% else %}
+                                                            N/A
+                                                        {% endif %}
+                                                    </td>
+                                                </tr>
+                                            {% endif %}
+                                            <tr class="govuk-table__row app-table__row">
+                                                <th scope="row" class="govuk-table__header">Calibre</th>
+                                                <td class="govuk-table__cell">{{ firearm_details.calibre }}</td>
+                                            </tr>
+                                            <tr class="govuk-table__row app-table__row">
+                                                <th scope="row" class="govuk-table__header">Number of items</th>
+                                                <td class="govuk-table__cell">
+                                                    {{ firearm_details.number_of_items }}
+                                                </td>
+                                            </tr>
+                                            <tr class="govuk-table__row app-table__row">
+                                                <th scope="row" class="govuk-table__header">Identification markings</th>
+                                                <td class="govuk-table__cell">
+                                                    {% if firearm_details.serial_numbers_available == "AVAILABLE" %}
+                                                        Yes, I can add serial numbers now
+                                                    {% elif firearm_details.serial_numbers_available == "LATER" %}
+                                                        Yes, I can add serial numbers later
+                                                    {% else %}
+                                                        No
+                                                        <span class="govuk-hint">
+                                                            {{ firearm_details.no_identification_markings_details|default_na }}
+                                                        </span>
+                                                    {% endif %}
+                                                </td>
+                                            </tr>
+                                            {% if firearm_details.serial_numbers_available == "AVAILABLE" %}
+                                                <tr class="govuk-table__row app-table__row">
+                                                    <th scope="row" class="govuk-table__header">Serial numbers</th>
+                                                    <td class="govuk-table__cell">
+                                                        <details class="govuk-details" data-module="govuk-details">
+                                                            <summary class="govuk-details__summary">
+                                                                <span class="govuk-details__summary-text">
+                                                                    View serial numbers
+                                                                </span>
+                                                            </summary>
+                                                            <div class="govuk-details__text">
+                                                                {% for item in firearm_details.serial_numbers %}
+                                                                    {{ forloop.counter}}. {{ item }} {%if not forloop.last %} <br> {% endif %}
+                                                                {% endfor %}
+                                                            </div>
+                                                        </details>
+                                                    </td>
+                                                </tr>
+                                            {% endif %}
+                                        {% endif %}
+                                    {% endwith %}
+                                    {% if firearm_details.type.key == "firearms_accessory" %}
+                                        <tr class="govuk-table__row app-table__row">
+                                            <th scope="row" class="govuk-table__header">Military use</th>
+                                            <td class="govuk-table__cell">{{ good_on_application.good.is_military_use.value|default_na }}
+                                                {% if good_on_application.good.modified_military_use_details %}
+                                                    <span class="govuk-hint"> {{ good_on_application.good.modified_military_use_details }} </span>
+                                                {% endif %}
+                                            </td>
+                                        </tr>
+                                        <tr class="govuk-table__row app-table__row">
+                                            <th scope="row" class="govuk-table__header">Component</th>
+                                            <td class="govuk-table__cell">
+                                                {{ good_on_application.good.is_component.value|default_na }}
+                                                {% if good_on_application.good.modified_military_use_details %}
+                                                    <span class="govuk-hint">{{ good_on_application.good.component_details }}</span>
+                                                {% endif %}
+                                            </td>
+                                        </tr>
+                                        <tr class="govuk-table__row app-table__row">
+                                            <th scope="row" class="govuk-table__header">Information security features</th>
+                                            <td class="govuk-table__cell">
+                                                {{ good_on_application.good.uses_information_security|friendly_boolean }}
+                                                {% if good_on_application.good.information_security_details %}
+                                                    <span class="govuk-hint">{{ good_on_application.good.information_security_details }}</span>
+                                                {% endif %}
+                                            </td>
+                                        </tr>
+                                    {% endif %}
+                                    {% with firearm_types="software_related_to_firearms technology_related_to_firearms" %}
+                                        {% if firearm_details.type.key in firearm_types.split %}
+                                            <tr class="govuk-table__row app-table__row">
+                                                <th scope="row" class="govuk-table__header">Purpose</th>
+                                                <td class="govuk-table__cell">{{ good_on_application.good.software_or_technology_details|default_na }}</td>
+                                            </tr>
+                                            <tr class="govuk-table__row app-table__row">
+                                                <th scope="row" class="govuk-table__header">Military use</th>
+                                                <td class="govuk-table__cell">{{ good_on_application.good.is_military_use.value|default_na }}
+                                                    {% if good_on_application.good.modified_military_use_details %}
+                                                        <span class="govuk-hint">{{ good_on_application.good.modified_military_use_details }}</span>
+                                                    {% endif %}
+                                                </td>
+                                            </tr>
+                                            <tr class="govuk-table__row app-table__row">
+                                                <th scope="row" class="govuk-table__header">Information security features</th>
+                                                <td class="govuk-table__cell">
+                                                    {{ good_on_application.good.uses_information_security|friendly_boolean }}
+                                                    {% if good_on_application.good.information_security_details %}
+                                                        <span class="govuk-hint">{{ good_on_application.good.information_security_details }}</span>
+                                                    {% endif %}
+                                                </td>
+                                            </tr>
+                                        {% endif %}
+                                    {% endwith %}
+                                    {% if firearm_details.has_proof_mark is not None %}
+                                        <tr class="govuk-table__row app-table__row">
+                                            <th scope="row" class="govuk-table__header">Has valid proof marks</th>
+                                            <td class="govuk-table__cell">
+                                                {% if firearm_details.has_proof_mark %}
+                                                    Yes
+                                                {% else %}
+                                                    No, {{ firearm_details.no_proof_mark_details }}
+                                                {% endif %}
+                                            </td>
+                                        </tr>
+                                    {% endif %}
+                                    {% if firearm_details.has_proof_mark is not None %}
+                                        <tr class="govuk-table__row app-table__row">
+                                            <th scope="row" class="govuk-table__header">Deactivated</th>
+                                            <td class="govuk-table__cell">
+                                                {% if firearm_details.is_deactivated %}
+                                                    Yes, {{ firearm_details.date_of_deactivation }}
+                                                {% else %}
+                                                    No
+                                                {% endif %}
+                                            </td>
+                                        </tr>
+                                        {% if firearm_details.is_deactivated %}
+                                            <tr class="govuk-table__row app-table__row">
+                                                <th scope="row" class="govuk-table__header">Proof house standard</th>
+                                                <td class="govuk-table__cell">
+                                                    {% if firearm_details.deactivation_standard %}
+                                                        Yes, {{ firearm_details.deactivation_standard }}
+                                                    {% else %}
+                                                        No, {{ firearm_details.deactivation_standard_other }}
+                                                    {% endif %}
+                                                </td>
+                                            </tr>
+                                        {% endif %}
+                                    {% endif %}
+                                    <tr class="govuk-table__row app-table__row">
+                                        <th scope="row" class="govuk-table__header">Registered firearms dealer</th>
+                                        <td class="govuk-table__cell">
+                                            {% if organisation_documents.rfd_certificate %}
+                                                Yes
+                                            {% else %}
+                                                No
+                                            {% endif %}
+                                            <div>
+                                                {% if organisation_documents.rfd_certificate %}
+                                                    <a target="_blank" href="{% url 'cases:document' queue_pk=queue.id pk=case.id file_pk=organisation_documents.rfd_certificate.document.id %}" class="govuk-link--no-visited-state">{{ organisation_documents.rfd_certificate.document.name }}</a>
+                                                {% endif %}
+                                            </div>
+                                        </td>
+                                    </tr>
+                                    {% if organisation_documents.rfd_certificate %}
+                                        <tr class="govuk-table__row app-table__row">
+                                            <th scope="row" class="govuk-table__header">RFD certificate number</th>
+                                            <td class="govuk-table__cell">
+                                                {{ organisation_documents.rfd_certificate.reference_code }}
+                                                <div class="govuk-hint">{{ organisation_documents.rfd_certificate.expiry_date }}</div>
+                                            </td>
+                                        </tr>
+                                    {% endif %}
+                                    <tr class="govuk-table__row app-table__row">
+                                        <th scope="row" class="govuk-table__header">Covered by Firearms Act 1968</th>
+                                        <td class="govuk-table__cell">
+                                            {% if firearm_details.is_covered_by_firearm_act_section_one_two_or_five == "Yes" %}
+                                                {% if firearm_details.firearms_act_section == "firearms_act_section1" %}
+                                                    Section 1
+                                                    <div>
+                                                        <a target="_blank" href="{% url 'cases:document' queue_pk=queue.id  pk=case.id file_pk=organisation_documents.section_one_certificate.document.id %}" class="govuk-link--no-visited-state">{{ organisation_documents.section_one_certificate.document.name }}</a>
+                                                    </div>
+                                                {% elif firearm_details.firearms_act_section == "firearms_act_section2" %}
+                                                    Section 2
+                                                    <div>
+                                                        <a target="_blank" href="{% url 'cases:document' queue_pk=queue.id  pk=case.id file_pk=organisation_documents.section_two_certificate.document.id %}" class="govuk-link--no-visited-state">{{ organisation_documents.section_two_certificate.document.name }}</a>
+                                                    </div>
+                                                {% elif firearm_details.firearms_act_section == "firearms_act_section5" %}
+                                                    Section 5
+                                                    <div>
+                                                        <a target="_blank" href="{% url 'cases:document' queue_pk=queue.id  pk=case.id file_pk=organisation_documents.section_five_certificate.document.id %}" class="govuk-link--no-visited-state">{{ organisation_documents.section_five_certificate.document.name }}</a>
+                                                    </div>
+                                                {% endif %}
+                                            {% elif firearm_details.is_covered_by_firearm_act_section_one_two_or_five == "No" %}
+                                                No
+                                            {% elif firearm_details.is_covered_by_firearm_act_section_one_two_or_five == "Unsure" %}
+                                                I don't know
+                                            {% endif %}
+                                        </td>
+                                    </tr>
+                                    {% if firearm_details.is_covered_by_firearm_act_section_one_two_or_five == "Yes" %}
+                                        <tr class="govuk-table__row app-table__row">
+                                            <th scope="row" class="govuk-table__header">Firearm Act certificate number</th>
+                                            <td class="govuk-table__cell">
+                                                {{ firearm_details.section_certificate_number }}
+                                                <span class="govuk-hint">{{ firearm_details.section_certificate_date_of_expiry|date_display }}</span>
+                                            </td>
+                                        </tr>
+                                    {% endif %}
+                                {% endif %}
+                            {% endwith %}
+                            <tr class="govuk-table__row app-table__row">
+                                <th scope="row" class="govuk-table__header">Incorporated</th>
+                                <td class="govuk-table__cell">{{ good_on_application|yesno|title }}</td>
+                            </tr>
+                            <tr class="govuk-table__row app-table__row">
+                                <th scope="row" class="govuk-table__header">Document</th>
+                                <td class="govuk-table__cell">
+                                    {% if good_on_application.good.documents %}
+                                        {% if good_on_application.good.documents|length > 1 %}
+                                            <ol class="govuk-list govuk-list--number">
+                                                {% for document in good_on_application.good.documents %}
+                                                    <li>
+                                                        <a class="govuk-link govuk-link--no-visited-state" href="{% url 'cases:document' queue_pk=queue.id pk=case.id file_pk=document.id %}">{{ document.name }}</a>
+                                                        <span class="govuk-hint">{{ document.description }}</span>
+                                                    </li>
+                                                {% endfor %}
+                                            </ol>
+                                        {% else %}
+                                            {% with document=good_on_application.good.documents.0 %}
+                                                <a class="govuk-link govuk-link--no-visited-state" href="{% url 'cases:document' queue_pk=queue.id pk=case.id file_pk=document.id %}">{{ document.name }}</a>
+                                                <span class="govuk-hint">{{ document.description }}</span>
+                                            {% endwith %}
+                                        {% endif %}
+                                    {% else %}
+                                        {% if good_on_application.good.is_document_sensitive %}
+                                            Document is above OFFICIAL-SENSITIVE
+                                        {% endif %}
+                                        {% if not good_on_application.good.is_document_available %}
+                                            No
+                                            <span class="govuk-hint">{{ good_on_application.good.no_document_comments }}</span>
+                                        {% endif %}
+                                    {% endif %}
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
 
+                <div class="govuk-tabs__panel" id="history-tab" >
+                    <h2 class="govuk-heading-l">History</h2>
+                        {% include "includes/audit-trail.html" with activity=good_on_application.audit_trail %}
+                </div>
 
-              <div class="govuk-tabs__panel" id="full-details-tab">
-                <h2 class="govuk-heading-l">Full details</h2>
-                <table class="govuk-table app-table">
-                    <tbody class="govuk-table__body" id="tbody-placeholder">
-                        <tr class="govuk-table__row app-table__row">
-                            <th scope="row" class="govuk-table__header">Category</th>
-                            <td class="govuk-table__cell">{{ good_on_application.good.item_category.value }}</td>
-                        </tr>
-												{% with firearm_details=good_on_application.firearm_details|default_if_none:good_on_application.good.firearm_details %}
-													{% if firearm_details %}
-															<tr class="govuk-table__row app-table__row">
-																	<th scope="row" class="govuk-table__header">Product type</th>
-																	<td class="govuk-table__cell">{{ firearm_details.type.value }}</td>
-															</tr>
-													{% else %}
-															<tr class="govuk-table__row app-table__row">
-																			<th scope="row" class="govuk-table__header">Product type</th>
-																			<td class="govuk-table__cell">
-																					{% if good_on_application.item_type %}
-																							{{ good_on_application.item_type }}
-																					{% elif good_on_application.other_item_type %}
-																							{{ good_on_application.other_item_type }}
-																					{% else %}
-																							N/A
-																					{% endif %}
-																			</td>
-																	</tr>
-													{% endif %}
-													<tr class="govuk-table__row app-table__row">
-														<th scope="row" class="govuk-table__header">Name</th>
-														<td class="govuk-table__cell">{% if good_on_application.good.name %} {{ good_on_application.good.name }} {% else %} {{ good_on_application.good.description }} {% endif %}</td>
-													</tr>
-													<tr class="govuk-table__row app-table__row">
-															<th scope="row" class="govuk-table__header">Description</th>
-															<td class="govuk-table__cell">{{ good_on_application.good.description }}</td>
-													</tr>
-													<tr class="govuk-table__row app-table__row">
-															<th scope="row" class="govuk-table__header">Part number</th>
-															<td class="govuk-table__cell">{{ good_on_application.good.part_number }}</td>
-													</tr>
-													<tr class="govuk-table__row app-table__row">
-															<th scope="row" class="govuk-table__header">Value</th>
-															<td class="govuk-table__cell">{{ good_on_application.value }}</td>
-													</tr>
-													<tr class="govuk-table__row app-table__row">
-															<th scope="row" class="govuk-table__header">Licensable</th>
-															<td class="govuk-table__cell" id="is-licensable-value">
-																	{# when the product is reviewed by an internal user this value is set #}
-																	{% if good_on_application.is_good_controlled is not None %}
-																		{{ good_on_application.is_good_controlled.value }}
-																	{# otherwise we use the value the exporter user has given #}
-																	{% else %}
-																		{{ good_on_application.good.is_good_controlled.value }}
-																	{% endif %}
-															</td>
-													</tr>
-													<tr class="govuk-table__row app-table__row">
-															<th scope="row" class="govuk-table__header">Control list entries</th>
-															<td id="control-list-entries-value" class="govuk-table__cell">
-																{% if good_on_application.is_good_controlled is None %}
-																	{% for control_list_entry in good_on_application.good.control_list_entries %}
-																			{{ control_list_entry.rating }}
-																			{% if not forloop.last %}, {% endif %}
-																	{% endfor %}
-																{% else %}
-																	{% for control_list_entry in good_on_application.control_list_entries %}
-																		{{ control_list_entry.rating }}
-																		{% if not forloop.last %}, {% endif %}
-																	{% endfor %}
-															{% endif %}
-															</td>
-													</tr>
-													<tr class="govuk-table__row app-table__row">
-															<th scope="row" class="govuk-table__header">Security graded</th>
-															<td id="security-graded-value" class="govuk-table__cell">
-																	{{ good_on_application.good.is_pv_graded|title }}
-																	{% if good_on_application.good.grading_comment %}
-																			- {{ good_on_application.good.grading_comment }}
-																	{% endif %}
-															</td>
-													</tr>
-													{% if firearm_details %}
-														{% with firearm_types="firearms ammunition components_for_firearms components_for_ammunition" %}
-															{% if firearm_details.type.key in firearm_types.split %}
-																{% if firearm_details.type.key == "firearms" %}
-																	<tr class="govuk-table__row app-table__row">
-																		<th scope="row" class="govuk-table__header">Year of manufacture</th>
-																		<td class="govuk-table__cell">{{ firearm_details.year_of_manufacture }}</td>
-																	</tr>
-																	<tr class="govuk-table__row app-table__row">
-																		<th scope="row" class="govuk-table__header">Replica firearm</th>
-																		<td class="govuk-table__cell">
-																			{% if firearm_details.is_replica is not None %}
-																				{{ firearm_details.is_replica|friendly_boolean }} {% if firearm_details.replica_description %}, {{ firearm_details.replica_description }} {% endif %}
-																			{% else %}
-																				N/A
-																			{% endif %}
-																		</td>
-																	</tr>
-																{% endif %}
-
-																	<tr class="govuk-table__row app-table__row">
-																			<th scope="row" class="govuk-table__header">Calibre</th>
-																			<td class="govuk-table__cell">{{ firearm_details.calibre }}</td>
-																	</tr>
-
-																	<tr class="govuk-table__row app-table__row">
-																		<th scope="row" class="govuk-table__header">Number of items</th>
-																		<td class="govuk-table__cell">
-																			{{ firearm_details.number_of_items }}
-																		</td>
-																	</tr>
-
-																	<tr class="govuk-table__row app-table__row">
-																			<th scope="row" class="govuk-table__header">Identification markings</th>
-																			<td class="govuk-table__cell">
-																				{% if firearm_details.serial_numbers_available == "AVAILABLE" %}
-																					Yes, I can add serial numbers now
-																				{% elif firearm_details.serial_numbers_available == "LATER" %}
-																					Yes, I can add serial numbers later
-																				{% else %}
-																					No
-																					<span class="govuk-hint">
-																						{{ firearm_details.no_identification_markings_details|default_na }}
-																					</span>
-																				{% endif %}
-																			</td>
-																	</tr>
-																	{% if firearm_details.serial_numbers_available == "AVAILABLE" %}
-																		<tr class="govuk-table__row app-table__row">
-																			<th scope="row" class="govuk-table__header">Serial numbers</th>
-																			<td class="govuk-table__cell">
-																				<details class="govuk-details" data-module="govuk-details">
-																					<summary class="govuk-details__summary">
-																					  <span class="govuk-details__summary-text">
-																						View serial numbers
-																					  </span>
-																					</summary>
-																					<div class="govuk-details__text">
-																						{% for item in firearm_details.serial_numbers %}
-																						{{ forloop.counter}}. {{ item }} {%if not forloop.last %} <br> {% endif %}
-																						{% endfor %}
-																					</div>
-																				</details>
-																			</td>
-																		</tr>
-																	{% endif %}
-
-															{% endif %}
-															{% endwith %}
-
-															{% if firearm_details.type.key == "firearms_accessory" %}
-																	<tr class="govuk-table__row app-table__row">
-																			<th scope="row" class="govuk-table__header">Military use</th>
-																			<td class="govuk-table__cell">{{ good_on_application.good.is_military_use.value|default_na }}
-																					{% if good_on_application.good.modified_military_use_details %}
-																					<span class="govuk-hint"> {{ good_on_application.good.modified_military_use_details }} </span>
-																					{% endif %}
-																			</td>
-																	</tr>
-																	<tr class="govuk-table__row app-table__row">
-																			<th scope="row" class="govuk-table__header">Component</th>
-																			<td class="govuk-table__cell">{{ good_on_application.good.is_component.value|default_na }}
-																					{% if good_on_application.good.modified_military_use_details %}
-																					<span class="govuk-hint"> {{ good_on_application.good.component_details }} </span>
-																					{% endif %}
-																			</td>
-																	</tr>
-																	<tr class="govuk-table__row app-table__row">
-																			<th scope="row" class="govuk-table__header">Information security features</th>
-																			<td class="govuk-table__cell">{{ good_on_application.good.uses_information_security|friendly_boolean }}
-																					{% if good_on_application.good.information_security_details %}
-																					<span class="govuk-hint"> {{ good_on_application.good.information_security_details }} </span>
-																					{% endif %}
-																			</td>
-																	</tr>
-															{% endif %}
-
-															{% with firearm_types="software_related_to_firearms technology_related_to_firearms" %}
-															{% if firearm_details.type.key in firearm_types.split %}
-																	<tr class="govuk-table__row app-table__row">
-																			<th scope="row" class="govuk-table__header">Purpose</th>
-																			<td class="govuk-table__cell">{{ good_on_application.good.software_or_technology_details|default_na }}</td>
-																	</tr>
-																	<tr class="govuk-table__row app-table__row">
-																			<th scope="row" class="govuk-table__header">Military use</th>
-																			<td class="govuk-table__cell">{{ good_on_application.good.is_military_use.value|default_na }}
-																					{% if good_on_application.good.modified_military_use_details %}
-																					<span class="govuk-hint"> {{ good_on_application.good.modified_military_use_details }} </span>
-																					{% endif %}
-																			</td>
-																	</tr>
-																	<tr class="govuk-table__row app-table__row">
-																			<th scope="row" class="govuk-table__header">Information security features</th>
-																			<td class="govuk-table__cell">{{ good_on_application.good.uses_information_security|friendly_boolean }}
-																					{% if good_on_application.good.information_security_details %}
-																					<span class="govuk-hint"> {{ good_on_application.good.information_security_details }} </span>
-																					{% endif %}
-																			</td>
-																	</tr>
-															{% endif %}
-															{% endwith %}
-
-															{% if firearm_details.has_proof_mark is not None %}
-																	<tr class="govuk-table__row app-table__row">
-																			<th scope="row" class="govuk-table__header">Has valid proof marks</th>
-																			<td class="govuk-table__cell">
-																					{% if firearm_details.has_proof_mark %}
-																							Yes
-																					{% else %}
-																							No, {{ firearm_details.no_proof_mark_details }}
-																					{% endif %}
-																			</td>
-																	</tr>
-															{% endif %}
-
-															{% if firearm_details.has_proof_mark is not None %}
-																	<tr class="govuk-table__row app-table__row">
-																			<th scope="row" class="govuk-table__header">Deactivated</th>
-																			<td class="govuk-table__cell">
-																					{% if firearm_details.is_deactivated %}
-																						Yes, {{ firearm_details.date_of_deactivation }}
-																					{% else %}
-																						No
-																					{% endif %}
-																			</td>
-																	</tr>
-																	{% if firearm_details.is_deactivated %}
-																		<tr class="govuk-table__row app-table__row">
-																				<th scope="row" class="govuk-table__header">Proof house standard</th>
-																				<td class="govuk-table__cell">
-																					{% if firearm_details.deactivation_standard %}
-																							Yes, {{ firearm_details.deactivation_standard }}
-																					{% else %}
-																							No, {{ firearm_details.deactivation_standard_other }}
-																					{% endif %}
-																				</td>
-																		</tr>
-																	{% endif %}
-															{% endif %}
-															<tr class="govuk-table__row app-table__row">
-																<th scope="row" class="govuk-table__header">Registered firearms dealer</th>
-																<td class="govuk-table__cell">
-																	{% if organisation_documents.rfd_certificate %}
-																		Yes
-																	{% else %}
-																		No
-																	{% endif %}
-																	<div>
-																		{% if organisation_documents.rfd_certificate %}
-																			<a target="_blank" href="{% url 'cases:document' queue_pk=queue.id pk=case.id file_pk=organisation_documents.rfd_certificate.document.id %}" class="govuk-link--no-visited-state">{{ organisation_documents.rfd_certificate.document.name }}</a>
-																		{% endif %}
-																	</div>
-																</td>
-															</tr>
-															{% if organisation_documents.rfd_certificate %}
-																<tr class="govuk-table__row app-table__row">
-																	<th scope="row" class="govuk-table__header">RFD certificate number</th>
-																	<td class="govuk-table__cell">
-																		{{ organisation_documents.rfd_certificate.reference_code }}
-																		<div class="govuk-hint">{{ organisation_documents.rfd_certificate.expiry_date }}</div>
-																	</td>
-																</tr>
-															{% endif %}
-
-															<tr class="govuk-table__row app-table__row">
-																<th scope="row" class="govuk-table__header">Covered by Firearms Act 1968</th>
-																<td class="govuk-table__cell">
-																	{% if firearm_details.is_covered_by_firearm_act_section_one_two_or_five == "Yes" %}
-																		{% if firearm_details.firearms_act_section == "firearms_act_section1" %}
-																			Section 1
-																			<div>
-																				<a target="_blank" href="{% url 'cases:document' queue_pk=queue.id  pk=case.id file_pk=organisation_documents.section_one_certificate.document.id %}" class="govuk-link--no-visited-state">{{ organisation_documents.section_one_certificate.document.name }}</a>
-																			</div>
-																		{% elif firearm_details.firearms_act_section == "firearms_act_section2" %}
-																			Section 2
-																			<div>
-																				<a target="_blank" href="{% url 'cases:document' queue_pk=queue.id  pk=case.id file_pk=organisation_documents.section_two_certificate.document.id %}" class="govuk-link--no-visited-state">{{ organisation_documents.section_two_certificate.document.name }}</a>
-																			</div>
-																		{% elif firearm_details.firearms_act_section == "firearms_act_section5" %}
-																			Section 5
-																			<div>
-																				<a target="_blank" href="{% url 'cases:document' queue_pk=queue.id  pk=case.id file_pk=organisation_documents.section_five_certificate.document.id %}" class="govuk-link--no-visited-state">{{ organisation_documents.section_five_certificate.document.name }}</a>
-																			</div>
-																		{% endif %}
-																	{% elif firearm_details.is_covered_by_firearm_act_section_one_two_or_five == "No" %}
-																		No
-																	{% elif firearm_details.is_covered_by_firearm_act_section_one_two_or_five == "Unsure" %}
-																		I don't know
-																	{% endif %}
-																</td>
-															</tr>
-
-															{% if firearm_details.is_covered_by_firearm_act_section_one_two_or_five == "Yes" %}
-																<tr class="govuk-table__row app-table__row">
-																	<th scope="row" class="govuk-table__header">Firearm Act certificate number</th>
-																	<td class="govuk-table__cell">
-																			{{ firearm_details.section_certificate_number }}
-																			<span class="govuk-hint">{{ firearm_details.section_certificate_date_of_expiry|date_display }}</span>
-																	</td>
-																</tr>
-															{% endif %}
-
-													{% endif %}
-												{% endwith %}
-                        <tr class="govuk-table__row app-table__row">
-                            <th scope="row" class="govuk-table__header">Incorporated</th>
-                            <td class="govuk-table__cell">{{ good_on_application|yesno|title }}</td>
-                        </tr>
-                        <tr class="govuk-table__row app-table__row">
-                            <th scope="row" class="govuk-table__header">Document</th>
-                            <td class="govuk-table__cell">
-              								{% if good_on_application.good.documents %}
-              									{% if good_on_application.good.documents|length > 1 %}
-              										<ol class="govuk-list govuk-list--number">
-              											{% for document in good_on_application.good.documents %}
-              											<li>
-              											<a class="govuk-link govuk-link--no-visited-state" href="{% url 'cases:document' queue_pk=queue.id pk=case.id file_pk=document.id %}">{{ document.name }}</a>
-              												<span class="govuk-hint"> {{ document.description }} </span>
-              											</li>
-              											{% endfor %}
-              										</ol>
-              									{% else %}
-              										{% with document=good_on_application.good.documents.0 %}
-              										<a class="govuk-link govuk-link--no-visited-state" href="{% url 'cases:document' queue_pk=queue.id pk=case.id file_pk=document.id %}">{{ document.name }}</a>
-              											<span class="govuk-hint"> {{ document.description }} </span>
-              										{% endwith %}
-              									{% endif %}
-              								{% else %}
-              									{% if good_on_application.good.is_document_sensitive %}
-              										Document is above OFFICIAL-SENSITIVE
-              									{% endif %}
-              									{% if not good_on_application.good.is_document_available %}
-                                  No
-              										<span class="govuk-hint">{{ good_on_application.good.no_document_comments }}</span>
-              									{% endif %}
-              								{% endif %}
-              							</td>
-                        </tr>
-                    </tbody>
-                </table>
+                <div class="govuk-tabs__panel" id="related-cases-tab">
+                    <h2 class="govuk-heading-l">Cases</h2>
+                    <p class="govuk-body">Other cases this product's part number and control list entries appear in</p>
+                    {% include "search/results_cases.html" with results=other_cases %}
+                </div>
             </div>
-
-            <div id="history-tab" class="govuk-tabs__panel">
-                <h2 class="govuk-heading-l">History</h2>
-                {% include "includes/audit-trail.html" with activity=good_on_application.audit_trail %}
-            </div>
-
-            <div id="related-cases-tab" class="govuk-tabs__panel">
-                <h2 class="govuk-heading-l">Cases</h2>
-                <p class="govuk-body">Other cases this product's part number and control list entries appear in</p>
-                {% include "search/results_cases.html" with results=other_cases %}
-            </div>
-          </div>
         </div>
-
     </div>
 {% endblock %}
 
 {% block javascript %}
-     <script src="{% static 'search-cases.js' %}"></script>
+    <script src="{% static 'search-cases.js' %}"></script>
 {% endblock %}

--- a/caseworker/templates/case/product-on-case.html
+++ b/caseworker/templates/case/product-on-case.html
@@ -148,17 +148,19 @@
 																	<tr class="govuk-table__row app-table__row">
 																			<th scope="row" class="govuk-table__header">Identification markings</th>
 																			<td class="govuk-table__cell">
-																				{% if firearm_details.has_identification_markings %}
-																					Yes
+																				{% if firearm_details.serial_numbers_available == "AVAILABLE" %}
+																					Yes, I can add serial numbers now
+																				{% elif firearm_details.serial_numbers_available == "LATER" %}
+																					Yes, I can add serial numbers later
 																				{% else %}
-																					No <br>
+																					No
 																					<span class="govuk-hint">
-																						 {{ firearm_details.no_identification_markings_details }}
+																						{{ firearm_details.no_identification_markings_details|default_na }}
 																					</span>
 																				{% endif %}
 																			</td>
 																	</tr>
-																	{% if firearm_details.has_identification_markings is True %}
+																	{% if firearm_details.serial_numbers_available == "AVAILABLE" %}
 																		<tr class="govuk-table__row app-table__row">
 																			<th scope="row" class="govuk-table__header">Serial numbers</th>
 																			<td class="govuk-table__cell">

--- a/caseworker/templates/case/review-good-standard.html
+++ b/caseworker/templates/case/review-good-standard.html
@@ -15,7 +15,13 @@
             {% endif %}
             <tr class="govuk-table__row app-table__row">
                 <th scope="row" class="govuk-table__header">Name</th>
-                <td class="govuk-table__cell">{% if object.good.name %} {{ object.good.name }} {% else %} {{ object.good.description }} {% endif %}</td>
+                <td class="govuk-table__cell">
+                    {% if object.good.name %}
+                        {{ object.good.name }}
+                    {% else %}
+                        {{ object.good.description }}
+                    {% endif %}
+                </td>
             </tr>
             <tr class="govuk-table__row app-table__row">
                 <th scope="row" class="govuk-table__header">Description</th>
@@ -61,7 +67,6 @@
                     <!-- core firearms types -->
                     {% with firearms_core_types="firearms ammunition components_for_firearms components_for_ammunition" %}
                         {% if firearm_details.type.key in firearms_core_types.split %}
-
                             {% if firearm_details.type.key == "firearms" %}
                                 <tr class="govuk-table__row app-table__row">
                                     <th scope="row" class="govuk-table__header">Year of manufacture</th>
@@ -81,6 +86,7 @@
                                     </td>
                                 </tr>
                             {% endif %}
+
                             <tr class="govuk-table__row app-table__row">
                                 <th scope="row" class="govuk-table__header">Calibre</th>
                                 <td class="govuk-table__cell">{{ firearm_details.calibre|default_na }}</td>
@@ -173,20 +179,19 @@
                                     <td class="govuk-table__cell">
                                         <details class="govuk-details" data-module="govuk-details">
                                             <summary class="govuk-details__summary">
-                                            <span class="govuk-details__summary-text">
-                                                View serial numbers
-                                            </span>
+                                                <span class="govuk-details__summary-text">
+                                                    View serial numbers
+                                                </span>
                                             </summary>
                                             <div class="govuk-details__text">
                                                 {% for item in firearm_details.serial_numbers %}
-                                                {{ forloop.counter}}. {{ item }} {%if not forloop.last %} <br> {% endif %}
+                                                    {{ forloop.counter}}. {{ item }} {%if not forloop.last %} <br> {% endif %}
                                                 {% endfor %}
                                             </div>
                                         </details>
                                     </td>
                                 </tr>
                             {% endif %}
-
                         {% endif %}
                     {% endwith %}
 
@@ -222,7 +227,7 @@
                                 {% if object.good.uses_information_security %}
                                     {{ object.good.uses_information_security|yesno|title }}
                                     {% if object.good.information_security_details %}
-                                    , {{ object.good.information_security_details }}
+                                        , {{ object.good.information_security_details }}
                                     {% endif %}
                                 {% else %}
                                     Not added
@@ -242,7 +247,7 @@
                                 {% if object.good.is_military_use %}
                                     {{ object.good.is_military_use.value }}
                                     {% if object.good.modified_military_use_details %}
-                                    , {{ object.good.modified_military_use_details }}
+                                        , {{ object.good.modified_military_use_details }}
                                     {% endif %}
                                 {% else %}
                                     Not added
@@ -255,7 +260,7 @@
                                 {% if object.good.uses_information_security %}
                                     {{ object.good.uses_information_security|yesno|title }}
                                     {% if object.good.information_security_details %}
-                                    , {{ object.good.information_security_details }}
+                                        , {{ object.good.information_security_details }}
                                     {% endif %}
                                 {% else %}
                                     Not added
@@ -276,7 +281,7 @@
                         {% if object.good.is_military_use %}
                             {{ object.good.is_military_use.value }}
                             {% if object.good.modified_military_use_details %}
-                            , {{ object.good.modified_military_use_details }}
+                                , {{ object.good.modified_military_use_details }}
                             {% endif %}
                         {% else %}
                             Not added
@@ -301,7 +306,7 @@
                         {% if object.good.uses_information_security %}
                             {{ object.good.uses_information_security|yesno|title }}
                             {% if object.good.information_security_details %}
-                            , {{ object.good.information_security_details }}
+                                , {{ object.good.information_security_details }}
                             {% endif %}
                         {% else %}
                             Not added
@@ -321,16 +326,16 @@
                         {% if object.good.documents|length > 1 %}
                             <ol class="govuk-list govuk-list--number">
                                 {% for document in object.good.documents %}
-                                <li>
-                                <a class="govuk-link govuk-link--no-visited-state" href="{% url 'cases:document' queue_pk=queue.id pk=case.id file_pk=document.id %}">{{ document.name }}</a>
-                                    <span class="govuk-hint"> {{ document.description }} </span>
-                                </li>
+                                    <li>
+                                        <a class="govuk-link govuk-link--no-visited-state" href="{% url 'cases:document' queue_pk=queue.id pk=case.id file_pk=document.id %}">{{ document.name }}</a>
+                                        <span class="govuk-hint">{{ document.description }}</span>
+                                    </li>
                                 {% endfor %}
                             </ol>
                         {% else %}
                             {% with document=object.good.documents.0 %}
-                            <a class="govuk-link govuk-link--no-visited-state" href="{% url 'cases:document' queue_pk=queue.id pk=case.id file_pk=document.id %}">{{ document.name }}</a>
-                                <span class="govuk-hint"> {{ document.description }} </span>
+                                <a class="govuk-link govuk-link--no-visited-state" href="{% url 'cases:document' queue_pk=queue.id pk=case.id file_pk=document.id %}">{{ document.name }}</a>
+                                <span class="govuk-hint">{{ document.description }}</span>
                             {% endwith %}
                         {% endif %}
                     {% else %}

--- a/caseworker/templates/case/review-good-standard.html
+++ b/caseworker/templates/case/review-good-standard.html
@@ -155,19 +155,19 @@
                             <tr class="govuk-table__row app-table__row">
                                 <th scope="row" class="govuk-table__header">Identification markings</th>
                                 <td class="govuk-table__cell">
-                                    {% if firearm_details.has_identification_markings is not None %}
-                                        {% if firearm_details.has_identification_markings %}
-                                            Yes
-                                        {% else %}
-                                            No <br>
-                                            <span class="govuk-hint">
-                                                {{ firearm_details.no_identification_markings_details }}
-                                            </span>
-                                        {% endif %}
+                                    {% if firearm_details.serial_numbers_available == "AVAILABLE" %}
+                                        Yes, I can add serial numbers now
+                                    {% elif firearm_details.serial_numbers_available == "LATER" %}
+                                        Yes, I can add serial numbers later
+                                    {% else %}
+                                        No
+                                        <span class="govuk-hint">
+                                            {{ firearm_details.no_identification_markings_details|default_na }}
+                                        </span>
                                     {% endif %}
                                 </td>
                             </tr>
-                            {% if firearm_details.has_identification_markings is True %}
+                            {% if firearm_details.serial_numbers_available == "AVAILABLE" %}
                                 <tr class="govuk-table__row app-table__row">
                                     <th scope="row" class="govuk-table__header">Serial numbers</th>
                                     <td class="govuk-table__cell">

--- a/exporter/applications/services.py
+++ b/exporter/applications/services.py
@@ -149,7 +149,7 @@ def serialize_good_on_app_data(json, good=None, preexisting=False):
     if firearm_details:
         if not preexisting and good:
             firearm_details["number_of_items"] = good["firearm_details"]["number_of_items"]
-            if good["firearm_details"]["has_identification_markings"] is True:
+            if good["firearm_details"]["serial_numbers_available"] == "AVAILABLE":
                 firearm_details["serial_numbers"] = good["firearm_details"]["serial_numbers"]
             else:
                 firearm_details["serial_numbers"] = list()

--- a/exporter/core/helpers.py
+++ b/exporter/core/helpers.py
@@ -209,7 +209,7 @@ def is_pv_graded(wizard):
 def show_serial_numbers_form(indentification_markings_step_name):
     def _show_serial_numbers_form(wizard):
         cleaned_data = wizard.get_cleaned_data_for_step(indentification_markings_step_name)
-        return str_to_bool(cleaned_data.get("has_identification_markings"))
+        return cleaned_data.get("serial_numbers_available") == "AVAILABLE"
 
     return _show_serial_numbers_form
 

--- a/exporter/goods/forms.py
+++ b/exporter/goods/forms.py
@@ -443,13 +443,14 @@ class FirearmsNumberOfItemsForm(forms.Form):
 class IdentificationMarkingsForm(forms.Form):
     title = CreateGoodForm.FirearmGood.IdentificationMarkings.TITLE
 
-    has_identification_markings = forms.ChoiceField(
+    serial_numbers_available = forms.ChoiceField(
         choices=(
-            (True, CreateGoodForm.FirearmGood.IdentificationMarkings.YES),
-            (False, CreateGoodForm.FirearmGood.IdentificationMarkings.NO),
+            ("AVAILABLE", CreateGoodForm.FirearmGood.IdentificationMarkings.YES_NOW),
+            ("LATER", CreateGoodForm.FirearmGood.IdentificationMarkings.YES_LATER),
+            ("NOT_AVAILABLE", CreateGoodForm.FirearmGood.IdentificationMarkings.NO),
         ),
         error_messages={
-            "required": "Select yes if the product has identification markings",
+            "required": "Select whether you can enter serial numbers now, later or the product does not have them.",
         },
         label="",
     )
@@ -466,8 +467,9 @@ class IdentificationMarkingsForm(forms.Form):
         self.helper.layout = Layout(
             HTML.h1(self.title),
             ConditionalRadios(
-                "has_identification_markings",
-                CreateGoodForm.FirearmGood.IdentificationMarkings.YES,
+                "serial_numbers_available",
+                CreateGoodForm.FirearmGood.IdentificationMarkings.YES_NOW,
+                CreateGoodForm.FirearmGood.IdentificationMarkings.YES_LATER,
                 ConditionalQuestion(
                     CreateGoodForm.FirearmGood.IdentificationMarkings.NO,
                     "no_identification_markings_details",
@@ -480,7 +482,7 @@ class IdentificationMarkingsForm(forms.Form):
         cleaned_data = super().clean()
         cleaned_data["identification_markings_step"] = True
 
-        if cleaned_data.get("has_identification_markings") == "False":
+        if cleaned_data.get("serial_numbers_available") == "NOT_AVAILABLE":
             if not cleaned_data.get("no_identification_markings_details"):
                 self.add_error(
                     "no_identification_markings_details",

--- a/exporter/goods/services.py
+++ b/exporter/goods/services.py
@@ -79,7 +79,7 @@ def add_identification_marking_details(firearm_details, json):
 
     if "identification_markings_step" in json:
         # parent component doesnt get sent when empty unlike the remaining form fields
-        firearm_details["has_identification_markings"] = json.get("has_identification_markings", "")
+        firearm_details["serial_numbers_available"] = json.get("serial_numbers_available", "")
         firearm_details["no_identification_markings_details"] = json.get("no_identification_markings_details")
         try:
             del json["no_identification_markings_details"]

--- a/exporter/goods/views.py
+++ b/exporter/goods/views.py
@@ -936,7 +936,7 @@ class EditIdentificationMarkingsView(LoginRequiredMixin, GoodCommonMixin, FormVi
         data = get_good_details(self.request, self.object_id)[0]["firearm_details"]
 
         return {
-            "has_identification_markings": data["has_identification_markings"],
+            "serial_numbers_available": data["serial_numbers_available"],
             "no_identification_markings_details": data["no_identification_markings_details"],
         }
 
@@ -949,8 +949,8 @@ class EditIdentificationMarkingsView(LoginRequiredMixin, GoodCommonMixin, FormVi
                 kwargs={"pk": self.object_id, "type": "application", "draft_pk": self.draft_id},
             )
         elif self.application_id and self.object_id:
-            has_identification_markings = form.cleaned_data["has_identification_markings"]
-            if str_to_bool(has_identification_markings) is True:
+            serial_numbers_available = form.cleaned_data["serial_numbers_available"]
+            if serial_numbers_available == "AVAILABLE":
                 success_url = reverse(
                     "applications:serial_numbers", kwargs={"pk": self.application_id, "good_pk": self.object_id}
                 )

--- a/exporter/templates/applications/goods/add-good-detail-summary.html
+++ b/exporter/templates/applications/goods/add-good-detail-summary.html
@@ -4,482 +4,477 @@
 {% endblock %}
 
 {% block body %}
-	<div class="lite-app-bar">
-		<div class="lite-app-bar__content">
-			<h1 class="govuk-heading-l">
-				{% block title %} {% lcs 'Goods.AddGoodSummary.TITLE' %} {% endblock %}
-			</h1>
-		</div>
-	</div>
+    <div class="lite-app-bar">
+        <div class="lite-app-bar__content">
+            <h1 class="govuk-heading-l">
+                {% block title %} {% lcs 'Goods.AddGoodSummary.TITLE' %} {% endblock %}
+            </h1>
+        </div>
+    </div>
 
-	<dl class="govuk-summary-list" id="good-detail-summary">
-		<div class="govuk-summary-list__row">
-			<dt class="govuk-summary-list__key">
-				{% lcs "Goods.AddGoodSummary.FirearmDetails.PRODUCT_TYPE" %}
-			</dt>
-			<dd class="govuk-summary-list__value">
-				{{ good.firearm_details.type.value|default_na }}
-			</dd>
-			<dd class="govuk-summary-list__actions">
-			</dd>
-		</div>
-		<div class="govuk-summary-list__row">
-			<dt class="govuk-summary-list__key">
-				Name
-			</dt>
-			<dd class="govuk-summary-list__value">
-				{{ good.name }}
-			</dd>
-			<dd class="govuk-summary-list__actions">
-				{% if good.status.key == 'draft' %}
-					<a id="change-good-name" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:edit_good' application_id good.id %}#name">Change</a>
-				{% endif %}
-			</dd>
-		</div>
-		<div class="govuk-summary-list__row">
-			<dt class="govuk-summary-list__key">
-				{% lcs "Goods.AddGoodSummary.DESCRIPTION" %}
-			</dt>
-			<dd class="govuk-summary-list__value">
-				{{ good.description }}
-			</dd>
-			<dd class="govuk-summary-list__actions">
-				{% if good.status.key == 'draft' %}
-					<a id="change-good-description" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:edit_good' application_id good.id %}#description">Change</a>
-				{% endif %}
-			</dd>
-		</div>
+    <dl class="govuk-summary-list" id="good-detail-summary">
+        <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+                {% lcs "Goods.AddGoodSummary.FirearmDetails.PRODUCT_TYPE" %}
+            </dt>
+            <dd class="govuk-summary-list__value">
+                {{ good.firearm_details.type.value|default_na }}
+            </dd>
+            <dd class="govuk-summary-list__actions">
+            </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+                Name
+            </dt>
+            <dd class="govuk-summary-list__value">
+                {{ good.name }}
+            </dd>
+            <dd class="govuk-summary-list__actions">
+                {% if good.status.key == 'draft' %}
+                    <a id="change-good-name" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:edit_good' application_id good.id %}#name">Change</a>
+                {% endif %}
+            </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+                {% lcs "Goods.AddGoodSummary.DESCRIPTION" %}
+            </dt>
+            <dd class="govuk-summary-list__value">
+                {{ good.description }}
+            </dd>
+            <dd class="govuk-summary-list__actions">
+                {% if good.status.key == 'draft' %}
+                    <a id="change-good-description" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:edit_good' application_id good.id %}#description">Change</a>
+                {% endif %}
+            </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+                {% lcs 'Goods.AddGoodSummary.PART_NUMBER' %}
+            </dt>
+            <dd class="govuk-summary-list__value">
+                {{ good.part_number|default_na }}
+            </dd>
+            <dd class="govuk-summary-list__actions">
+                {% if good.status.key == 'draft' %}
+                    <a id="change-part-number" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:edit_good' application_id good.id %}#part_number">Change</a>
+                {% endif %}
+            </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+                {% lcs 'Goods.AddGoodSummary.CLC' %}
+            </dt>
+            {% if good.control_list_entries %}
+                <dd class="govuk-summary-list__value">
+                    {{ good.control_list_entries|display_clc_ratings }}
+                </dd>
+            {% else %}
+                <dd class="govuk-summary-list__value">
+                    {{ good.control_list_entries|default_na }}
+                </dd>
+            {% endif %}
+            <dd class="govuk-summary-list__actions">
+                {% if good.status.key == 'draft' %}
+                    <a id="change-good-controlled" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:edit_good' application_id good.id %}#pane_is_good_controlled">Change</a>
+                {% endif %}
+            </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+                {% lcs 'Goods.AddGoodSummary.SECURITY_GRADING' %}
+            </dt>
+            <dd class="govuk-summary-list__value">
+                {{ good.is_pv_graded.value }}
+            </dd>
+            <dd class="govuk-summary-list__actions">
+                {% if good.status.key == 'draft' %}
+                    <a id="change-good-grading" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:edit_grading' application_id good.id %}">Change</a>
+                {% endif %}
+            </dd>
+        </div>
 
-		<div class="govuk-summary-list__row">
-			<dt class="govuk-summary-list__key">
-				{% lcs 'Goods.AddGoodSummary.PART_NUMBER' %}
-			</dt>
-			<dd class="govuk-summary-list__value">
-				{{ good.part_number|default_na }}
-			</dd>
-			<dd class="govuk-summary-list__actions">
-				{% if good.status.key == 'draft' %}
-					<a id="change-part-number" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:edit_good' application_id good.id %}#part_number">Change</a>
-				{% endif %}
-			</dd>
-		</div>
+        {% if good.item_category.key != 'group2_firearms' %}
+            {% with firearm_types='group3_software group3_technology' %}
+                {% if good.item_category.key in firearm_types.split %}
+                    <div class="govuk-summary-list__row">
+                        <dt class="govuk-summary-list__key">
+                            {% lcs 'Goods.AddGoodSummary.PURPOSE_SOFTWARE_TECHNOLOGY' %}
+                        </dt>
+                        <dd class="govuk-summary-list__value">
+                            {{ good.software_or_technology_details|default_na  }}
+                        </dd>
+                        <dd class="govuk-summary-list__actions">
+                            {% if good.status.key == 'draft' %}
+                                <a id="change-good-technology-software" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:good_software_technology' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs 'Goods.AddGoodSummary.PURPOSE_SOFTWARE_TECHNOLOGY' %}</span></a>
+                            {% endif %}
+                        </dd>
+                    </div>
+                {% endif %}
+            {% endwith %}
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    {% lcs "Goods.AddGoodSummary.MILITARY_USE" %}
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    {{ good.is_military_use.value|default_na }}
+                    {% if good.modified_military_use_details %}
+                        <span class="govuk-hint">{{ good.modified_military_use_details }}</span>
+                    {% endif %}
+                </dd>
+                <dd class="govuk-summary-list__actions">
+                    {% if good.status.key == 'draft' %}
+                        <a id="change-good-details" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:good_military_use' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs 'Goods.AddGoodSummary.MILITARY_USE' %}</span></a>
+                    {% endif %}
+                </dd>
+            </div>
 
-		<div class="govuk-summary-list__row">
-			<dt class="govuk-summary-list__key">
-				{% lcs 'Goods.AddGoodSummary.CLC' %}
-			</dt>
-			{% if good.control_list_entries %}
-				<dd class="govuk-summary-list__value">
-					{{ good.control_list_entries|display_clc_ratings }}
-				</dd>
-			{% else %}
-				<dd class="govuk-summary-list__value">
-					{{ good.control_list_entries|default_na }}
-				</dd>
-			{% endif %}
-			<dd class="govuk-summary-list__actions">
-				{% if good.status.key == 'draft' %}
-					<a id="change-good-controlled" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:edit_good' application_id good.id %}#pane_is_good_controlled">Change</a>
-				{% endif %}
-			</dd>
-		</div>
-		<div class="govuk-summary-list__row">
-			<dt class="govuk-summary-list__key">
-				{% lcs 'Goods.AddGoodSummary.SECURITY_GRADING' %}
-			</dt>
-			<dd class="govuk-summary-list__value">
-				{{ good.is_pv_graded.value }}
-			</dd>
-			<dd class="govuk-summary-list__actions">
-				{% if good.status.key == 'draft' %}
-					<a id="change-good-grading" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:edit_grading' application_id good.id %}">Change</a>
-				{% endif %}
-			</dd>
-		</div>
+            {% if good.item_category.key not in 'group3_software,group3_technology' %}
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        {% lcs "Goods.AddGoodSummary.COMPONENT" %}
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        {{ good.is_component.value|default_na }}
+                        {% if good.component_details %}
+                            <span class="govuk-hint">{{ good.component_details }}</span>
+                        {% endif %}
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                        {% if good.status.key == 'draft' %}
+                            <a class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:good_component' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs 'Goods.AddGoodSummary.COMPONENT' %}</span></a>
+                        {% endif %}
+                    </dd>
+                </div>
+            {% endif %}
 
-		{% if good.item_category.key != 'group2_firearms' %}
-			{% with firearm_types='group3_software group3_technology' %}
-			{% if good.item_category.key in firearm_types.split %}
-				<div class="govuk-summary-list__row">
-					<dt class="govuk-summary-list__key">
-						{% lcs 'Goods.AddGoodSummary.PURPOSE_SOFTWARE_TECHNOLOGY' %}
-					</dt>
-					<dd class="govuk-summary-list__value">
-						{{ good.software_or_technology_details|default_na  }}
-					</dd>
-					<dd class="govuk-summary-list__actions">
-						{% if good.status.key == 'draft' %}
-							<a id="change-good-technology-software" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:good_software_technology' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs 'Goods.AddGoodSummary.PURPOSE_SOFTWARE_TECHNOLOGY' %}</span></a>
-						{% endif %}
-					</dd>
-				</div>
-			{% endif %}
-			{% endwith %}
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    {% lcs "Goods.AddGoodSummary.INFORMATION_SECURITY_FEATURES" %}
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    {% if good.uses_information_security is not None %}
+                        {{ good.uses_information_security|friendly_boolean }}
+                    {% else %}
+                        {{ good.uses_information_security|default_na }}
+                    {% endif %}
+                    {% if good.information_security_details %}
+                        <span class="govuk-hint">{{ good.information_security_details }}</span>
+                    {% endif %}
+                </dd>
+                <dd class="govuk-summary-list__actions">
+                    {% if good.status.key == 'draft' %}
+                        <a class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:good_information_security' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs 'Goods.AddGoodSummary.INFORMATION_SECURITY_FEATURES' %}</span></a>
+                    {% endif %}
+                </dd>
+            </div>
+        {% endif %}
 
-			<div class="govuk-summary-list__row">
-				<dt class="govuk-summary-list__key">
-					{% lcs "Goods.AddGoodSummary.MILITARY_USE" %}
-				</dt>
-				<dd class="govuk-summary-list__value">
-					{{ good.is_military_use.value|default_na }}
-					{% if good.modified_military_use_details %}
-						<span class="govuk-hint"> {{ good.modified_military_use_details }} </span>
-					{% endif %}
-				</dd>
-				<dd class="govuk-summary-list__actions">
-					{% if good.status.key == 'draft' %}
-						<a id="change-good-details" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:good_military_use' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs 'Goods.AddGoodSummary.MILITARY_USE' %}</span></a>
-					{% endif %}
-				</dd>
-			</div>
+        {% if good.item_category.key == 'group2_firearms' %}
+            {% with firearms_core_types="firearms ammunition components_for_firearms components_for_ammunition" %}
+                {% if good.firearm_details.type.key in firearms_core_types.split %}
+                    {% if good.firearm_details.type.key == "firearms" %}
+                        <div class="govuk-summary-list__row">
+                            <dt class="govuk-summary-list__key">
+                                {% lcs "Goods.AddGoodSummary.FirearmDetails.YEAR_OF_MANUFACTURE" %}
+                            </dt>
+                            <dd class="govuk-summary-list__value">
+                                {{ good.firearm_details.year_of_manufacture|default_na }}
+                            </dd>
+                            <dd class="govuk-summary-list__actions">
+                                {% if good.status.key == 'draft' %}
+                                    <a id="change-year-of-manufacture" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:year-of-manufacture' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "Goods.AddGoodSummary.FirearmDetails.YEAR_OF_MANUFACTURE" %}</span></a>
+                                {% endif %}
+                            </dd>
+                        </div>
+                        <div class="govuk-summary-list__row">
+                            <dt class="govuk-summary-list__key">
+                                {% lcs "Goods.AddGoodSummary.FirearmDetails.REPLICA_FIREARM" %}
+                            </dt>
+                            <dd class="govuk-summary-list__value">
+                                {% if good.firearm_details.is_replica is not None %}
+                                    {{ good.firearm_details.is_replica|friendly_boolean }}
+                                    <span class="govuk-hint">
+                                        {% if good.firearm_details.replica_description %}
+                                            {{ good.firearm_details.replica_description|default_na }}
+                                        {% endif %}
+                                    </span>
+                                {% else %}
+                                    N/A
+                                {% endif %}
+                            </dd>
+                            <dd class="govuk-summary-list__actions">
+                                {% if good.status.key == 'draft' %}
+                                    <a id="change-is-firearm-replica" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:replica' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "Goods.AddGoodSummary.FirearmDetails.REPLICA_FIREARM" %}</span></a>
+                                {% endif %}
+                            </dd>
+                        </div>
+                    {% endif %}
 
-			{% if good.item_category.key not in 'group3_software,group3_technology' %}
-				<div class="govuk-summary-list__row">
-					<dt class="govuk-summary-list__key">
-						{% lcs "Goods.AddGoodSummary.COMPONENT" %}
-					</dt>
-					<dd class="govuk-summary-list__value">
-						{{ good.is_component.value|default_na }}
-						{% if good.component_details %}
-							<span class="govuk-hint"> {{ good.component_details }} </span>
-						{% endif %}
-					</dd>
-					<dd class="govuk-summary-list__actions">
-						{% if good.status.key == 'draft' %}
-							<a class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:good_component' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs 'Goods.AddGoodSummary.COMPONENT' %}</span></a>
-						{% endif %}
-					</dd>
-				</div>
-			{% endif %}
+                    <div class="govuk-summary-list__row">
+                        <dt class="govuk-summary-list__key">
+                            {% lcs "Goods.AddGoodSummary.FirearmDetails.CALIBRE" %}
+                        </dt>
+                        <dd class="govuk-summary-list__value">
+                            {{ good.firearm_details.calibre|default_na }}
+                        </dd>
+                        <dd class="govuk-summary-list__actions">
+                            {% if good.status.key == 'draft' %}
+                                <a id="change-calibre" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:calibre' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "Goods.AddGoodSummary.FirearmDetails.CALIBRE" %}</span></a>
+                            {% endif %}
+                        </dd>
+                    </div>
 
-			<div class="govuk-summary-list__row">
-				<dt class="govuk-summary-list__key">
-					{% lcs "Goods.AddGoodSummary.INFORMATION_SECURITY_FEATURES" %}
-				</dt>
-				<dd class="govuk-summary-list__value">
-					{% if good.uses_information_security is not None %}
-						{{ good.uses_information_security|friendly_boolean }}
-					{% else %}
-						{{ good.uses_information_security|default_na }}
-					{% endif %}
-					{% if good.information_security_details %}
-						<span class="govuk-hint"> {{ good.information_security_details }} </span>
-					{% endif %}
-				</dd>
-				<dd class="govuk-summary-list__actions">
-					{% if good.status.key == 'draft' %}
-						<a class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:good_information_security' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs 'Goods.AddGoodSummary.INFORMATION_SECURITY_FEATURES' %}</span></a>
-					{% endif %}
-				</dd>
-			</div>
-		{% endif %}
+                    <div class="govuk-summary-list__row">
+                        <dt class="govuk-summary-list__key">
+                            {% lcs "Goods.AddGoodSummary.FirearmDetails.COVERED_BY_THE_FIREARMS_ACT_1968" %}
+                        </dt>
+                        <dd class="govuk-summary-list__value">
+                            {% with covered_by_firearms_act=good.firearm_details.is_covered_by_firearm_act_section_one_two_or_five section=good.firearm_details.firearms_act_section %}
+                                {% if covered_by_firearms_act == "Yes" %}
+                                    {{ covered_by_firearms_act }}
+                                    <span class="govuk-hint govuk-!-margin-0">
+                                        {% if section == "firearms_act_section1" %}
+                                            Section 1
+                                        {% elif section == "firearms_act_section2" %}
+                                            Section 2
+                                        {% elif section == "firearms_act_section5" %}
+                                            Section 5
+                                        {% endif %}
+                                    </span>
+                                    {% if not good.firearm_details.section_certificate_missing %}
+                                        {% if section == "firearms_act_section5" %}
+                                            <span class="govuk-hint govuk-!-margin-0">
+                                                Expires {{ section_document.expiry_date }}
+                                            </span>
+                                            <span class="govuk-hint govuk-!-margin-0">
+                                                Reference {{ section_document.reference_code }}
+                                            </span>
+                                        {% else %}
+                                            <span class="govuk-hint govuk-!-margin-0">
+                                                Expires {{ good.firearm_details.section_certificate_date_of_expiry|date_display }}
+                                            </span>
+                                            <span class="govuk-hint govuk-!-margin-0">
+                                                Reference {{ good.firearm_details.section_certificate_number }}
+                                            </span>
+                                        {% endif %}
+                                    {% endif %}
+                                {% elif covered_by_firearms_act == "No" %}
+                                    No
+                                {% elif covered_by_firearms_act == "Unsure" %}
+                                    I don't know
+                                {% endif %}
+                            {% endwith %}
+                        </dd>
+                        <dd class="govuk-summary-list__actions">
+                            {% if good.status.key == 'draft' %}
+                                <a id="change-firearms-act-details" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:firearms_act' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "Goods.AddGoodSummary.FirearmDetails.COVERED_BY_THE_FIREARMS_ACT_1968" %}</span></a>
+                            {% endif %}
+                        </dd>
+                    </div>
 
-		{% if good.item_category.key == 'group2_firearms' %}
-		{% with firearms_core_types="firearms ammunition components_for_firearms components_for_ammunition" %}
-			{% if good.firearm_details.type.key in firearms_core_types.split %}
-				{% if good.firearm_details.type.key == "firearms" %}
-					<div class="govuk-summary-list__row">
-						<dt class="govuk-summary-list__key">
-							{% lcs "Goods.AddGoodSummary.FirearmDetails.YEAR_OF_MANUFACTURE" %}
-						</dt>
-						<dd class="govuk-summary-list__value">
-							{{ good.firearm_details.year_of_manufacture|default_na }}
-						</dd>
-						<dd class="govuk-summary-list__actions">
-							{% if good.status.key == 'draft' %}
-								<a id="change-year-of-manufacture" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:year-of-manufacture' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "Goods.AddGoodSummary.FirearmDetails.YEAR_OF_MANUFACTURE" %}</span></a>
-							{% endif %}
-						</dd>
-					</div>
-					<div class="govuk-summary-list__row">
-						<dt class="govuk-summary-list__key">
-							{% lcs "Goods.AddGoodSummary.FirearmDetails.REPLICA_FIREARM" %}
-						</dt>
-						<dd class="govuk-summary-list__value">
-							{% if good.firearm_details.is_replica is not None %}
-								{{ good.firearm_details.is_replica|friendly_boolean }}
-								<span class="govuk-hint">
-									{% if good.firearm_details.replica_description %}
-										{{ good.firearm_details.replica_description|default_na }}
-									{% endif %}
-								</span>
-							{% else %}
-								N/A
-							{% endif %}
-						</dd>
-						<dd class="govuk-summary-list__actions">
-							{% if good.status.key == 'draft' %}
-								<a id="change-is-firearm-replica" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:replica' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "Goods.AddGoodSummary.FirearmDetails.REPLICA_FIREARM" %}</span></a>
-							{% endif %}
-						</dd>
-					</div>
-				{% endif %}
+                    {% if good.firearm_details.is_covered_by_firearm_act_section_one_two_or_five == "Yes" %}
+                        <div class="govuk-summary-list__row">
+                            <dt class="govuk-summary-list__key">Document</dt>
+                            <dd class="govuk-summary-list__value">
+                                {% if good.firearm_details.section_certificate_missing %}
+                                    No
+                                    <span class="govuk-hint govuk-!-margin-0">
+                                        {{ good.firearm_details.section_certificate_missing_reason }}
+                                    </span>
+                                {% else %}
+                                    Yes
+                                    {% for document in good_application_documents %}
+                                        <span class="govuk-hint govuk-!-margin-0">
+                                            <a {% if document.safe == True %}href="{% url 'applications:good-on-application-document' pk=application_id good_pk=good.id doc_pk=document.id %}"{% endif %} class="govuk-link--no-visited-state">{{ document.name }}</a>
+                                        </span>
+                                    {% endfor %}
+                                {% endif %}
+                            </dd>
+                            <dd class="govuk-summary-list__actions">
+                                {% if not is_rfd %}
+                                    {% if good.status.key == 'draft' %}
+                                        <a id="change-firearms-act-details" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:firearms_act_certificate' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "Goods.AddGoodSummary.FirearmDetails.COVERED_BY_THE_FIREARMS_ACT_1968" %}</span></a>
+                                    {% endif %}
+                                {% endif %}
+                            </dd>
+                        </div>
+                    {% endif %}
 
+                    <div class="govuk-summary-list__row">
+                        <dt class="govuk-summary-list__key">
+                            Number of items
+                        </dt>
+                        <dd class="govuk-summary-list__value">
+                            {{ good.firearm_details.number_of_items }}
+                        </dd>
+                        <dd class="govuk-summary-list__actions">
+                            {% if good.status.key == 'draft' %}
+                                <a id="change-number-of-items" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:number_of_items' application_id good.id %}">{% lcs 'generic.CHANGE' %}</a>
+                            {% endif %}
+                        </dd>
+                    </div>
+                    <div class="govuk-summary-list__row">
+                        <dt class="govuk-summary-list__key">
+                            {% lcs "Goods.AddGoodSummary.FirearmDetails.IDENTIFICATION_MARKINGS" %}
+                        </dt>
+                        <dd class="govuk-summary-list__value">
+                            {% if good.firearm_details.serial_numbers_available == "AVAILABLE" %}
+                                Yes, I can add serial numbers now
+                            {% elif good.firearm_details.serial_numbers_available == "LATER" %}
+                                Yes, I can add serial numbers later
+                            {% else %}
+                                No
+                                <span class="govuk-hint">
+                                    {{ good.firearm_details.no_identification_markings_details|default_na }}
+                                </span>
+                            {% endif %}
+                        </dd>
+                        <dd class="govuk-summary-list__actions">
+                            {% if good.status.key == 'draft' %}
+                                <a id="change-identification-markings" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:identification_markings' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "Goods.AddGoodSummary.FirearmDetails.IDENTIFICATION_MARKINGS" %}</span></a>
+                            {% endif %}
+                        </dd>
+                    </div>
 
-				<div class="govuk-summary-list__row">
-					<dt class="govuk-summary-list__key">
-						{% lcs "Goods.AddGoodSummary.FirearmDetails.CALIBRE" %}
-					</dt>
-					<dd class="govuk-summary-list__value">
-						{{ good.firearm_details.calibre|default_na }}
-					</dd>
-					<dd class="govuk-summary-list__actions">
-						{% if good.status.key == 'draft' %}
-							<a id="change-calibre" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:calibre' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "Goods.AddGoodSummary.FirearmDetails.CALIBRE" %}</span></a>
-						{% endif %}
-					</dd>
-				</div>
+                    {% if good.firearm_details.serial_numbers_available == "AVAILABLE" %}
+                        <div class="govuk-summary-list__row">
+                            <dt class="govuk-summary-list__key">
+                                Serial numbers
+                            </dt>
+                            <dd class="govuk-summary-list__value">
+                                <details class="govuk-details" data-module="govuk-details">
+                                    <summary class="govuk-details__summary">
+                                        <span class="govuk-details__summary-text">
+                                            View serial numbers
+                                        </span>
+                                    </summary>
+                                    <div class="govuk-details__text">
+                                        {% for item in good.firearm_details.serial_numbers %}
+                                            {{ forloop.counter}}. {{ item }} {%if not forloop.last %} <br> {% endif %}
+                                        {% endfor %}
+                                    </div>
+                                </details>
+                            </dd>
+                            <dd class="govuk-summary-list__actions">
+                                {% if good.status.key == 'draft' %}
+                                    <a id="change-serial-numbers" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:serial_numbers' application_id good.id %}">{% lcs 'generic.CHANGE' %}</a>
+                                {% endif %}
+                            </dd>
+                        </div>
+                    {% endif %}
+                {% endif %}
+            {% endwith %}
 
-				<div class="govuk-summary-list__row">
-					<dt class="govuk-summary-list__key">
-						{% lcs "Goods.AddGoodSummary.FirearmDetails.COVERED_BY_THE_FIREARMS_ACT_1968" %}
-					</dt>
-					<dd class="govuk-summary-list__value">
-						{% with covered_by_firearms_act=good.firearm_details.is_covered_by_firearm_act_section_one_two_or_five section=good.firearm_details.firearms_act_section %}
-							{% if covered_by_firearms_act == "Yes" %}
-								{{ covered_by_firearms_act }}
-								<span class="govuk-hint govuk-!-margin-0">
-									{% if section == "firearms_act_section1" %}
-										Section 1
-									{% elif section == "firearms_act_section2" %}
-										Section 2
-									{% elif section == "firearms_act_section5" %}
-										Section 5
-									{% endif %}
-								</span>
-								{% if not good.firearm_details.section_certificate_missing %}
-									{% if section == "firearms_act_section5" %}
-										<span class="govuk-hint govuk-!-margin-0">
-											Expires {{ section_document.expiry_date }}
-										</span>
-										<span class="govuk-hint govuk-!-margin-0">
-											Reference {{ section_document.reference_code }}
-										</span>
-									{% else %}
-										<span class="govuk-hint govuk-!-margin-0">
-											Expires {{ good.firearm_details.section_certificate_date_of_expiry|date_display }}
-										</span>
-										<span class="govuk-hint govuk-!-margin-0">
-											Reference {{ good.firearm_details.section_certificate_number }}
-										</span>
-									{% endif %}
-								{% endif %}
-							{% elif covered_by_firearms_act == "No" %}
-								No
-							{% elif covered_by_firearms_act == "Unsure" %}
-								I don't know
-							{% endif %}
-						{% endwith %}
-					</dd>
-					<dd class="govuk-summary-list__actions">
-						{% if good.status.key == 'draft' %}
-							<a id="change-firearms-act-details" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:firearms_act' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "Goods.AddGoodSummary.FirearmDetails.COVERED_BY_THE_FIREARMS_ACT_1968" %}</span></a>
-						{% endif %}
-					</dd>
-				</div>
+            {% if good.firearm_details.type.key == "firearms_accessory" %}
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        {% lcs "Goods.AddGoodSummary.MILITARY_USE" %}
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        {{ good.is_military_use.value|default_na }}
+                        {% if good.modified_military_use_details %}
+                            <span class="govuk-hint">{{ good.modified_military_use_details }}</span>
+                        {% endif %}
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                        {% if good.status.key == 'draft' %}
+                            <a id="change-good-details" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:good_military_use' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs 'Goods.AddGoodSummary.MILITARY_USE' %}</span></a>
+                        {% endif %}
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        {% lcs "Goods.AddGoodSummary.COMPONENT" %}
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        {{ good.is_component.value|default_na }}
+                        {% if good.component_details %}
+                            <span class="govuk-hint">{{ good.component_details }}</span>
+                        {% endif %}
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                        {% if good.status.key == 'draft' %}
+                            <a class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:good_component' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs 'Goods.AddGoodSummary.COMPONENT' %}</span></a>
+                        {% endif %}
+                    </dd>
+                </div>
 
-				{% if good.firearm_details.is_covered_by_firearm_act_section_one_two_or_five == "Yes" %}
-					<div class="govuk-summary-list__row">
-						<dt class="govuk-summary-list__key">Document</dt>
-						<dd class="govuk-summary-list__value">
-							{% if good.firearm_details.section_certificate_missing %}
-								No
-								<span class="govuk-hint govuk-!-margin-0">
-									{{ good.firearm_details.section_certificate_missing_reason }}
-								</span>
-							{% else %}
-								Yes
-								{% for document in good_application_documents %}
-									<span class="govuk-hint govuk-!-margin-0">
-										<a {% if document.safe == True %}href="{% url 'applications:good-on-application-document' pk=application_id good_pk=good.id doc_pk=document.id %}"{% endif %} class="govuk-link--no-visited-state">{{ document.name }}</a>
-									</span>
-								{% endfor %}
-							{% endif %}
-						</dd>
-						<dd class="govuk-summary-list__actions">
-							{% if not is_rfd %}
-								{% if good.status.key == 'draft' %}
-										<a id="change-firearms-act-details" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:firearms_act_certificate' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "Goods.AddGoodSummary.FirearmDetails.COVERED_BY_THE_FIREARMS_ACT_1968" %}</span></a>
-									{% endif %}
-							{% endif %}
-						</dd>
-					</div>
-				{% endif %}
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        {% lcs "Goods.AddGoodSummary.INFORMATION_SECURITY_FEATURES" %}
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        {% if good.uses_information_security is not None %}
+                            {{ good.uses_information_security|friendly_boolean }}
+                        {% else %}
+                            {{ good.uses_information_security|default_na }}
+                        {% endif %}
+                        {% if good.information_security_details %}
+                            <span class="govuk-hint">{{ good.information_security_details }}</span>
+                        {% endif %}
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                        {% if good.status.key == 'draft' %}
+                            <a class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:good_information_security' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs 'Goods.AddGoodSummary.INFORMATION_SECURITY_FEATURES' %}</span></a>
+                        {% endif %}
+                    </dd>
+                </div>
+            {% endif %}
 
-				<div class="govuk-summary-list__row">
-					<dt class="govuk-summary-list__key">
-						Number of items
-					</dt>
-					<dd class="govuk-summary-list__value">
-						{{ good.firearm_details.number_of_items }}
-					</dd>
-					<dd class="govuk-summary-list__actions">
-						{% if good.status.key == 'draft' %}
-							<a id="change-number-of-items" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:number_of_items' application_id good.id %}">{% lcs 'generic.CHANGE' %}</a>
-						{% endif %}
-					</dd>
-				</div>
-				<div class="govuk-summary-list__row">
-					<dt class="govuk-summary-list__key">
-						{% lcs "Goods.AddGoodSummary.FirearmDetails.IDENTIFICATION_MARKINGS" %}
-					</dt>
-					<dd class="govuk-summary-list__value">
-						{% if good.firearm_details.serial_numbers_available == "AVAILABLE" %}
-							Yes, I can add serial numbers now
-						{% elif good.firearm_details.serial_numbers_available == "LATER" %}
-							Yes, I can add serial numbers later
-						{% else %}
-							No
-							<span class="govuk-hint">
-								{{ good.firearm_details.no_identification_markings_details|default_na }}
-							</span>
-						{% endif %}
-					</dd>
-					<dd class="govuk-summary-list__actions">
-						{% if good.status.key == 'draft' %}
-							<a id="change-identification-markings" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:identification_markings' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs "Goods.AddGoodSummary.FirearmDetails.IDENTIFICATION_MARKINGS" %}</span></a>
-						{% endif %}
-					</dd>
-				</div>
-
-				{% if good.firearm_details.serial_numbers_available == "AVAILABLE" %}
-					<div class="govuk-summary-list__row">
-						<dt class="govuk-summary-list__key">
-							Serial numbers
-						</dt>
-						<dd class="govuk-summary-list__value">
-							<details class="govuk-details" data-module="govuk-details">
-								<summary class="govuk-details__summary">
-								  <span class="govuk-details__summary-text">
-									View serial numbers
-								  </span>
-								</summary>
-								<div class="govuk-details__text">
-									{% for item in good.firearm_details.serial_numbers %}
-									{{ forloop.counter}}. {{ item }} {%if not forloop.last %} <br> {% endif %}
-									{% endfor %}
-								</div>
-							  </details>
-						</dd>
-						<dd class="govuk-summary-list__actions">
-							{% if good.status.key == 'draft' %}
-								<a id="change-serial-numbers" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:serial_numbers' application_id good.id %}">{% lcs 'generic.CHANGE' %}</a>
-							{% endif %}
-						</dd>
-					</div>
-				{% endif %}
-			{% endif %}
-		{% endwith %}
-
-		{% if good.firearm_details.type.key == "firearms_accessory" %}
-			<div class="govuk-summary-list__row">
-				<dt class="govuk-summary-list__key">
-					{% lcs "Goods.AddGoodSummary.MILITARY_USE" %}
-				</dt>
-				<dd class="govuk-summary-list__value">
-					{{ good.is_military_use.value|default_na }}
-					{% if good.modified_military_use_details %}
-						<span class="govuk-hint"> {{ good.modified_military_use_details }} </span>
-					{% endif %}
-				</dd>
-				<dd class="govuk-summary-list__actions">
-					{% if good.status.key == 'draft' %}
-						<a id="change-good-details" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:good_military_use' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs 'Goods.AddGoodSummary.MILITARY_USE' %}</span></a>
-					{% endif %}
-				</dd>
-			</div>
-			<div class="govuk-summary-list__row">
-				<dt class="govuk-summary-list__key">
-					{% lcs "Goods.AddGoodSummary.COMPONENT" %}
-				</dt>
-				<dd class="govuk-summary-list__value">
-					{{ good.is_component.value|default_na }}
-					{% if good.component_details %}
-						<span class="govuk-hint"> {{ good.component_details }} </span>
-					{% endif %}
-				</dd>
-				<dd class="govuk-summary-list__actions">
-					{% if good.status.key == 'draft' %}
-						<a class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:good_component' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs 'Goods.AddGoodSummary.COMPONENT' %}</span></a>
-					{% endif %}
-				</dd>
-			</div>
-
-			<div class="govuk-summary-list__row">
-				<dt class="govuk-summary-list__key">
-					{% lcs "Goods.AddGoodSummary.INFORMATION_SECURITY_FEATURES" %}
-				</dt>
-				<dd class="govuk-summary-list__value">
-					{% if good.uses_information_security is not None %}
-						{{ good.uses_information_security|friendly_boolean }}
-					{% else %}
-						{{ good.uses_information_security|default_na }}
-					{% endif %}
-					{% if good.information_security_details %}
-						<span class="govuk-hint"> {{ good.information_security_details }} </span>
-					{% endif %}
-				</dd>
-				<dd class="govuk-summary-list__actions">
-					{% if good.status.key == 'draft' %}
-						<a class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:good_information_security' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs 'Goods.AddGoodSummary.INFORMATION_SECURITY_FEATURES' %}</span></a>
-					{% endif %}
-				</dd>
-			</div>
-		{% endif %}
-
-		{% if good.firearm_details.type.key == "software_related_to_firearms" or good.firearm_details.type.key == "technology_related_to_firearms" %}
-			<div class="govuk-summary-list__row">
-				<dt class="govuk-summary-list__key">
-					{% lcs 'Goods.AddGoodSummary.PURPOSE_SOFTWARE_TECHNOLOGY' %}
-				</dt>
-				<dd class="govuk-summary-list__value">
-					{{ good.software_or_technology_details|default_na  }}
-				</dd>
-				<dd class="govuk-summary-list__actions">
-					{% if good.status.key == 'draft' %}
-						<a id="change-good-technology-software" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:good_software_technology' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs 'Goods.AddGoodSummary.PURPOSE_SOFTWARE_TECHNOLOGY' %}</span></a>
-					{% endif %}
-				</dd>
-			</div>
-			<div class="govuk-summary-list__row">
-				<dt class="govuk-summary-list__key">
-					{% lcs "Goods.AddGoodSummary.MILITARY_USE" %}
-				</dt>
-				<dd class="govuk-summary-list__value">
-					{{ good.is_military_use.value|default_na }}
-					{% if good.modified_military_use_details %}
-						<span class="govuk-hint"> {{ good.modified_military_use_details }} </span>
-					{% endif %}
-				</dd>
-				<dd class="govuk-summary-list__actions">
-					{% if good.status.key == 'draft' %}
-						<a id="change-good-details" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:good_military_use' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs 'Goods.AddGoodSummary.MILITARY_USE' %}</span></a>
-					{% endif %}
-				</dd>
-			</div>
-			<div class="govuk-summary-list__row">
-				<dt class="govuk-summary-list__key">
-					{% lcs "Goods.AddGoodSummary.INFORMATION_SECURITY_FEATURES" %}
-				</dt>
-				<dd class="govuk-summary-list__value">
-					{% if good.uses_information_security is not None %}
-						{{ good.uses_information_security|friendly_boolean }}
-					{% else %}
-						{{ good.uses_information_security|default_na }}
-					{% endif %}
-					{% if good.information_security_details %}
-						<span class="govuk-hint"> {{ good.information_security_details }} </span>
-					{% endif %}
-				</dd>
-				<dd class="govuk-summary-list__actions">
-					{% if good.status.key == 'draft' %}
-						<a class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:good_information_security' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs 'Goods.AddGoodSummary.INFORMATION_SECURITY_FEATURES' %}</span></a>
-					{% endif %}
-				</dd>
-			</div>
-		{% endif %}
-
-		{% endif %}
-	</dl>
-	<a class="govuk-button" id="button-attach-document" href="{% url 'applications:check_document_availability' application_id good_id %}?preexisting=False">{% lcs "Goods.AddGoodSummary.SAVE_AND_CONTINUE_BUTTON" %}</a>
+            {% if good.firearm_details.type.key == "software_related_to_firearms" or good.firearm_details.type.key == "technology_related_to_firearms" %}
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        {% lcs 'Goods.AddGoodSummary.PURPOSE_SOFTWARE_TECHNOLOGY' %}
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        {{ good.software_or_technology_details|default_na  }}
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                        {% if good.status.key == 'draft' %}
+                            <a id="change-good-technology-software" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:good_software_technology' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs 'Goods.AddGoodSummary.PURPOSE_SOFTWARE_TECHNOLOGY' %}</span></a>
+                        {% endif %}
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        {% lcs "Goods.AddGoodSummary.MILITARY_USE" %}
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        {{ good.is_military_use.value|default_na }}
+                        {% if good.modified_military_use_details %}
+                            <span class="govuk-hint">{{ good.modified_military_use_details }}</span>
+                        {% endif %}
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                        {% if good.status.key == 'draft' %}
+                            <a id="change-good-details" class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:good_military_use' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs 'Goods.AddGoodSummary.MILITARY_USE' %}</span></a>
+                        {% endif %}
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        {% lcs "Goods.AddGoodSummary.INFORMATION_SECURITY_FEATURES" %}
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        {% if good.uses_information_security is not None %}
+                            {{ good.uses_information_security|friendly_boolean }}
+                        {% else %}
+                            {{ good.uses_information_security|default_na }}
+                        {% endif %}
+                        {% if good.information_security_details %}
+                            <span class="govuk-hint">{{ good.information_security_details }}</span>
+                        {% endif %}
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                        {% if good.status.key == 'draft' %}
+                            <a class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:good_information_security' application_id good.id %}">{% lcs 'generic.CHANGE' %} <span class="govuk-visually-hidden">{% lcs 'Goods.AddGoodSummary.INFORMATION_SECURITY_FEATURES' %}</span></a>
+                        {% endif %}
+                    </dd>
+                </div>
+            {% endif %}
+        {% endif %}
+    </dl>
+    <a class="govuk-button" id="button-attach-document" href="{% url 'applications:check_document_availability' application_id good_id %}?preexisting=False">{% lcs "Goods.AddGoodSummary.SAVE_AND_CONTINUE_BUTTON" %}</a>
 {% endblock %}

--- a/exporter/templates/applications/goods/add-good-detail-summary.html
+++ b/exporter/templates/applications/goods/add-good-detail-summary.html
@@ -324,13 +324,15 @@
 						{% lcs "Goods.AddGoodSummary.FirearmDetails.IDENTIFICATION_MARKINGS" %}
 					</dt>
 					<dd class="govuk-summary-list__value">
-						{% if good.firearm_details.has_identification_markings is not None %}
-								{{ good.firearm_details.has_identification_markings|friendly_boolean }}
-								<span class="govuk-hint">
-									{% if good.firearm_details.has_identification_markings is False %}
-										{{ good.firearm_details.no_identification_markings_details|default_na }}
-									{% endif %}
-								</span>
+						{% if good.firearm_details.serial_numbers_available == "AVAILABLE" %}
+							Yes, I can add serial numbers now
+						{% elif good.firearm_details.serial_numbers_available == "LATER" %}
+							Yes, I can add serial numbers later
+						{% else %}
+							No
+							<span class="govuk-hint">
+								{{ good.firearm_details.no_identification_markings_details|default_na }}
+							</span>
 						{% endif %}
 					</dd>
 					<dd class="govuk-summary-list__actions">
@@ -340,7 +342,7 @@
 					</dd>
 				</div>
 
-				{% if good.firearm_details.has_identification_markings %}
+				{% if good.firearm_details.serial_numbers_available == "AVAILABLE" %}
 					<div class="govuk-summary-list__row">
 						<dt class="govuk-summary-list__key">
 							Serial numbers

--- a/exporter/templates/applications/goods/goods-detail-summary.html
+++ b/exporter/templates/applications/goods/goods-detail-summary.html
@@ -1,501 +1,496 @@
 {% extends 'layouts/base.html' %}
 
 {% block back_link %}
-	<a href="{% if application_status_draft %} {% url 'applications:summary' application_id %} {% else %} {% url 'applications:application' application_id %} {% endif %}" id="back-link" class="govuk-back-link">{% lcs 'goods.GoodsDetailSummary.BACK_BUTTON' %}</a>
+    <a href="{% if application_status_draft %} {% url 'applications:summary' application_id %} {% else %} {% url 'applications:application' application_id %} {% endif %}" id="back-link" class="govuk-back-link">{% lcs 'goods.GoodsDetailSummary.BACK_BUTTON' %}</a>
 {% endblock %}
 
 {% block body %}
-	<div class="lite-app-bar">
-		<div class="lite-app-bar__content">
-			<h1 class="govuk-heading-l">
-				{% block title %} {% lcs 'goods.GoodsDetailSummary.TITLE' %} {% endblock %}
-			</h1>
-		</div>
-	</div>
+    <div class="lite-app-bar">
+        <div class="lite-app-bar__content">
+            <h1 class="govuk-heading-l">
+                {% block title %} {% lcs 'goods.GoodsDetailSummary.TITLE' %} {% endblock %}
+            </h1>
+        </div>
+    </div>
 
-	{% if goods %}
-		{% for good in goods %}
-			<h2 class="govuk-heading-m"> {% lcs 'goods.GoodsDetailSummary.HEADING' %} {{ forloop.counter }} </h2>
-			<dl class="govuk-summary-list" id="good-detail-summary{{ forloop.counter }}">
-				<div class="govuk-summary-list__row">
-					<dt class="govuk-summary-list__key">
-						{% lcs 'goods.GoodsDetailSummary.SELECT_CATEGORY' %}
-					</dt>
-					<dd class="govuk-summary-list__value">
-						{{ good.good.item_category.value }}
-					</dd>
-				</div>
-				<div class="govuk-summary-list__row">
-					<dt class="govuk-summary-list__key">
-						Name
-					</dt>
-					<dd class="govuk-summary-list__value">
-						{% if good.good.name %}
-							{{ good.good.name }}
-						{% else %}
-							{{ good.good.description }}
-						{% endif %}
-					</dd>
-				</div>
+    {% if goods %}
+        {% for good in goods %}
+            <h2 class="govuk-heading-m"> {% lcs 'goods.GoodsDetailSummary.HEADING' %} {{ forloop.counter }} </h2>
+            <dl class="govuk-summary-list" id="good-detail-summary{{ forloop.counter }}">
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        {% lcs 'goods.GoodsDetailSummary.SELECT_CATEGORY' %}
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        {{ good.good.item_category.value }}
+                    </dd>
+                </div>
 
-				<div class="govuk-summary-list__row">
-					<dt class="govuk-summary-list__key">
-						{% lcs "goods.GoodPage.Table.DESCRIPTION" %}
-					</dt>
-					<dd class="govuk-summary-list__value">
-						{{ good.good.description }}
-					</dd>
-				</div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        Name
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        {% if good.good.name %}
+                            {{ good.good.name }}
+                        {% else %}
+                            {{ good.good.description }}
+                        {% endif %}
+                    </dd>
+                </div>
 
-				<div class="govuk-summary-list__row">
-					<dt class="govuk-summary-list__key">
-						{% lcs 'goods.GoodsDetailSummary.PART_NUMBER' %}
-					</dt>
-					<dd class="govuk-summary-list__value">
-						{{ good.good.part_number|default_na }}
-					</dd>
-				</div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        {% lcs "goods.GoodPage.Table.DESCRIPTION" %}
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        {{ good.good.description }}
+                    </dd>
+                </div>
 
-				<div class="govuk-summary-list__row">
-					<dt class="govuk-summary-list__key">
-						{% lcs 'goods.GoodsDetailSummary.CONTROLLED' %}
-					</dt>
-					{% if good.good.control_list_entries %}
-						<dd class="govuk-summary-list__value">
-							{{ good.good.control_list_entries|display_clc_ratings }}
-						</dd>
-					{% else %}
-						<dd class="govuk-summary-list__value">
-							{{ good.good.control_list_entries|default_na }}
-						</dd>
-					{% endif %}
-				</div>
-				<div class="govuk-summary-list__row">
-					<dt class="govuk-summary-list__key">
-						{% lcs 'goods.GoodsDetailSummary.GRADED' %}
-					</dt>
-					<dd class="govuk-summary-list__value">
-						{% if good.good.pv_grading_details %}
-							{% lcs 'goods.GoodsDetailSummary.PV_GRADING_YES' %}
-						{% else %}
-							{% lcs 'goods.GoodsDetailSummary.PV_GRADING_NO' %}
-						{% endif %}
-					</dd>
-				</div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        {% lcs 'goods.GoodsDetailSummary.PART_NUMBER' %}
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        {{ good.good.part_number|default_na }}
+                    </dd>
+                </div>
 
-				{% if good.good.item_category.key != 'group2_firearms' %}
-					{% if good.good.item_category.key in 'group3_software,group3_technology' %}
-						<div class="govuk-summary-list__row">
-							<dt class="govuk-summary-list__key">
-								{% lcs "goods.GoodsDetailSummary.PURPOSE_SOFTWARE_TECHNOLOGY" %}
-							</dt>
-							<dd class="govuk-summary-list__value">
-								{{ good.good.software_or_technology_details|default_na }}
-							</dd>
-						</div>
-					{% endif %}
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        {% lcs 'goods.GoodsDetailSummary.CONTROLLED' %}
+                    </dt>
+                    {% if good.good.control_list_entries %}
+                        <dd class="govuk-summary-list__value">
+                            {{ good.good.control_list_entries|display_clc_ratings }}
+                        </dd>
+                    {% else %}
+                        <dd class="govuk-summary-list__value">
+                            {{ good.good.control_list_entries|default_na }}
+                        </dd>
+                    {% endif %}
+                </div>
 
-					<div class="govuk-summary-list__row">
-						<dt class="govuk-summary-list__key">
-							{% lcs 'goods.GoodsDetailSummary.MILITARY' %}
-						</dt>
-						<dd class="govuk-summary-list__value">
-							{{ good.good.is_military_use.value }}
-							{% if good.good.modified_military_use_details %}
-								<span class="govuk-hint"> {{ good.good.modified_military_use_details }} </span>
-							{% endif %}
-						</dd>
-					</div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        {% lcs 'goods.GoodsDetailSummary.GRADED' %}
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        {% if good.good.pv_grading_details %}
+                            {% lcs 'goods.GoodsDetailSummary.PV_GRADING_YES' %}
+                        {% else %}
+                            {% lcs 'goods.GoodsDetailSummary.PV_GRADING_NO' %}
+                        {% endif %}
+                    </dd>
+                </div>
 
-					{% if good.good.item_category.key not in 'group3_software,group3_technology' %}
-						<div class="govuk-summary-list__row">
-							<dt class="govuk-summary-list__key">
-								{% lcs 'goods.GoodsDetailSummary.COMPONENT' %}
-							</dt>
-							<dd class="govuk-summary-list__value">
-								{{ good.good.is_component.value|default_na }}
-								{% if good.good.component_details %}
-									<span class="govuk-hint"> {{ good.good.component_details }} </span>
-								{% endif %}
-							</dd>
-						</div>
-					{% endif %}
+                {% if good.good.item_category.key != 'group2_firearms' %}
+                    {% if good.good.item_category.key in 'group3_software,group3_technology' %}
+                        <div class="govuk-summary-list__row">
+                            <dt class="govuk-summary-list__key">
+                                {% lcs "goods.GoodsDetailSummary.PURPOSE_SOFTWARE_TECHNOLOGY" %}
+                            </dt>
+                            <dd class="govuk-summary-list__value">
+                                {{ good.good.software_or_technology_details|default_na }}
+                            </dd>
+                        </div>
+                    {% endif %}
 
-					<div class="govuk-summary-list__row">
-						<dt class="govuk-summary-list__key">
-							{% lcs 'goods.GoodsDetailSummary.DESIGNED_FOR_INFORMATION_SECURITY' %}
-						</dt>
-						<dd class="govuk-summary-list__value">
-							{% if good.good.uses_information_security is not None %}
-								{{ good.good.uses_information_security|friendly_boolean }}
-							{% else %}
-								{{ good.good.uses_information_security|default_na }}
-							{% endif %}
-							{% if good.good.information_security_details %}
-								<span class="govuk-hint"> {{ good.good.information_security_details }} </span>
-							{% endif %}
-						</dd>
-					</div>
-				{% endif %}
+                    <div class="govuk-summary-list__row">
+                        <dt class="govuk-summary-list__key">
+                            {% lcs 'goods.GoodsDetailSummary.MILITARY' %}
+                        </dt>
+                        <dd class="govuk-summary-list__value">
+                            {{ good.good.is_military_use.value }}
+                            {% if good.good.modified_military_use_details %}
+                                <span class="govuk-hint">{{ good.good.modified_military_use_details }}</span>
+                            {% endif %}
+                        </dd>
+                    </div>
 
-				{% if good.good.item_category.key == 'group2_firearms' %}
-					<div class="govuk-summary-list__row">
-						<dt class="govuk-summary-list__key">
-							{% lcs "goods.GoodsDetailSummary.FirearmDetails.PRODUCT_TYPE" %}
-						</dt>
-						<dd class="govuk-summary-list__value">
-							{{ good.good.firearm_details.type.value|default_na }}
-						</dd>
-					</div>
-					{% with firearm_core_types="firearms ammunition components_for_firearms components_for_ammunition" %}
-					{% if good.firearm_details and good.firearm_details.type.key in firearm_core_types.split %}
+                    {% if good.good.item_category.key not in 'group3_software,group3_technology' %}
+                        <div class="govuk-summary-list__row">
+                            <dt class="govuk-summary-list__key">
+                                {% lcs 'goods.GoodsDetailSummary.COMPONENT' %}
+                            </dt>
+                            <dd class="govuk-summary-list__value">
+                                {{ good.good.is_component.value|default_na }}
+                                {% if good.good.component_details %}
+                                    <span class="govuk-hint">{{ good.good.component_details }}</span>
+                                {% endif %}
+                            </dd>
+                        </div>
+                    {% endif %}
 
-						<div class="govuk-summary-list__row">
-							<dt class="govuk-summary-list__key">
-								{% lcs "goods.GoodsDetailSummary.FirearmDetails.YEAR_OF_MANUFACTURE" %}
-							</dt>
-							<dd class="govuk-summary-list__value">
-								{{ good.firearm_details.year_of_manufacture|default_na }}
-							</dd>
-						</div>
+                    <div class="govuk-summary-list__row">
+                        <dt class="govuk-summary-list__key">
+                            {% lcs 'goods.GoodsDetailSummary.DESIGNED_FOR_INFORMATION_SECURITY' %}
+                        </dt>
+                        <dd class="govuk-summary-list__value">
+                            {% if good.good.uses_information_security is not None %}
+                                {{ good.good.uses_information_security|friendly_boolean }}
+                            {% else %}
+                                {{ good.good.uses_information_security|default_na }}
+                            {% endif %}
+                            {% if good.good.information_security_details %}
+                                <span class="govuk-hint">{{ good.good.information_security_details }}</span>
+                            {% endif %}
+                        </dd>
+                    </div>
+                {% endif %}
 
-						<div class="govuk-summary-list__row">
-							<dt class="govuk-summary-list__key">
-								{% lcs "goods.GoodsDetailSummary.FirearmDetails.CALIBRE" %}
-							</dt>
-							<dd class="govuk-summary-list__value">
-								{{ good.good.firearm_details.calibre|default_na }}
-							</dd>
-						</div>
+                {% if good.good.item_category.key == 'group2_firearms' %}
+                    <div class="govuk-summary-list__row">
+                        <dt class="govuk-summary-list__key">
+                            {% lcs "goods.GoodsDetailSummary.FirearmDetails.PRODUCT_TYPE" %}
+                        </dt>
+                        <dd class="govuk-summary-list__value">
+                            {{ good.good.firearm_details.type.value|default_na }}
+                        </dd>
+                    </div>
+                    {% with firearm_core_types="firearms ammunition components_for_firearms components_for_ammunition" %}
+                        {% if good.firearm_details and good.firearm_details.type.key in firearm_core_types.split %}
+                            <div class="govuk-summary-list__row">
+                                <dt class="govuk-summary-list__key">
+                                    {% lcs "goods.GoodsDetailSummary.FirearmDetails.YEAR_OF_MANUFACTURE" %}
+                                </dt>
+                                <dd class="govuk-summary-list__value">
+                                    {{ good.firearm_details.year_of_manufacture|default_na }}
+                                </dd>
+                            </div>
 
-						{% if good.firearm_details %}
-						<div class="govuk-summary-list__row">
-							<dt class="govuk-summary-list__key">
-								Registered firearms dealer
-							</dt>
-							<dd class="govuk-summary-list__value">
-								{% if organisation_documents.rfd_certificate %}
-									<div>Yes</div>
-									<span class="govuk-hint govuk-!-margin-0">
-										Expires {{ organisation_documents.rfd_certificate.expiry_date }}
-									</span>
-									<span class="govuk-hint govuk-!-margin-0">
-										Reference {{ organisation_documents.rfd_certificate.reference_code }}
-									</span>
-					                <a href="{% url 'organisation:document' pk=organisation_documents.rfd_certificate.id %}" class="govuk-link govuk-link--no-visited-state govuk-!-margin-bottom-2" target="_blank">{{ organisation_documents.rfd_certificate.document.name }}</a>
-								{% else %}
-									No
-								{% endif %}
-							</dd>
-						</div>
-						{% endif %}
+                            <div class="govuk-summary-list__row">
+                                <dt class="govuk-summary-list__key">
+                                    {% lcs "goods.GoodsDetailSummary.FirearmDetails.CALIBRE" %}
+                                </dt>
+                                <dd class="govuk-summary-list__value">
+                                    {{ good.good.firearm_details.calibre|default_na }}
+                                </dd>
+                            </div>
 
-					<div class="govuk-summary-list__row">
-						<dt class="govuk-summary-list__key">
-							{% lcs "goods.GoodsDetailSummary.FirearmDetails.COVERED_BY_THE_FIREARMS_ACT_1968" %}
-						</dt>
-						<dd class="govuk-summary-list__value">
+                            {% if good.firearm_details %}
+                                <div class="govuk-summary-list__row">
+                                    <dt class="govuk-summary-list__key">
+                                        Registered firearms dealer
+                                    </dt>
+                                    <dd class="govuk-summary-list__value">
+                                        {% if organisation_documents.rfd_certificate %}
+                                            <div>Yes</div>
+                                            <span class="govuk-hint govuk-!-margin-0">
+                                                Expires {{ organisation_documents.rfd_certificate.expiry_date }}
+                                            </span>
+                                            <span class="govuk-hint govuk-!-margin-0">
+                                                Reference {{ organisation_documents.rfd_certificate.reference_code }}
+                                            </span>
+                                            <a href="{% url 'organisation:document' pk=organisation_documents.rfd_certificate.id %}" class="govuk-link govuk-link--no-visited-state govuk-!-margin-bottom-2" target="_blank">{{ organisation_documents.rfd_certificate.document.name }}</a>
+                                        {% else %}
+                                            No
+                                        {% endif %}
+                                    </dd>
+                                </div>
+                            {% endif %}
 
-							{% with covered_by_firearms_act=good.firearm_details.is_covered_by_firearm_act_section_one_two_or_five section=good.firearm_details.firearms_act_section %}
+                            <div class="govuk-summary-list__row">
+                                <dt class="govuk-summary-list__key">
+                                    {% lcs "goods.GoodsDetailSummary.FirearmDetails.COVERED_BY_THE_FIREARMS_ACT_1968" %}
+                                </dt>
+                                <dd class="govuk-summary-list__value">
+                                    {% with covered_by_firearms_act=good.firearm_details.is_covered_by_firearm_act_section_one_two_or_five section=good.firearm_details.firearms_act_section %}
+                                        {% if covered_by_firearms_act == "Yes" %}
+                                            {{ covered_by_firearms_act }}
+                                            <span class="govuk-hint govuk-!-margin-0">
+                                                {% if section == "firearms_act_section1" %}
+                                                    Section 1
+                                                {% elif section == "firearms_act_section2" %}
+                                                    Section 2
+                                                {% elif section == "firearms_act_section5" %}
+                                                    Section 5
+                                                {% endif %}
+                                            </span>
+                                            {% if not good.firearm_details.section_certificate_missing %}
+                                                <span class="govuk-hint govuk-!-margin-0">
+                                                    Expires {{ good.firearm_details.section_certificate_date_of_expiry|date_display }}
+                                                </span>
+                                                <span class="govuk-hint govuk-!-margin-0">
+                                                    Reference {{ good.firearm_details.section_certificate_number }}
+                                                </span>
+                                                {% if not good.good.firearm_details.section_certificate_missing %}
+                                                    <span class="govuk-hint govuk-!-margin-0">
+                                                        Expires {{ good.good.firearm_details.section_certificate_date_of_expiry|date_display }}
+                                                    </span>
+                                                    <span class="govuk-hint govuk-!-margin-0">
+                                                        Reference {{ good.good.firearm_details.section_certificate_number }}
+                                                    </span>
+                                                {% endif %}
+                                            {% endif %}
+                                        {% elif covered_by_firearms_act == "No" %}
+                                            No
+                                        {% elif covered_by_firearms_act == "Unsure" %}
+                                            I don't know
+                                        {% endif %}
+                                    {% endwith %}
+                                </dd>
+                            </div>
+                            {% if good.good.firearm_details.is_covered_by_firearm_act_section_one_two_or_five == "Yes" %}
+                                <div class="govuk-summary-list__row">
+                                    <dt class="govuk-summary-list__key">Document</dt>
+                                    <dd class="govuk-summary-list__value">
+                                        {% if good.good.firearm_details.section_certificate_missing %}
+                                            No
+                                            <span class="govuk-hint govuk-!-margin-0">
+                                                {{ good.good.firearm_details.section_certificate_missing_reason }}
+                                            </span>
+                                        {% else %}
+                                            Yes
+                                            {% for document in good.good_application_documents %}
+                                                <span class="govuk-hint govuk-!-margin-0">
+                                                    <a {% if document.safe == True %}href="{% url 'applications:good-on-application-document' pk=application_id good_pk=good.good.id doc_pk=document.id %}"{% endif %} class="govuk-link--no-visited-state">{{ document.name }}</a>
+                                                </span>
+                                            {% endfor %}
+                                        {% endif %}
+                                    </dd>
+                                </div>
+                            {% endif %}
 
-							{% if covered_by_firearms_act == "Yes" %}
-								{{ covered_by_firearms_act }}
-								<span class="govuk-hint govuk-!-margin-0">
-									{% if section == "firearms_act_section1" %}
-										Section 1
-									{% elif section == "firearms_act_section2" %}
-										Section 2
-									{% elif section == "firearms_act_section5" %}
-										Section 5
-									{% endif %}
-								</span>
-								{% if not good.firearm_details.section_certificate_missing %}
-									<span class="govuk-hint govuk-!-margin-0">
-										Expires {{ good.firearm_details.section_certificate_date_of_expiry|date_display }}
-									</span>
-									<span class="govuk-hint govuk-!-margin-0">
-										Reference {{ good.firearm_details.section_certificate_number }}
-									</span>
-									{% if not good.good.firearm_details.section_certificate_missing %}
-										<span class="govuk-hint govuk-!-margin-0">
-											Expires {{ good.good.firearm_details.section_certificate_date_of_expiry|date_display }}
-										</span>
-										<span class="govuk-hint govuk-!-margin-0">
-											Reference {{ good.good.firearm_details.section_certificate_number }}
-										</span>
-									{% endif %}
-								{% endif %}
-							{% elif covered_by_firearms_act == "No" %}
-								No
-							{% elif covered_by_firearms_act == "Unsure" %}
-								I don't know
-							{% endif %}
-							{% endwith %}
-							</dd>
-						</div>
-						{% if good.good.firearm_details.is_covered_by_firearm_act_section_one_two_or_five == "Yes" %}
-							<div class="govuk-summary-list__row">
-								<dt class="govuk-summary-list__key">Document</dt>
-								<dd class="govuk-summary-list__value">
-									{% if good.good.firearm_details.section_certificate_missing %}
-										No
-										<span class="govuk-hint govuk-!-margin-0">
-											{{ good.good.firearm_details.section_certificate_missing_reason }}
-										</span>
-									{% else %}
-										Yes
-										{% for document in good.good_application_documents %}
-											<span class="govuk-hint govuk-!-margin-0">
-												<a {% if document.safe == True %}href="{% url 'applications:good-on-application-document' pk=application_id good_pk=good.good.id doc_pk=document.id %}"{% endif %} class="govuk-link--no-visited-state">{{ document.name }}</a>
-											</span>
-										{% endfor %}
-									{% endif %}
-								</dd>
-							</div>
-						{% endif %}
+                            <div class="govuk-summary-list__row">
+                                <dt class="govuk-summary-list__key">
+                                    Number of items
+                                </dt>
+                                <dd class="govuk-summary-list__value">
+                                    {{ good.firearm_details.number_of_items}}
+                                </dd>
+                            </div>
 
-						<div class="govuk-summary-list__row">
-							<dt class="govuk-summary-list__key">
-								Number of items
-							</dt>
-							<dd class="govuk-summary-list__value">
-								{{ good.firearm_details.number_of_items}}
-							</dd>
-						</div>
+                            <div class="govuk-summary-list__row">
+                                <dt class="govuk-summary-list__key">
+                                    {% lcs "goods.GoodsDetailSummary.FirearmDetails.IDENTIFICATION_MARKINGS" %}
+                                </dt>
+                                <dd class="govuk-summary-list__value">
+                                    {% if good.firearm_details.serial_numbers_available == "AVAILABLE" %}
+                                        Yes, I can add serial numbers now
+                                    {% elif good.firearm_details.serial_numbers_available == "LATER" %}
+                                        Yes, I can add serial numbers later
+                                    {% else %}
+                                        No
+                                        <span class="govuk-hint">
+                                            {{ good.firearm_details.no_identification_markings_details|default_na }}
+                                        </span>
+                                    {% endif %}
+                                </dd>
+                            </div>
 
-						<div class="govuk-summary-list__row">
-							<dt class="govuk-summary-list__key">
-								{% lcs "goods.GoodsDetailSummary.FirearmDetails.IDENTIFICATION_MARKINGS" %}
-							</dt>
-							<dd class="govuk-summary-list__value">
-								{% if good.firearm_details.serial_numbers_available == "AVAILABLE" %}
-									Yes, I can add serial numbers now
-								{% elif good.firearm_details.serial_numbers_available == "LATER" %}
-									Yes, I can add serial numbers later
-								{% else %}
-									No
-									<span class="govuk-hint">
-										{{ good.firearm_details.no_identification_markings_details|default_na }}
-									</span>
-								{% endif %}
-							</dd>
-						</div>
+                            {% if good.firearm_details.serial_numbers_available == "AVAILABLE" %}
+                                <div class="govuk-summary-list__row">
+                                    <dt class="govuk-summary-list__key">
+                                        Serial numbers
+                                    </dt>
+                                    <dd class="govuk-summary-list__value">
+                                        <details class="govuk-details" data-module="govuk-details">
+                                            <summary class="govuk-details__summary">
+                                                <span class="govuk-details__summary-text">
+                                                    View serial numbers
+                                                </span>
+                                            </summary>
+                                            <div class="govuk-details__text">
+                                                {% for item in good.firearm_details.serial_numbers %}
+                                                    {{ forloop.counter}}. {{ item }} {%if not forloop.last %} <br> {% endif %}
+                                                {% endfor %}
+                                            </div>
+                                        </details>
+                                    </dd>
+                                </div>
+                            {% endif %}
+                        {% endif %}
+                    {% endwith %}
 
-						{% if good.firearm_details.serial_numbers_available == "AVAILABLE" %}
-							<div class="govuk-summary-list__row">
-								<dt class="govuk-summary-list__key">
-									Serial numbers
-								</dt>
-								<dd class="govuk-summary-list__value">
-									<details class="govuk-details" data-module="govuk-details">
-										<summary class="govuk-details__summary">
-										<span class="govuk-details__summary-text">
-											View serial numbers
-										</span>
-										</summary>
-										<div class="govuk-details__text">
-											{% for item in good.firearm_details.serial_numbers %}
-											{{ forloop.counter}}. {{ item }} {%if not forloop.last %} <br> {% endif %}
-											{% endfor %}
-										</div>
-									</details>
-								</dd>
-							</div>
-						{% endif %}
-					{% endif %}
-					{% endwith %}
+                    {% if good.firearm_details and good.firearm_details.type.key == "firearms_accessory" %}
+                        <div class="govuk-summary-list__row">
+                            <dt class="govuk-summary-list__key">
+                                {% lcs 'goods.GoodsDetailSummary.MILITARY' %}
+                            </dt>
+                            <dd class="govuk-summary-list__value">
+                                {{ good.good.is_military_use.value }}
+                                {% if good.good.modified_military_use_details %}
+                                    <span class="govuk-hint">{{ good.good.modified_military_use_details }}</span>
+                                {% endif %}
+                            </dd>
+                        </div>
 
-					{% if good.firearm_details and good.firearm_details.type.key == "firearms_accessory" %}
+                        <div class="govuk-summary-list__row">
+                            <dt class="govuk-summary-list__key">
+                                {% lcs 'goods.GoodsDetailSummary.COMPONENT' %}
+                            </dt>
+                            <dd class="govuk-summary-list__value">
+                                {{ good.good.is_component.value|default_na }}
+                                {% if good.good.component_details %}
+                                    <span class="govuk-hint">{{ good.good.component_details }}</span>
+                                {% endif %}
+                            </dd>
+                        </div>
 
-						<div class="govuk-summary-list__row">
-							<dt class="govuk-summary-list__key">
-								{% lcs 'goods.GoodsDetailSummary.MILITARY' %}
-							</dt>
-							<dd class="govuk-summary-list__value">
-								{{ good.good.is_military_use.value }}
-								{% if good.good.modified_military_use_details %}
-									<span class="govuk-hint"> {{ good.good.modified_military_use_details }} </span>
-								{% endif %}
-							</dd>
-						</div>
+                        <div class="govuk-summary-list__row">
+                            <dt class="govuk-summary-list__key">
+                                {% lcs 'goods.GoodsDetailSummary.DESIGNED_FOR_INFORMATION_SECURITY' %}
+                            </dt>
+                            <dd class="govuk-summary-list__value">
+                                {% if good.good.uses_information_security is not None %}
+                                    {{ good.good.uses_information_security|friendly_boolean }}
+                                {% else %}
+                                    {{ good.good.uses_information_security|default_na }}
+                                {% endif %}
+                                {% if good.good.information_security_details %}
+                                    <span class="govuk-hint">{{ good.good.information_security_details }}</span>
+                                {% endif %}
+                            </dd>
+                        </div>
+                    {% endif %}
 
-						<div class="govuk-summary-list__row">
-							<dt class="govuk-summary-list__key">
-								{% lcs 'goods.GoodsDetailSummary.COMPONENT' %}
-							</dt>
-							<dd class="govuk-summary-list__value">
-								{{ good.good.is_component.value|default_na }}
-								{% if good.good.component_details %}
-									<span class="govuk-hint"> {{ good.good.component_details }} </span>
-								{% endif %}
-							</dd>
-						</div>
-						<div class="govuk-summary-list__row">
-							<dt class="govuk-summary-list__key">
-								{% lcs 'goods.GoodsDetailSummary.DESIGNED_FOR_INFORMATION_SECURITY' %}
-							</dt>
-							<dd class="govuk-summary-list__value">
-								{% if good.good.uses_information_security is not None %}
-									{{ good.good.uses_information_security|friendly_boolean }}
-								{% else %}
-									{{ good.good.uses_information_security|default_na }}
-								{% endif %}
-								{% if good.good.information_security_details %}
-									<span class="govuk-hint"> {{ good.good.information_security_details }} </span>
-								{% endif %}
-							</dd>
-						</div>
-					{% endif %}
-					{% if good.firearm_details.type.key == "software_related_to_firearms" or good.firearm_details.type.key == "technology_related_to_firearms" %}
-						<div class="govuk-summary-list__row">
-							<dt class="govuk-summary-list__key">
-								{% lcs "goods.GoodsDetailSummary.PURPOSE_SOFTWARE_TECHNOLOGY" %}
-							</dt>
-							<dd class="govuk-summary-list__value">
-								{{ good.good.software_or_technology_details|default_na }}
-							</dd>
-						</div>
+                    {% if good.firearm_details.type.key == "software_related_to_firearms" or good.firearm_details.type.key == "technology_related_to_firearms" %}
+                        <div class="govuk-summary-list__row">
+                            <dt class="govuk-summary-list__key">
+                                {% lcs "goods.GoodsDetailSummary.PURPOSE_SOFTWARE_TECHNOLOGY" %}
+                            </dt>
+                            <dd class="govuk-summary-list__value">
+                                {{ good.good.software_or_technology_details|default_na }}
+                            </dd>
+                        </div>
 
-						<div class="govuk-summary-list__row">
-							<dt class="govuk-summary-list__key">
-								{% lcs 'goods.GoodsDetailSummary.MILITARY' %}
-							</dt>
-							<dd class="govuk-summary-list__value">
-								{{ good.good.is_military_use.value }}
-								{% if good.good.modified_military_use_details %}
-									<span class="govuk-hint"> {{ good.good.modified_military_use_details }} </span>
-								{% endif %}
-							</dd>
-						</div>
+                        <div class="govuk-summary-list__row">
+                            <dt class="govuk-summary-list__key">
+                                {% lcs 'goods.GoodsDetailSummary.MILITARY' %}
+                            </dt>
+                            <dd class="govuk-summary-list__value">
+                                {{ good.good.is_military_use.value }}
+                                {% if good.good.modified_military_use_details %}
+                                    <span class="govuk-hint">{{ good.good.modified_military_use_details }}</span>
+                                {% endif %}
+                            </dd>
+                        </div>
 
-						<div class="govuk-summary-list__row">
-							<dt class="govuk-summary-list__key">
-								{% lcs 'goods.GoodsDetailSummary.DESIGNED_FOR_INFORMATION_SECURITY' %}
-							</dt>
-							<dd class="govuk-summary-list__value">
-								{% if good.good.uses_information_security is not None %}
-									{{ good.good.uses_information_security|friendly_boolean }}
-								{% else %}
-									{{ good.good.uses_information_security|default_na }}
-								{% endif %}
-								{% if good.good.information_security_details %}
-									<span class="govuk-hint"> {{ good.good.information_security_details }} </span>
-								{% endif %}
-							</dd>
-						</div>
+                        <div class="govuk-summary-list__row">
+                            <dt class="govuk-summary-list__key">
+                                {% lcs 'goods.GoodsDetailSummary.DESIGNED_FOR_INFORMATION_SECURITY' %}
+                            </dt>
+                            <dd class="govuk-summary-list__value">
+                                {% if good.good.uses_information_security is not None %}
+                                    {{ good.good.uses_information_security|friendly_boolean }}
+                                {% else %}
+                                    {{ good.good.uses_information_security|default_na }}
+                                {% endif %}
+                                {% if good.good.information_security_details %}
+                                    <span class="govuk-hint">{{ good.good.information_security_details }}</span>
+                                {% endif %}
+                            </dd>
+                        </div>
+                    {% endif %}
+                {% endif %}
 
-					{% endif %}
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        {% lcs 'goods.GoodsDetailSummary.INCORPORATED' %}
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        {{ good.is_good_incorporated|friendly_boolean|default_na }}
+                    </dd>
+                </div>
 
+                {% if good.good.pv_grading_details %}
+                    <div class="govuk-summary-list__row">
+                        <dt class="govuk-summary-list__key">
+                            {% lcs 'goods.GoodGradingForm.PREFIX' %}
+                        </dt>
+                        <dd class="govuk-summary-list__value">
+                            {{ good.good.pv_grading_details.prefix|default_na }}
+                        </dd>
+                    </div>
 
-				{% endif %}
+                    <div class="govuk-summary-list__row">
+                        <dt class="govuk-summary-list__key">
+                            {% lcs 'goods.GoodGradingForm.GRADING' %}
+                        </dt>
+                        <dd class="govuk-summary-list__value">
+                            {% if good.good.pv_grading_details.grading %}
+                                {{ good.good.pv_grading_details.grading.value }}
+                            {% else %}
+                                {{ good.good.pv_grading_details.custom_grading }}
+                            {% endif %}
+                        </dd>
+                    </div>
 
-				<div class="govuk-summary-list__row">
-					<dt class="govuk-summary-list__key">
-						{% lcs 'goods.GoodsDetailSummary.INCORPORATED' %}
-					</dt>
-					<dd class="govuk-summary-list__value">
-						{{ good.is_good_incorporated|friendly_boolean|default_na }}
-					</dd>
-				</div>
+                    <div class="govuk-summary-list__row">
+                        <dt class="govuk-summary-list__key">
+                            {% lcs 'goods.GoodGradingForm.SUFFIX' %}
+                        </dt>
+                        <dd class="govuk-summary-list__value">
+                            {{ good.good.pv_grading_details.suffix|default_na }}
+                        </dd>
+                    </div>
 
-				{% if good.good.pv_grading_details %}
-					<div class="govuk-summary-list__row">
-						<dt class="govuk-summary-list__key">
-							{% lcs 'goods.GoodGradingForm.PREFIX' %}
-						</dt>
-						<dd class="govuk-summary-list__value">
-							{{ good.good.pv_grading_details.prefix|default_na }}
-						</dd>
-					</div>
+                    <div class="govuk-summary-list__row">
+                        <dt class="govuk-summary-list__key">
+                            {% lcs 'goods.GoodGradingForm.ISSUING_AUTHORITY' %}
+                        </dt>
+                        <dd class="govuk-summary-list__value">
+                            {{ good.good.pv_grading_details.issuing_authority }}
+                        </dd>
+                    </div>
 
-					<div class="govuk-summary-list__row">
-						<dt class="govuk-summary-list__key">
-							{% lcs 'goods.GoodGradingForm.GRADING' %}
-						</dt>
-						<dd class="govuk-summary-list__value">
-							{% if good.good.pv_grading_details.grading %}
-								{{ good.good.pv_grading_details.grading.value }}
-							{% else %}
-								{{ good.good.pv_grading_details.custom_grading }}
-							{% endif %}
-						</dd>
-					</div>
+                    <div class="govuk-summary-list__row">
+                        <dt class="govuk-summary-list__key">
+                            {% lcs 'goods.GoodGradingForm.REFERENCE' %}
+                        </dt>
+                        <dd class="govuk-summary-list__value">
+                            {{ good.good.pv_grading_details.reference }}
+                        </dd>
+                    </div>
 
-					<div class="govuk-summary-list__row">
-						<dt class="govuk-summary-list__key">
-							{% lcs 'goods.GoodGradingForm.SUFFIX' %}
-						</dt>
-						<dd class="govuk-summary-list__value">
-							{{ good.good.pv_grading_details.suffix|default_na }}
-						</dd>
-					</div>
+                    <div class="govuk-summary-list__row">
+                        <dt class="govuk-summary-list__key">
+                            {% lcs 'goods.GoodGradingForm.DATE_OF_ISSUE' %}
+                        </dt>
+                        <dd class="govuk-summary-list__value">
+                            {{ good.good.pv_grading_details.date_of_issue|str_date_only }}
+                        </dd>
+                    </div>
+                {% endif %}
 
-					<div class="govuk-summary-list__row">
-						<dt class="govuk-summary-list__key">
-							{% lcs 'goods.GoodGradingForm.ISSUING_AUTHORITY' %}
-						</dt>
-						<dd class="govuk-summary-list__value">
-							{{ good.good.pv_grading_details.issuing_authority }}
-						</dd>
-					</div>
-
-					<div class="govuk-summary-list__row">
-						<dt class="govuk-summary-list__key">
-							{% lcs 'goods.GoodGradingForm.REFERENCE' %}
-						</dt>
-						<dd class="govuk-summary-list__value">
-							{{ good.good.pv_grading_details.reference }}
-						</dd>
-					</div>
-
-					<div class="govuk-summary-list__row">
-						<dt class="govuk-summary-list__key">
-							{% lcs 'goods.GoodGradingForm.DATE_OF_ISSUE' %}
-						</dt>
-						<dd class="govuk-summary-list__value">
-							{{ good.good.pv_grading_details.date_of_issue|str_date_only }}
-						</dd>
-					</div>
-
-				{% endif %}
-
-				<div class="govuk-summary-list__row">
-					<dt class="govuk-summary-list__key">
-						{% lcs "goods.GoodsDetailSummary.DOCUMENTS" %}
-					</dt>
-					{% if good.good.documents %}
-						<dd class="govuk-summary-list__value">
-							{% if good.good.documents|length > 1 %}
-								<ol class="govuk-list govuk-list--number">
-									{% for document in good.good.documents %}
-									<li>
-										<a {% if document.safe == True %}href="{% url 'goods:document' pk=good.good.id file_pk=document.id %}"{% endif %} class="govuk-link--no-visited-state">{{ document.name }}</a><br>
-										<span class="govuk-hint"> {{ document.description }} </span>
-									</li>
-									{% endfor %}
-								</ol>
-							{% else %}
-								{% with document=good.good.documents.0 %}
-									<a {% if document.safe == True %}href="{% url 'goods:document' pk=good.good.id file_pk=document.id %}"{% endif %} class="govuk-link--no-visited-state">{{ document.name }}</a><br>
-									<span class="govuk-hint"> {{ document.description }} </span>
-								{% endwith %}
-							{% endif %}
-						</dd>
-					{% else %}
-						{% if good.good.is_document_sensitive %}
-							<dd class="govuk-summary-list__value">
-								Document is above OFFICIAL-SENSITIVE
-							</dd>
-						{% elif not good.good.is_document_available %}
-							<dd class="govuk-summary-list__value">
-								No document available
-								<span class="govuk-hint">{{ good.no_document_comments }}</span>
-							</dd>
-						{% endif %}
-					{% endif %}
-				</div>
-			</dl>
-		{% endfor %}
-
-	{% endif %}
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        {% lcs "goods.GoodsDetailSummary.DOCUMENTS" %}
+                    </dt>
+                    {% if good.good.documents %}
+                        <dd class="govuk-summary-list__value">
+                            {% if good.good.documents|length > 1 %}
+                                <ol class="govuk-list govuk-list--number">
+                                    {% for document in good.good.documents %}
+                                        <li>
+                                            <a {% if document.safe == True %}href="{% url 'goods:document' pk=good.good.id file_pk=document.id %}"{% endif %} class="govuk-link--no-visited-state">{{ document.name }}</a><br>
+                                            <span class="govuk-hint"> {{ document.description }} </span>
+                                        </li>
+                                    {% endfor %}
+                                </ol>
+                            {% else %}
+                                {% with document=good.good.documents.0 %}
+                                    <a {% if document.safe == True %}href="{% url 'goods:document' pk=good.good.id file_pk=document.id %}"{% endif %} class="govuk-link--no-visited-state">{{ document.name }}</a><br>
+                                    <span class="govuk-hint"> {{ document.description }} </span>
+                                {% endwith %}
+                            {% endif %}
+                        </dd>
+                    {% else %}
+                        {% if good.good.is_document_sensitive %}
+                            <dd class="govuk-summary-list__value">
+                                Document is above OFFICIAL-SENSITIVE
+                            </dd>
+                        {% elif not good.good.is_document_available %}
+                            <dd class="govuk-summary-list__value">
+                                No document available
+                                <span class="govuk-hint">{{ good.no_document_comments }}</span>
+                            </dd>
+                        {% endif %}
+                    {% endif %}
+                </div>
+            </dl>
+        {% endfor %}
+    {% endif %}
 {% endblock %}

--- a/exporter/templates/applications/goods/goods-detail-summary.html
+++ b/exporter/templates/applications/goods/goods-detail-summary.html
@@ -268,18 +268,20 @@
 								{% lcs "goods.GoodsDetailSummary.FirearmDetails.IDENTIFICATION_MARKINGS" %}
 							</dt>
 							<dd class="govuk-summary-list__value">
-								{% if good.firearm_details.has_identification_markings is not None %}
-									{{ good.firearm_details.has_identification_markings|friendly_boolean }}
+								{% if good.firearm_details.serial_numbers_available == "AVAILABLE" %}
+									Yes, I can add serial numbers now
+								{% elif good.firearm_details.serial_numbers_available == "LATER" %}
+									Yes, I can add serial numbers later
+								{% else %}
+									No
 									<span class="govuk-hint">
-										{% if good.firearm_details.has_identification_markings is False %}
-											{{ good.firearm_details.no_identification_markings_details|default_na }}
-										{% endif %}
+										{{ good.firearm_details.no_identification_markings_details|default_na }}
 									</span>
 								{% endif %}
 							</dd>
 						</div>
 
-						{% if good.firearm_details.has_identification_markings is True %}
+						{% if good.firearm_details.serial_numbers_available == "AVAILABLE" %}
 							<div class="govuk-summary-list__row">
 								<dt class="govuk-summary-list__key">
 									Serial numbers

--- a/lite_content/lite_exporter_frontend/goods.py
+++ b/lite_content/lite_exporter_frontend/goods.py
@@ -256,11 +256,10 @@ class CreateGoodForm:
             DONT_KNOW = "I don't know"
 
         class IdentificationMarkings:
-            TITLE = "Has the product been marked with a serial number or other type of identification marking?"
-            MARKINGS_DETAILS = "Serial number or other type of marking"
-            MARKINGS_HELP_TEXT = "Enter one or more"
+            TITLE = "Will each product have a serial number or other identification marking?"
             NO_MARKINGS_DETAILS = "Explain why the product has not been marked"
-            YES = "Yes"
+            YES_NOW = "Yes, I can add serial numbers now"
+            YES_LATER = "Yes, I can add serial numbers later"
             NO = "No"
 
             BUTTON_TEXT = "Continue"

--- a/unit_tests/caseworker/cases/test_views.py
+++ b/unit_tests/caseworker/cases/test_views.py
@@ -389,8 +389,8 @@ def test_good_on_application_detail_clc_entries(
     assert response.status_code == 200
     soup = BeautifulSoup(response.content.decode("utf-8"), "html.parser")
     clc_entries = soup.find(id="control-list-entries-value").text
-    clc_entries = clc_entries.replace("\n", "").replace("\t", "")
-    assert clc_entries == "ML1, ML2"
+    clc_entries = "".join(line.strip() for line in clc_entries.split("\n"))
+    assert clc_entries == "ML1,ML2"
 
     data_good_on_application["is_good_controlled"] = None
     data_good_on_application["control_list_entries"] = []
@@ -403,8 +403,8 @@ def test_good_on_application_detail_clc_entries(
     assert response.status_code == 200
     soup = BeautifulSoup(response.content.decode("utf-8"), "html.parser")
     clc_entries = soup.find(id="control-list-entries-value").text
-    clc_entries = clc_entries.replace("\n", "").replace("\t", "")
-    assert clc_entries == "ML4, ML5"
+    clc_entries = "".join(line.strip() for line in clc_entries.split("\n"))
+    assert clc_entries == "ML4,ML5"
 
 
 def test_good_on_application_detail_security_graded_check(
@@ -425,5 +425,5 @@ def test_good_on_application_detail_security_graded_check(
         assert response.status_code == 200
         soup = BeautifulSoup(response.content.decode("utf-8"), "html.parser")
         security_grading = soup.find(id="security-graded-value").text
-        security_grading = security_grading.replace("\n", "").replace("\t", "")
+        security_grading = "".join(line.strip() for line in security_grading.split("\n"))
         assert security_grading == expected_value.capitalize()

--- a/unit_tests/exporter/goods/test_forms.py
+++ b/unit_tests/exporter/goods/test_forms.py
@@ -174,37 +174,45 @@ def test_firearms_number_of_items_form(data, valid, error_field, error_message):
 
 
 @pytest.mark.parametrize(
-    "data, valid, error_field, error_message",
+    "data, valid, errors",
     (
-        ({"has_identification_markings": "True"}, True, None, None),
         (
-            {"has_identification_markings": "False", "no_identification_markings_details": "test details"},
+            {},
+            False,
+            {
+                "serial_numbers_available": [
+                    "Select whether you can enter serial numbers now, later or the product does not have them."
+                ]
+            },
+        ),
+        (
+            {"serial_numbers_available": "AVAILABLE"},
             True,
-            None,
-            None,
+            {},
         ),
         (
-            {"has_identification_markings": "False", "no_identification_markings_details": ""},
-            False,
-            "no_identification_markings_details",
-            "Enter a reason why the product has not been marked",
+            {"serial_numbers_available": "LATER"},
+            True,
+            {},
         ),
         (
-            {"has_identification_markings": ""},
+            {"serial_numbers_available": "NOT_AVAILABLE", "no_identification_markings_details": "test details"},
+            True,
+            {},
+        ),
+        (
+            {"serial_numbers_available": "NOT_AVAILABLE", "no_identification_markings_details": ""},
             False,
-            "has_identification_markings",
-            "Select yes if the product has identification markings",
+            {"no_identification_markings_details": ["Enter a reason why the product has not been marked"]},
         ),
     ),
 )
-def test_identification_markings_form(data, valid, error_field, error_message):
+def test_identification_markings_form(data, valid, errors):
     form = forms.IdentificationMarkingsForm(data=data)
 
     assert form.is_valid() == valid
     assert form.cleaned_data["identification_markings_step"]
-
-    if not valid:
-        assert form.errors[error_field][0] == error_message
+    assert form.errors == errors
 
 
 @pytest.mark.parametrize(

--- a/unit_tests/exporter/goods/views/test_good_detail.py
+++ b/unit_tests/exporter/goods/views/test_good_detail.py
@@ -36,7 +36,7 @@ def good():
             "section_certificate_missing_reason": "",
             "section_certificate_number": None,
             "section_certificate_date_of_expiry": None,
-            "has_identification_markings": None,
+            "serial_numbers_available": None,
             "no_identification_markings_details": None,
             "has_proof_mark": None,
             "no_proof_mark_details": "",

--- a/unit_tests/exporter/goods/views/test_single_form_views.py
+++ b/unit_tests/exporter/goods/views/test_single_form_views.py
@@ -52,22 +52,20 @@ def test_edit_identification_markings_view(authorized_client, requests_mock, goo
     url = reverse("goods:identification_markings", kwargs={"pk": good_pk})
     requests_mock.get(
         f"/goods/{good_pk}/details/?pk={good_pk}",
-        json={
-            "good": {"firearm_details": {"has_identification_markings": "", "no_identification_markings_details": ""}}
-        },
+        json={"good": {"firearm_details": {"serial_numbers_available": "", "no_identification_markings_details": ""}}},
     )
     requests_mock.put(f"/goods/{good_pk}/details/", json={})
 
     response = authorized_client.post(
         url,
         data={
-            "has_identification_markings": True,
+            "serial_numbers_available": "AVAILABLE",
         },
     )
 
     assert response.status_code == 302
     assert response.url == reverse("goods:good", kwargs={"pk": good_pk})
-    assert requests_mock.last_request.json()["has_identification_markings"]
+    assert requests_mock.last_request.json()["serial_numbers_available"]
 
 
 def test_edit_serial_numbers_view(authorized_client, requests_mock, good_pk):


### PR DESCRIPTION
This updates the question posed as to whether a product has serial numbers or not. Originally this was a boolean choice, whereas now the exporter can choose to indicate that their product has serial numbers but would like to provide them at a later date.

There are some additional changes to some of the affected HTML files to tidy up their indentation which was inconsistent and sometimes confusing, the [ first commit](https://github.com/uktrade/lite-frontend/pull/445/commits/ffff340ac2ae476c7360bc0923367a7d8bbf588a) has the bulk of the core changes without the HTML indentation changes.