### PR TITLE
LTD-1956-fix-introspect-forced-logout 

### DIFF
--- a/core/auth/views.py
+++ b/core/auth/views.py
@@ -75,6 +75,7 @@ class AbstractAuthCallbackView(abc.ABC, View):
 
         token = self.fetch_token(request, auth_code)
         self.request.session[settings.TOKEN_SESSION_KEY] = dict(token)
+        self.request.session[f"{settings.TOKEN_SESSION_KEY}_auth_code"] = auth_code
         del self.request.session[f"{settings.TOKEN_SESSION_KEY}_oauth_state"]
         data, status_code = self.authenticate_user()
 

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -1,22 +1,23 @@
 import time
 import logging
-
 import requests
 from s3chunkuploader.file_handler import UploadFailed
 from urllib.parse import urlparse
+import jwt
+from authlib.oauth2 import OAuth2Error
+from authlib.integrations.base_client.errors import OAuthError
+from authlib.oauth2.rfc7523 import PrivateKeyJWT
+from requests.exceptions import RequestException
 
 from django.conf import settings
 from django.contrib.auth import logout
 from django.core.cache import cache
 from django.shortcuts import redirect
 from django.utils.cache import add_never_cache_headers
-from authlib.oauth2 import OAuth2Error
 from django.http import HttpResponseForbidden
-from requests.exceptions import RequestException
 
 from lite_content.lite_internal_frontend.strings import cases
 from lite_forms.generators import error_page
-
 
 SESSION_TIMEOUT_KEY = "_session_timeout_seconds_"
 logger = logging.getLogger(__name__)
@@ -115,16 +116,48 @@ class AuthBrokerTokenIntrospectionMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
 
+    def get_token(self, request):
+        new_token = False
+        token = request.authbroker_client.token.get("access_token")
+        try:
+            jwt.decode(token, options={"verify_signature": False, "verify_exp": True})
+        except jwt.ExpiredSignatureError:
+            # Token expired lets get a new one using refresh token
+            # We making a big assumption here assuming client uses openid PrivateJWT auth method
+            request.authbroker_client.token_endpoint_auth_method = PrivateKeyJWT(
+                token_endpoint=settings.AUTHBROKER_TOKEN_URL
+            )
+            new_jwt_token = request.authbroker_client.refresh_token(
+                url=settings.AUTHBROKER_TOKEN_URL,
+                code=request.session[f"{settings.TOKEN_SESSION_KEY}_auth_code"],
+                client_id=settings.AUTHBROKER_CLIENT_ID,
+            )
+            token = new_jwt_token.get("access_token")
+            request.session[settings.TOKEN_SESSION_KEY] = dict(new_jwt_token)
+            new_token = True
+        except jwt.DecodeError:
+            # The client doesn't have the correct support for full JWT we will return the original token
+            pass
+        return token, new_token
+
+    def client_introspect_call(self, request):
+        logger.info("Introspecting with SSO: %s", request.session.get("lite_api_user_id"))
+        response = request.authbroker_client.get(settings.AUTHBROKER_PROFILE_URL)
+        response.raise_for_status()
+
     def introspect(self, request):
         client = request.authbroker_client
-        token = client.token.get("access_token", "")
+        # If refresh tokens are supported we will only return valid tokens here this to stop the call to the client
+        # from failing because of short lived tokens
+        token, new_token = self.get_token(request)
         cache_key = f"sso_introspection:{token}"
         cache_value = cache.get(cache_key)
         if cache_value is not None:
             return
-        logger.info("Introspecting with SSO: %s", request.session.get("lite_api_user_id"))
-        response = client.get(settings.AUTHBROKER_PROFILE_URL)
-        response.raise_for_status()
+        if not new_token:
+            # This is to prevent another client call if only just received a new token
+            self.client_introspect_call(request)
+
         ttl = settings.AUTHBROKER_TOKEN_INTROSPECTION_TTL
         cache.set(cache_key, True, timeout=ttl)
 
@@ -135,12 +168,13 @@ class AuthBrokerTokenIntrospectionMiddleware:
             return self.get_response(request)
         try:
             self.introspect(request)
-        except (OAuth2Error, RequestException) as e:
+        except (OAuth2Error, OAuthError, RequestException) as e:
             logger.warning(
                 "Introspecting with SSO failed for user %s: %s",
                 request.session.get("lite_api_user_id"),
                 str(e),
             )
+
             request.session.flush()
             return redirect(settings.LOGOUT_URL)
         return self.get_response(request)

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -146,7 +146,6 @@ class AuthBrokerTokenIntrospectionMiddleware:
         response.raise_for_status()
 
     def introspect(self, request):
-        client = request.authbroker_client
         # If refresh tokens are supported we will only return valid tokens here this to stop the call to the client
         # from failing because of short lived tokens
         token, new_token = self.get_token(request)


### PR DESCRIPTION
GOV.UK only has a token valid for 3 mins. 
So when we run introspect which happens for every call. When the call gives a 401 it results in a forced logout. 
This now uses a renews using the refresh token on every call if it expires so we obtain a new one which is valid for a further 3 mins. 

It's added more complexity to the code since we still have to handle GREAT/SSO using the same middleware which doesn't support openid and had longer living tokens so refresh isn't required. 

I'm also surprised no tests have broken, which means we have no unit test coverage for middleware a task for another day. 