### PR TITLE
Enter serial numbers later

### DIFF
--- a/caseworker/cases/helpers/case.py
+++ b/caseworker/cases/helpers/case.py
@@ -4,8 +4,9 @@ from django.shortcuts import render
 from django.utils import timezone
 from django.views.generic import TemplateView
 
+from core.constants import CaseStatusEnum
+
 from caseworker.advice.services import get_advice_tab_context
-from caseworker.cases.constants import CaseStatusEnum
 from caseworker.cases.helpers.ecju_queries import get_ecju_queries
 from caseworker.cases.objects import Slice, Case
 from caseworker.cases.services import (

--- a/caseworker/core/services.py
+++ b/caseworker/core/services.py
@@ -2,8 +2,9 @@ from collections import defaultdict
 
 from caseworker.users.services import get_gov_user
 from core import client
+from core.constants import CaseStatusEnum
 from core.helpers import convert_value_to_query_param
-from caseworker.cases.constants import CaseType, CaseStatusEnum
+from caseworker.cases.constants import CaseType
 from lite_forms.components import Option
 
 

--- a/core/constants.py
+++ b/core/constants.py
@@ -1,6 +1,64 @@
+import re
+
+
 class GoodsTypeCategory:
     MILITARY = "military"
     CRYPTOGRAPHIC = "cryptographic"
     MEDIA = "media"
     UK_CONTINENTAL_SHELF = "uk_continental_shelf"
     DEALER = "dealer"
+
+
+class CaseStatusEnum:
+    APPEAL_FINAL_REVIEW = "appeal_final_review"
+    APPEAL_REVIEW = "appeal_review"
+    APPLICANT_EDITING = "applicant_editing"
+    CHANGE_INTIAL_REVIEW = "change_initial_review"
+    CHANGE_UNDER_FINAL_REVIEW = "change_under_final_review"
+    CHANGE_UNDER_REVIEW = "change_under_review"
+    CLC = "clc_review"
+    OPEN = "open"
+    UNDER_INTERNAL_REVIEW = "under_internal_review"
+    RETURN_TO_INSPECTOR = "return_to_inspector"
+    AWAITING_EXPORTER_RESPONSE = "awaiting_exporter_response"
+    CLOSED = "closed"
+    DEREGISTERED = "deregistered"
+    DRAFT = "draft"  # System only status
+    FINALISED = "finalised"
+    INITIAL_CHECKS = "initial_checks"
+    PV = "pv_review"
+    REGISTERED = "registered"
+    REOPENED_FOR_CHANGES = "reopened_for_changes"
+    REOPENED_DUE_TO_ORG_CHANGES = "reopened_due_to_org_changes"
+    RESUBMITTED = "resubmitted"
+    REVOKED = "revoked"
+    OGD_ADVICE = "ogd_advice"
+    SUBMITTED = "submitted"
+    SURRENDERED = "surrendered"
+    SUSPENDED = "suspended"
+    UNDER_APPEAL = "under_appeal"
+    UNDER_ECJU_REVIEW = "under_ECJU_review"
+    UNDER_FINAL_REVIEW = "under_final_review"
+    UNDER_REVIEW = "under_review"
+    WITHDRAWN = "withdrawn"
+
+    @classmethod
+    def base_query_statuses(cls):
+        return [cls.SUBMITTED, cls.CLOSED, cls.WITHDRAWN]
+
+    @classmethod
+    def is_terminal(cls, status):
+        return status in [
+            cls.CLOSED,
+            cls.DEREGISTERED,
+            cls.FINALISED,
+            cls.REGISTERED,
+            cls.REVOKED,
+            cls.SURRENDERED,
+            cls.WITHDRAWN,
+        ]
+
+    @classmethod
+    def all(cls):
+        is_all_upper = re.compile(r"^[A-Z_]+$")
+        return [getattr(cls, param) for param in dir(cls) if is_all_upper.match(param)]

--- a/exporter/applications/services.py
+++ b/exporter/applications/services.py
@@ -428,3 +428,10 @@ def post_exhibition(request, pk, data):
     post_data = format_date_fields(data)
     data = client.post(request, f"/applications/{pk}/exhibition-details/", data=post_data)
     return data.json(), data.status_code
+
+
+def edit_good_on_application_firearm_details_serial_numbers(request, pk, good_on_application_pk, json):
+    data = client.put(
+        request, f"/applications/{pk}/good-on-application/{good_on_application_pk}/update-serial-numbers/", json
+    )
+    return data.json(), data.status_code

--- a/exporter/applications/urls.py
+++ b/exporter/applications/urls.py
@@ -110,17 +110,17 @@ urlpatterns = [
         name="firearms_act_certificate",
     ),
     path(
-        "<uuid:pk>/goods/<uuid:good_pk>/edit-firearm-details/identification_markings/",
+        "<uuid:pk>/goods/<uuid:good_pk>/edit-firearm-details/identification-markings/",
         EditIdentificationMarkingsView.as_view(),
         name="identification_markings",
     ),
     path(
-        "<uuid:pk>/goods/<uuid:good_pk>/edit-firearm-details/number_of_items/",
+        "<uuid:pk>/goods/<uuid:good_pk>/edit-firearm-details/number-of-items/",
         EditNumberOfItemsView.as_view(),
         name="number_of_items",
     ),
     path(
-        "<uuid:pk>/goods/<uuid:good_pk>/edit-firearm-details/serial_numbers/",
+        "<uuid:pk>/goods/<uuid:good_pk>/edit-firearm-details/serial-numbers/",
         EditSerialNumbersView.as_view(),
         name="serial_numbers",
     ),

--- a/exporter/applications/urls.py
+++ b/exporter/applications/urls.py
@@ -116,11 +116,6 @@ urlpatterns = [
         name="identification_markings",
     ),
     path(
-        "<uuid:pk>/goods/<uuid:good_pk>/update-serial-numbers/",
-        UpdateSerialNumbersView.as_view(),
-        name="update_serial_numbers",
-    ),
-    path(
         "<uuid:pk>/goods/<uuid:good_pk>/edit-firearm-details/number-of-items/",
         EditNumberOfItemsView.as_view(),
         name="number_of_items",
@@ -154,6 +149,11 @@ urlpatterns = [
         "<uuid:pk>/good-on-application/<uuid:good_on_application_pk>/remove/",
         goods.RemovePreexistingGood.as_view(),
         name="remove_preexisting_good",
+    ),
+    path(
+        "<uuid:pk>/good-on-application/<uuid:good_on_application_pk>/update-serial-numbers/",
+        UpdateSerialNumbersView.as_view(),
+        name="update_serial_numbers",
     ),
     path(
         "<uuid:pk>/goods/<uuid:good_pk>/documents/<uuid:doc_pk>/",

--- a/exporter/applications/urls.py
+++ b/exporter/applications/urls.py
@@ -35,6 +35,7 @@ from exporter.goods.views import (
     EditFirearmReplicaView,
     EditFirearmActCertificateDetails,
     EditYearOfManufactureView,
+    UpdateSerialNumbersView,
 )
 
 app_name = "applications"
@@ -113,6 +114,11 @@ urlpatterns = [
         "<uuid:pk>/goods/<uuid:good_pk>/edit-firearm-details/identification-markings/",
         EditIdentificationMarkingsView.as_view(),
         name="identification_markings",
+    ),
+    path(
+        "<uuid:pk>/goods/<uuid:good_pk>/update-serial-numbers/",
+        UpdateSerialNumbersView.as_view(),
+        name="update_serial_numbers",
     ),
     path(
         "<uuid:pk>/goods/<uuid:good_pk>/edit-firearm-details/number-of-items/",

--- a/exporter/goods/forms.py
+++ b/exporter/goods/forms.py
@@ -525,14 +525,17 @@ class SerialNumbersField(forms.MultiValueField):
         return data_list
 
 
-class FirearmsCaptureSerialNumbersForm(forms.Form):
-    title = "Enter the serial numbers for this product"
-
+class BaseSerialNumbersForm(forms.Form):
     def __init__(self, *args, **kwargs):
         number_of_items = kwargs.pop("number_of_items")
+
         super().__init__(*args, **kwargs)
 
-        self.fields["serial_numbers"] = SerialNumbersField(number_of_items, label="", required=False)
+        self.fields["serial_numbers"] = SerialNumbersField(
+            number_of_items,
+            label="",
+            required=False,
+        )
 
         self.helper = FormHelper()
         self.helper.layout = Layout(
@@ -540,13 +543,11 @@ class FirearmsCaptureSerialNumbersForm(forms.Form):
             HTML.p("Enter at least one serial number."),
             HTML.p(f"{number_of_items} items"),
             "serial_numbers",
-            Submit("submit", "Save and continue"),
+            Submit("submit", self.save_button_text),
         )
 
     def clean(self):
         cleaned_data = super().clean()
-
-        cleaned_data["capture_serial_numbers_step"] = True
 
         try:
             serial_numbers = cleaned_data.pop("serial_numbers")
@@ -557,6 +558,31 @@ class FirearmsCaptureSerialNumbersForm(forms.Form):
             cleaned_data[f"serial_number_input_{i}"] = serial_number
 
         return cleaned_data
+
+
+class FirearmsCaptureSerialNumbersForm(BaseSerialNumbersForm):
+    title = "Enter the serial numbers for this product"
+    save_button_text = "Save and continue"
+
+    def clean(self):
+        cleaned_data = super().clean()
+
+        cleaned_data["capture_serial_numbers_step"] = True
+
+        return cleaned_data
+
+
+class UpdateSerialNumbersForm(BaseSerialNumbersForm):
+    save_button_text = "Submit"
+
+    def __init__(self, *args, **kwargs):
+        self.product_name = kwargs.pop("product_name")
+
+        super().__init__(*args, **kwargs)
+
+    @property
+    def title(self):
+        return f"Enter the serial numbers for '{self.product_name}'"
 
 
 class ProductMilitaryUseForm(forms.Form):

--- a/exporter/goods/services.py
+++ b/exporter/goods/services.py
@@ -17,6 +17,12 @@ def get_good(request, pk, full_detail=False):
     return data.json().get("good"), data.status_code
 
 
+def get_good_on_application(request, pk):
+    response = client.get(request, f"/applications/good-on-application/{pk}")
+    response.raise_for_status()
+    return response.json()
+
+
 def get_good_details(request, pk):
     data = client.get(request, f"/goods/{pk}/details/" + convert_parameters_to_query_params(locals()))
     return data.json().get("good"), data.status_code
@@ -253,9 +259,4 @@ def get_good_document_sensitivity(request, pk):
 
 def post_good_document_sensitivity(request, pk, json):
     data = client.post(request, f"/goods/{pk}/document-sensitivity/", json)
-    return data.json(), data.status_code
-
-
-def edit_good_firearm_details_serial_numbers(request, pk, json):
-    data = client.put(request, f"/goods/{pk}/update-serial-numbers/", json)
     return data.json(), data.status_code

--- a/exporter/goods/services.py
+++ b/exporter/goods/services.py
@@ -254,3 +254,8 @@ def get_good_document_sensitivity(request, pk):
 def post_good_document_sensitivity(request, pk, json):
     data = client.post(request, f"/goods/{pk}/document-sensitivity/", json)
     return data.json(), data.status_code
+
+
+def edit_good_firearm_details_serial_numbers(request, pk, json):
+    data = client.put(request, f"/goods/{pk}/update-serial-numbers/", json)
+    return data.json(), data.status_code

--- a/exporter/goods/views.py
+++ b/exporter/goods/views.py
@@ -55,6 +55,7 @@ from exporter.goods.forms import (
     PvDetailsForm,
     RegisteredFirearmsDealerForm,
     SoftwareTechnologyDetailsForm,
+    UpdateSerialNumbersForm,
     attach_documents_form,
     build_firearm_create_back,
     check_document_available_form,
@@ -1174,3 +1175,40 @@ class DeleteDocument(LoginRequiredMixin, TemplateView):
             )
         else:
             return redirect(reverse("goods:good", kwargs={"pk": good_id}))
+
+
+class UpdateSerialNumbersView(LoginRequiredMixin, GoodCommonMixin, FormView):
+    form_class = UpdateSerialNumbersForm
+
+    @cached_property
+    def firearm_details(self):
+        return self.good["firearm_details"]
+
+    @cached_property
+    def good(self):
+        return get_good(self.request, self.object_id, full_detail=True)[0]
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+
+        kwargs["number_of_items"] = self.firearm_details["number_of_items"]
+        kwargs["product_name"] = self.good["name"]
+
+        return kwargs
+
+    def get_initial(self):
+        initial = super().get_initial()
+
+        initial["serial_numbers"] = self.firearm_details["serial_numbers"]
+
+        return initial
+
+    def get_success_url(self):
+        return reverse("applications:application", kwargs={"pk": self.application_id})
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+
+        ctx["back_link_url"] = self.get_success_url()
+
+        return ctx

--- a/unit_tests/exporter/applications/helpers/test_check_your_answers.py
+++ b/unit_tests/exporter/applications/helpers/test_check_your_answers.py
@@ -61,3 +61,38 @@ def test_convert_goods_on_application_good_level_control_list_entries(data_good_
     assert len(actual) == 1
     assert actual[0]["Controlled"] == "No"
     assert actual[0]["Control list entries"] == '<span class="govuk-hint govuk-!-margin-0">N/A</span>'
+
+
+def test_add_serial_numbers_link(data_good_on_application):
+    actual = check_your_answers.convert_goods_on_application([data_good_on_application])
+    assert '<span class="govuk-visually-hidden">Actions</a>' not in actual[0]
+
+    data_good_on_application["firearm_details"] = {
+        "serial_numbers_available": "NOT_AVAILABLE",
+    }
+    actual = check_your_answers.convert_goods_on_application([data_good_on_application])
+    assert '<span class="govuk-visually-hidden">Actions</a>' not in actual[0]
+
+    data_good_on_application["firearm_details"] = {
+        "number_of_items": 3,
+        "serial_numbers_available": "AVAILABLE",
+        "serial_numbers": [],
+    }
+    actual = check_your_answers.convert_goods_on_application([data_good_on_application])
+    assert '<span class="govuk-visually-hidden">Actions</a>' in actual[0]
+
+    data_good_on_application["firearm_details"] = {
+        "number_of_items": 3,
+        "serial_numbers_available": "AVAILABLE",
+        "serial_numbers": [],
+    }
+    actual = check_your_answers.convert_goods_on_application([data_good_on_application], is_summary=True)
+    assert '<span class="govuk-visually-hidden">Actions</a>' not in actual[0]
+
+    data_good_on_application["firearm_details"] = {
+        "number_of_items": 3,
+        "serial_numbers_available": "AVAILABLE",
+        "serial_numbers": ["111", "222", "333"],
+    }
+    actual = check_your_answers.convert_goods_on_application([data_good_on_application])
+    assert '<span class="govuk-visually-hidden">Actions</a>' not in actual[0]

--- a/unit_tests/exporter/goods/test_forms.py
+++ b/unit_tests/exporter/goods/test_forms.py
@@ -216,22 +216,59 @@ def test_identification_markings_form(data, valid, errors):
 
 
 @pytest.mark.parametrize(
-    "data, valid, errors",
+    "data, valid, cleaned_data, errors",
     (
-        ({"serial_numbers_0": "abc", "serial_numbers_1": "def", "serial_numbers_2": "ghi"}, True, {}),
+        (
+            {"serial_numbers_0": "abc", "serial_numbers_1": "def", "serial_numbers_2": "ghi"},
+            True,
+            {
+                "serial_number_input_0": "abc",
+                "serial_number_input_1": "def",
+                "serial_number_input_2": "ghi",
+                "capture_serial_numbers_step": True,
+            },
+            {},
+        ),
         (
             {"serial_numbers_0": "", "serial_numbers_1": "", "serial_numbers_2": ""},
             False,
+            {"capture_serial_numbers_step": True},
             {"serial_numbers": ["Enter at least one serial number"]},
         ),
     ),
 )
-def test_firearms_capture_serial_numbers_form(data, valid, errors):
+def test_firearms_capture_serial_numbers_form(data, valid, cleaned_data, errors):
     form = forms.FirearmsCaptureSerialNumbersForm(data=data, number_of_items=3)
 
     assert form.is_valid() == valid
-    assert form.cleaned_data["capture_serial_numbers_step"]
+    assert form.cleaned_data == cleaned_data
     assert form.errors == errors
+
+
+@pytest.mark.parametrize(
+    "data, valid, cleaned_data, errors",
+    (
+        (
+            {"serial_numbers_0": "abc", "serial_numbers_1": "def", "serial_numbers_2": "ghi"},
+            True,
+            {"serial_number_input_0": "abc", "serial_number_input_1": "def", "serial_number_input_2": "ghi"},
+            {},
+        ),
+        (
+            {"serial_numbers_0": "", "serial_numbers_1": "", "serial_numbers_2": ""},
+            False,
+            {},
+            {"serial_numbers": ["Enter at least one serial number"]},
+        ),
+    ),
+)
+def test_update_serial_numbers_form(data, valid, cleaned_data, errors):
+    form = forms.UpdateSerialNumbersForm(data=data, number_of_items=3, product_name="test product name")
+
+    assert form.is_valid() == valid
+    assert form.cleaned_data == cleaned_data
+    assert form.errors == errors
+    assert form.title == "Enter the serial numbers for 'test product name'"
 
 
 @pytest.mark.parametrize(

--- a/unit_tests/exporter/goods/views/test_single_form_views.py
+++ b/unit_tests/exporter/goods/views/test_single_form_views.py
@@ -3,6 +3,8 @@ from django.urls import reverse
 
 import pytest
 
+from core.constants import CaseStatusEnum
+
 
 @pytest.fixture
 def good_pk():
@@ -100,10 +102,22 @@ def test_update_serial_numbers_view(authorized_client, requests_mock, good_pk):
     application_url = reverse("applications:application", kwargs={"pk": pk})
 
     requests_mock.get(
+        f"/applications/{pk}/",
+        json={
+            "status": {
+                "key": CaseStatusEnum.SUBMITTED,
+            },
+        },
+    )
+
+    requests_mock.get(
         f"/goods/{good_pk}/?pk={good_pk}&full_detail=True",
         json={
             "good": {
                 "name": good_name,
+                "status": {
+                    "key": "submitted",
+                },
                 "firearm_details": {
                     "serial_numbers": serial_numbers,
                     "number_of_items": 2,
@@ -128,6 +142,72 @@ def test_update_serial_numbers_view(authorized_client, requests_mock, good_pk):
     )
     assert response.status_code == 302
     assert response.url == application_url
+
+
+def get_update_serial_number_permissions_parameters():
+    allowed_application_permissions = [
+        CaseStatusEnum.SUBMITTED,
+        CaseStatusEnum.FINALISED,
+    ]
+    all_permissions = CaseStatusEnum.all()
+    denied_application_permissions = list(set(all_permissions) - set(allowed_application_permissions))
+
+    parameters = []
+
+    for perm in allowed_application_permissions:
+        parameters += [
+            (perm, "draft", 400),
+            (perm, "submitted", 200),
+        ]
+
+    for perm in denied_application_permissions:
+        parameters += [
+            (perm, "draft", 400),
+            (perm, "submitted", 400),
+        ]
+
+    return parameters
+
+
+@pytest.mark.parametrize(
+    "application_status, good_status, expected_status_code",
+    get_update_serial_number_permissions_parameters(),
+)
+def test_update_serial_numbers_view_permissions(
+    authorized_client, requests_mock, good_pk, application_status, good_status, expected_status_code
+):
+    pk = str(uuid.uuid4())
+    url = reverse("applications:update_serial_numbers", kwargs={"pk": pk, "good_pk": good_pk})
+    good_name = "Test good"
+    serial_numbers = ["11111", "22222"]
+
+    requests_mock.get(
+        f"/applications/{pk}/",
+        json={
+            "status": {
+                "key": application_status,
+            },
+        },
+    )
+
+    requests_mock.get(
+        f"/goods/{good_pk}/?pk={good_pk}&full_detail=True",
+        json={
+            "good": {
+                "name": good_name,
+                "status": {
+                    "key": good_status,
+                },
+                "firearm_details": {
+                    "serial_numbers": serial_numbers,
+                    "number_of_items": 2,
+                },
+            },
+        },
+    )
+
+    response = authorized_client.get(url)
+    response.status_code == expected_status_code
 
 
 def test_good_military_use_view(authorized_client, requests_mock, good_pk):

--- a/unit_tests/exporter/goods/views/test_single_form_views.py
+++ b/unit_tests/exporter/goods/views/test_single_form_views.py
@@ -92,6 +92,44 @@ def test_edit_serial_numbers_view(authorized_client, requests_mock, good_pk):
     assert data["serial_number_input_1"] == "ghijkl"
 
 
+def test_update_serial_numbers_view(authorized_client, requests_mock, good_pk):
+    pk = str(uuid.uuid4())
+    url = reverse("applications:update_serial_numbers", kwargs={"pk": pk, "good_pk": good_pk})
+    good_name = "Test good"
+    serial_numbers = ["11111", "22222"]
+    application_url = reverse("applications:application", kwargs={"pk": pk})
+
+    requests_mock.get(
+        f"/goods/{good_pk}/?pk={good_pk}&full_detail=True",
+        json={
+            "good": {
+                "name": good_name,
+                "firearm_details": {
+                    "serial_numbers": serial_numbers,
+                    "number_of_items": 2,
+                },
+            },
+        },
+    )
+
+    response = authorized_client.get(url)
+    ctx = response.context
+    form = ctx["form"]
+    assert form.initial == {"serial_numbers": serial_numbers}
+    assert form.title == f"Enter the serial numbers for '{good_name}'"
+    assert ctx["back_link_url"] == application_url
+
+    response = authorized_client.post(
+        url,
+        data={
+            "serial_numbers_0": "abcdef",
+            "serial_numbers_1": "ghijkl",
+        },
+    )
+    assert response.status_code == 302
+    assert response.url == application_url
+
+
 def test_good_military_use_view(authorized_client, requests_mock, good_pk):
     url = reverse("goods:good_military_use", kwargs={"pk": good_pk})
     requests_mock.get(


### PR DESCRIPTION
Adds a form view, and link to said form view from the application details page, to allow serial numbers to be added later.

There are two different cases where we want to allow exporters to update serial numbers, either because they've explicitly said they would like to do it later or because they've said they could add them straight away yet only added a few of them.