### PR TITLE
Improve the way we login into sso

### DIFF
--- a/cypress/integration/caseworker/application.spec.js
+++ b/cypress/integration/caseworker/application.spec.js
@@ -1,69 +1,64 @@
 import { createApplication } from '../../api/createApplication'
 
-describe('Login', () => {
-  it('login', () => {
+
+describe('Application', () => {
+  const counterSignQueue = Cypress.env('fco_counter_sign_queue')
+  let response
+
+  before(async () => {
     cy.login()
+    cy.visit('/')
+    response = await createApplication()
   })
 
-  describe('Application', () => {
-    const counterSignQueue = Cypress.env('fco_counter_sign_queue')
-    let response
+  it.only('should approve a case in FCDO queue with the correct information', () => {
+    cy.visit(`/queues/${response.defaultQueue}/cases/${response.applicationId}/`)
+    cy.get('#heading-reference-code')
+      .should('contain', response.submittedApplication.reference_code)
+    cy.visit(`/queues/${response.defaultQueue}/cases/${response.applicationId}/advice`)
+    cy.findByText('Make recommendation').click()
+    cy.findByText('Approve all').click()
+    cy.findByText('Continue').click()
+    cy.get('[type="checkbox"]').check('BE')
+    cy.get('[type="checkbox"]').check('UA')
+    cy.get('textarea').first().type('FCDO Approval Reason')
+    cy.findByText('Submit recommendation').click()
+    cy.get('.govuk-main-wrapper')
+      .should('contain', 'Approved by Test Lite')
+      .should('contain', 'Belgium')
+      .should('contain', 'Ukraine')
+      .should('contain', 'FCDO Approval Reason')
+    cy.findByText('Move case forward').click()
 
-    before(async () => {
-      // Change domain
-      cy.visit('/')
-      response = await createApplication()
-    })
+    cy.visit(`/queues/${response.defaultQueue}/?case_reference=${response.submittedApplication.reference_code}`)
+    cy.get('#form-cases').should('contain', 'There are no new cases')
+  })
 
-    it('should approve a case in FCDO queue with the correct information', () => {
-      cy.visit(`/queues/${response.defaultQueue}/cases/${response.applicationId}/`)
-      cy.get('#heading-reference-code')
-        .should('contain', response.submittedApplication.reference_code)
-      cy.visit(`/queues/${response.defaultQueue}/cases/${response.applicationId}/advice`)
-      cy.findByText('Make recommendation').click()
-      cy.findByText('Approve all').click()
-      cy.findByText('Continue').click()
-      cy.get('[type="checkbox"]').check('BE')
-      cy.get('[type="checkbox"]').check('UA')
-      cy.get('textarea').first().type('FCDO Approval Reason')
-      cy.findByText('Submit recommendation').click()
-      cy.get('.govuk-main-wrapper')
-        .should('contain', 'Approved by Test Lite')
-        .should('contain', 'Belgium')
-        .should('contain', 'Ukraine')
-        .should('contain', 'FCDO Approval Reason')
-      cy.findByText('Move case forward').click()
-
-      cy.visit(`/queues/${response.defaultQueue}/?case_reference=${response.submittedApplication.reference_code}`)
-      cy.get('#form-cases').should('contain', 'There are no new cases')
-    })
-
-    it('should approve a case in Counter-Sign queue with the correct information', () => {
-      cy.visit('/').then(() => {
-        cy.visit(`/queues/${counterSignQueue}/cases/${response.applicationId}/details/`)
-      })
-      cy.get('#assigned-queues')
-        .should('not.contain', 'FCO Cases to Review')
-        .should('contain', 'FCO Counter-signing')
-      cy.visit(`/queues/${counterSignQueue}/cases/${response.applicationId}/advice/countersign/`)
-      cy.get('.govuk-details__text')
-        .should('contain', 'Belgium')
-        .should('contain', 'Ukraine')
-        .should('contain', 'FCDO Approval Reason')
-
-      cy.visit(`/queues/${counterSignQueue}/cases/${response.applicationId}/advice/countersign/`)
-      cy.findByText('Review and countersign').click()
-      cy.get('textarea').first().type('Countersign Approval Reason')
-      cy.findByText('Submit recommendation').click()
-      cy.findByText('Countersign Approval Reason').should('exist')
-      cy.findByText('FCDO Approval Reason').should('exist')
-      cy.findByText('Move case forward').click()
-
+  it('should approve a case in Counter-Sign queue with the correct information', () => {
+    cy.visit('/').then(() => {
       cy.visit(`/queues/${counterSignQueue}/cases/${response.applicationId}/details/`)
-      cy.get('#assigned-queues')
-        .should('not.contain', 'FCO Cases to Review')
-        .should('not.contain', 'FCO Counter-signing')
-        .should('contain', 'MOD Cases to Review')
     })
+    cy.get('#assigned-queues')
+      .should('not.contain', 'FCO Cases to Review')
+      .should('contain', 'FCO Counter-signing')
+    cy.visit(`/queues/${counterSignQueue}/cases/${response.applicationId}/advice/countersign/`)
+    cy.get('.govuk-details__text')
+      .should('contain', 'Belgium')
+      .should('contain', 'Ukraine')
+      .should('contain', 'FCDO Approval Reason')
+
+    cy.visit(`/queues/${counterSignQueue}/cases/${response.applicationId}/advice/countersign/`)
+    cy.findByText('Review and countersign').click()
+    cy.get('textarea').first().type('Countersign Approval Reason')
+    cy.findByText('Submit recommendation').click()
+    cy.findByText('Countersign Approval Reason').should('exist')
+    cy.findByText('FCDO Approval Reason').should('exist')
+    cy.findByText('Move case forward').click()
+
+    cy.visit(`/queues/${counterSignQueue}/cases/${response.applicationId}/details/`)
+    cy.get('#assigned-queues')
+      .should('not.contain', 'FCO Cases to Review')
+      .should('not.contain', 'FCO Counter-signing')
+      .should('contain', 'MOD Cases to Review')
   })
 })

--- a/cypress/integration/caseworker/application.spec.js
+++ b/cypress/integration/caseworker/application.spec.js
@@ -11,7 +11,7 @@ describe('Application', () => {
     response = await createApplication()
   })
 
-  it.only('should approve a case in FCDO queue with the correct information', () => {
+  it('should approve a case in FCDO queue with the correct information', () => {
     cy.visit(`/queues/${response.defaultQueue}/cases/${response.applicationId}/`)
     cy.get('#heading-reference-code')
       .should('contain', response.submittedApplication.reference_code)
@@ -34,7 +34,7 @@ describe('Application', () => {
     cy.get('#form-cases').should('contain', 'There are no new cases')
   })
 
-  it('should approve a case in Counter-Sign queue with the correct information', () => {
+  it('should approve a case in FCO Counter-signing queue with the correct information', () => {
     cy.visit('/').then(() => {
       cy.visit(`/queues/${counterSignQueue}/cases/${response.applicationId}/details/`)
     })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,21 +1,22 @@
 import '@testing-library/cypress/add-commands'
 
 Cypress.Commands.add('login', () => {
-  cy.visit(Cypress.env('sso_url'))
-  cy.get('#id_username').type(Cypress.env('sso_user'), { log: false })
-  cy.get('#id_password').type(Cypress.env('sso_password'), { log: false })
-  cy.findByText('login').click()
-  cy.findByText('You have signed in to DIT internal services')
-    .should('exist')
-})
-
-Cypress.Commands.add('setCsrfTokenCookie', () => {
-  cy.setCookie('csrftoken', 'WAzzVOJCY27ZNs6snAEC775y8W1HDXYJq09otCot3PO1KRYrvSbExjV9Cr6QYmFl', {
-    domain: "sso.trade.uat.uktrade.io",
-    expiry: 1675166092.722795,
-    httpOnly: false,
-    path: "/",
-    sameSite: "lax",
-    secure: false,
+  cy.request(Cypress.env('sso_url')).then((getResponse) => {
+    const loginCsrfCookie = getResponse.headers['set-cookie'][0]
+    const csrfToken = loginCsrfCookie.match("csrftoken=(.*); expires")
+    const options = {
+      method: 'POST',
+      url: Cypress.env('sso_url'),
+      form: true,
+      body: {
+        username: Cypress.env('sso_user'),
+        password: Cypress.env('sso_password'),
+        csrfmiddlewaretoken: csrfToken[1],
+      },
+      headers: {
+        referer: Cypress.env('sso_url'),
+      }
+    }
+    cy.request(options)
   })
 })


### PR DESCRIPTION
The intent of this PR is to prevent us from having to go through sso via client side, adding credentials in the browser and then navigating to internal domain.

The way we workaround all these steps and manage successfully authenticate to the app is by:

- submit a GET to sso login url and extract the csrftoken
- submit a POST to sso login with correct body/header and csrftoken from the first step
- persist the sessionId cookie generated by the POST

All the above is done within less than a second which means we save quite some time compared to previous way we were logging in.