### PR TITLE
remove routes section in details of caseworker side

### DIFF
--- a/caseworker/cases/views/main.py
+++ b/caseworker/cases/views/main.py
@@ -167,7 +167,6 @@ class CaseDetail(CaseView):
             conditional(self.case.data["inactive_parties"], Slices.DELETED_ENTITIES),
             Slices.LOCATIONS,
             Slices.END_USE_DETAILS,
-            Slices.ROUTE_OF_GOODS,
             Slices.SUPPORTING_DOCUMENTS,
             Slices.FREEDOM_OF_INFORMATION,
         ]


### PR DESCRIPTION
remove routes section in details of caseworker side, as it is replaced by new locations code