### PR TITLE
LTD-2064-NI-Remove-logic-hide-GB 

### DIFF
--- a/exporter/applications/forms/parties.py
+++ b/exporter/applications/forms/parties.py
@@ -253,7 +253,7 @@ class PartyAddressForm(forms.Form):
 
         self.fields["country"].widget = Autocomplete(attrs={"id": "country-autocomplete", "nonce": request.csp_nonce})
 
-        countries = get_countries(request, False, ["GB"])
+        countries = get_countries(request)
         country_choices = [(country["id"], country["name"]) for country in countries]
         self.fields["country"].choices += country_choices
 

--- a/unit_tests/exporter/applications/forms/test_parties.py
+++ b/unit_tests/exporter/applications/forms/test_parties.py
@@ -90,7 +90,7 @@ def test_party_address_form(mock_get_countries, data, valid, errors):
     form = parties.PartyAddressForm(request=request, data=data)
 
     assert form.is_valid() == valid
-    mock_get_countries.assert_called_once_with(request, False, ["GB"])
+    mock_get_countries.assert_called_once_with(request)
 
     if not valid:
         assert form.errors == errors


### PR DESCRIPTION
Remove the logic that hides the GB filter. This is due to the NI changes. 
Assumption here is that it was hardcoded filter so this filter is no required on this form. 


<img width="1248" alt="image" src="https://user-images.githubusercontent.com/44236490/158402903-f971c344-ad0d-4f88-abff-70fe81928e93.png">
