### PR TITLE
LTD-1369: Show End-user documents on the internal site Case details page

### DIFF
--- a/caseworker/cases/helpers/case.py
+++ b/caseworker/cases/helpers/case.py
@@ -53,6 +53,7 @@ class Slices:
     SANCTION_MATCHES = Slice("case/slices/sanctions.html")
     DENIAL_MATCHES = Slice("case/slices/denial-matches.html")
     DELETED_ENTITIES = Slice("case/slices/deleted-entities.html")
+    END_USER_DOCUMENTS = Slice("case/slices/end-user-documents.html")
     LOCATIONS = Slice("components/locations.html")
     F680_DETAILS = Slice("case/slices/f680-details.html", "F680 details")
     EXHIBITION_DETAILS = Slice("case/slices/exhibition-details.html", "Exhibition details")

--- a/caseworker/cases/views/main.py
+++ b/caseworker/cases/views/main.py
@@ -164,6 +164,7 @@ class CaseDetail(CaseView):
             Slices.DESTINATIONS,
             Slices.DENIAL_MATCHES,
             Slices.SANCTION_MATCHES,
+            conditional(self.case.data["end_user"], Slices.END_USER_DOCUMENTS),
             conditional(self.case.data["inactive_parties"], Slices.DELETED_ENTITIES),
             Slices.LOCATIONS,
             Slices.END_USE_DETAILS,

--- a/caseworker/templates/case/slices/end-user-documents.html
+++ b/caseworker/templates/case/slices/end-user-documents.html
@@ -1,0 +1,73 @@
+{% with end_user=case.data.end_user %}
+    <h2 class="govuk-heading-m">End-user documents</h2>
+    <table class="govuk-table">
+        <tbody class="govuk-table__body">
+            {% if end_user.documents|length %}
+                {% for document in end_user.documents %}
+                    {% if document.type == "end_user_undertaking_document" or document.type == "supporting_document" %}
+                        <tr class="govuk-table__row">
+                            <th scope="row" class="govuk-table__header">Upload an end-user document</th>
+                            <td class="govuk-table__cell">
+                                {% if document.safe %}
+                                    <a target="_blank" href="{% url 'cases:document' queue_pk=queue.id pk=case.id file_pk=document.id %}" class="govuk-link--no-visited-state">
+                                        End-user document ({{ document.name|document_extension|upper}} opens in new tab)
+                                    </a>
+                                {% else %}
+                                    {{ document.name }}
+                                {% endif %}
+                            </td>
+                        </tr>
+                        {% if end_user.product_differences_note %}
+                            <tr class="govuk-table__row">
+                                <th scope="row" class="govuk-table__header">
+                                    Describe any differences between products listed in the document and products on the application (optional)
+                                </th>
+                                <td class="govuk-table__cell">{{ end_user.product_differences_note }}</td>
+                            </tr>
+                        {% endif %}
+                    {% endif %}
+
+                    {% if document.type == "end_user_english_translation_document" %}
+                        <tr class="govuk-table__row">
+                            <th scope="row" class="govuk-table__header">Upload an English translation of the end-user document</th>
+                            <td class="govuk-table__cell">
+                                {% if document.safe %}
+                                    <a target="_blank" href="{% url 'cases:document' queue_pk=queue.id pk=case.id file_pk=document.id %}" class="govuk-link--no-visited-state">
+                                        English translation ({{ document.name|document_extension|upper}} opens in new tab)
+                                    </a>
+                                {% else %}
+                                    {{ document.name }}
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% endif %}
+
+                    {% if document.type == "end_user_company_letterhead_document" %}
+                        <tr class="govuk-table__row">
+                            <th scope="row" class="govuk-table__header">Upload a document on company letterhead</th>
+                            <td class="govuk-table__cell">
+                                {% if document.safe %}
+                                    <a target="_blank" href="{% url 'cases:document' queue_pk=queue.id pk=case.id file_pk=document.id %}" class="govuk-link--no-visited-state">
+                                        Company letterhead ({{ document.name|document_extension|upper}} opens in new tab)
+                                    </a>
+                                {% else %}
+                                    {{ document.name }}
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% endif %}
+
+                {% endfor %}
+            {% else %}
+                <tr class="govuk-table__row">
+                    <th scope="row" class="govuk-table__header">Do you have an end-user document?</th>
+                    <td class="govuk-table__cell">No, I do not have an end-user undertaking or stockist undertaking</td>
+                </tr>
+                <tr class="govuk-table__row">
+                    <th scope="row" class="govuk-table__header">Explain why you do not have an end-user undertaking or stockist undertaking</th>
+                    <td class="govuk-table__cell">{{ end_user.end_user_document_missing_reason }}</td>
+                </tr>
+            {% endif %}
+        </tbody>
+    </table>
+{% endwith %}

--- a/core/builtins/custom_tags.py
+++ b/core/builtins/custom_tags.py
@@ -2,9 +2,10 @@ from __future__ import division
 
 import datetime
 import json
-from importlib import import_module
+import os
 import re
 from collections import Counter, OrderedDict
+from importlib import import_module
 
 import bleach
 from dateutil.parser import parse
@@ -925,3 +926,9 @@ def full_name(user):
 def verbose_goods_starting_point(value):
     goods_starting_points = {"GB": "Great Britain", "NI": "Northern Ireland"}
     return goods_starting_points.get(value, "")
+
+
+@register.filter
+def document_extension(filename):
+    _, ext = os.path.splitext(filename)
+    return ext[1:]

--- a/unit_tests/core/builtins/test_custom_tags.py
+++ b/unit_tests/core/builtins/test_custom_tags.py
@@ -172,3 +172,22 @@ def test_pluralise_quantity(good_on_app, quantity_display):
 )
 def test_highlight_text_sanitization(input, term, expected):
     assert expected == highlight_text(input, term)
+
+
+@pytest.mark.parametrize(
+    "filename,expected",
+    [
+        ("testfile.pdf", "pdf"),
+        ("test file.pdf", "pdf"),
+        ("this is test file.pdf", "pdf"),
+        ("this-is-a-test-file.docx", "docx"),
+        ("test-123_file.doc", "doc"),
+        ("testfile.ppt", "ppt"),
+        ("testfile", ""),
+        ("test_archive.zip", "zip"),
+        ("test_archive.tar", "tar"),
+        ("test_archive.tar.gz", "gz"),
+    ],
+)
+def test_document_extension(filename, expected):
+    assert expected == custom_tags.document_extension(filename)


### PR DESCRIPTION
## Change description

Add new section to Case summary page to display the details of documents uploaded by End-user in the internal site.

When documents are available and uploaded,
![end_user_docs_available](https://user-images.githubusercontent.com/2622464/158585461-c0a07580-007d-40c7-bfd6-cdb086261a14.png)


When not available,
![end_user_docs_not_available](https://user-images.githubusercontent.com/2622464/158585483-9806ab98-767e-4130-8a65-8b9330efd99b.png)
