### PR TITLE
Ltd 1976 serial numbers being remembered across products

### DIFF
--- a/exporter/applications/helpers/check_your_answers.py
+++ b/exporter/applications/helpers/check_your_answers.py
@@ -99,7 +99,7 @@ def _convert_standard_application(application, editable=False, is_summary=False)
     url = reverse(f"applications:good_detail_summary", kwargs={"pk": pk})
     old_locations = bool(application["goods_locations"])
     converted = {
-        convert_to_link(url, strings.GOODS): convert_goods_on_application(application["goods"], is_summary),
+        convert_to_link(url, strings.GOODS): convert_goods_on_application(application["goods"], is_summary=is_summary),
         strings.END_USE_DETAILS: _get_end_use_details(application),
         strings.END_USER: convert_party(application["end_user"], application, editable),
         strings.CONSIGNEE: convert_party(application["consignee"], application, editable),

--- a/exporter/goods/services.py
+++ b/exporter/goods/services.py
@@ -102,6 +102,8 @@ def add_identification_marking_details(firearm_details, json):
         for i in range(number_of_items):
             serial_numbers.append(json.get(f"serial_number_input_{i}", ""))
         firearm_details["serial_numbers"] = serial_numbers
+    elif firearm_details.get("serial_numbers_available") == "LATER":
+        firearm_details["serial_numbers"] = []
 
     return firearm_details
 


### PR DESCRIPTION
Fixes an issue with serial numbers incorrectly being copied when adding a preexisting product and selecting the serial numbers to be deferred on the new product.