### PR TITLE
LTD-1369: Show all parties documents in one place

### DIFF
--- a/caseworker/templates/case/slices/destinations.html
+++ b/caseworker/templates/case/slices/destinations.html
@@ -33,7 +33,6 @@
 						<th scope="col" class="govuk-table__header">{% lcs 'cases.CasePage.DetailsTab.Destinations.Table.ADDRESS' %}</th>
 						<th scope="col" class="govuk-table__header">{% lcs 'cases.CasePage.DetailsTab.Destinations.Table.BUSINESS' %}</th>
 						<th scope="col" class="govuk-table__header">{% lcs 'cases.CasePage.DetailsTab.Destinations.Table.WEBSITE' %}</th>
-						<th scope="col" class="govuk-table__header">{% lcs 'cases.CasePage.DetailsTab.Destinations.Table.DOCUMENTS' %}</th>
 						<th scope="col" class="govuk-table__header">{% lcs 'cases.CasePage.DetailsTab.Destinations.Table.SIGNATORY_NAME' %}</th>
 						<th scope="col" class="govuk-table__header">{% lcs 'cases.CasePage.DetailsTab.Destinations.Table.FLAGS' %}</th>
 					</tr>
@@ -92,14 +91,6 @@
 							<td class="govuk-table__cell {% if show_advice %}lite-!-no-border{% endif %}">
 								<span aria-hidden="false" class="govuk-table__header">{% lcs 'cases.CasePage.DetailsTab.Destinations.Table.WEBSITE' %}</span>
 								{{ destination.website|linkify }}
-							</td>
-							<td class="govuk-table__cell {% if show_advice %}lite-!-no-border{% endif %}">
-								<span aria-hidden="false" class="govuk-table__header">{% lcs 'cases.CasePage.DetailsTab.Destinations.Table.DOCUMENTS' %}</span>
-								{% if destination.document %}
-									<a id="link-{{ destination.type}}-download" class="govuk-link" href="{% url 'cases:document' queue.id case.id destination.document.id %}">
-										{{ destination.document.name }}
-									</a>
-								{% endif %}
 							</td>
 							<td class="govuk-table__cell {% if show_advice %}lite-!-no-border{% endif %}">
 								<span aria-hidden="false" class="govuk-table__header">{% lcs 'cases.CasePage.DetailsTab.Destinations.Table.SIGNATORY_NAME' %}</span>

--- a/caseworker/templates/case/slices/end-user-documents.html
+++ b/caseworker/templates/case/slices/end-user-documents.html
@@ -1,4 +1,4 @@
-{% with end_user=case.data.end_user %}
+{% with end_user=case.data.end_user consignee=case.data.consignee third_parties=case.data.third_parties ultimate_end_users=case.data.ultimate_end_users %}
     <h2 class="govuk-heading-m">End-user documents</h2>
     <table class="govuk-table">
         <tbody class="govuk-table__body">
@@ -68,6 +68,58 @@
                     <td class="govuk-table__cell">{{ end_user.end_user_document_missing_reason }}</td>
                 </tr>
             {% endif %}
+
+            {% if consignee and consignee.documents|length %}
+                {% with document=consignee.documents.0 %}
+                    <tr class="govuk-table__row">
+                        <th scope="row" class="govuk-table__header">Upload a consignee document</th>
+                        <td class="govuk-table__cell">
+                            {% if document.safe %}
+                                <a target="_blank" href="{% url 'cases:document' queue_pk=queue.id pk=case.id file_pk=document.id %}" class="govuk-link--no-visited-state">
+                                    Consignee document ({{ document.name|document_extension|upper}} opens in new tab)
+                                </a>
+                            {% else %}
+                                {{ document.name }}
+                            {% endif %}
+                        </td>
+                    </tr>
+                {% endwith %}
+            {% endif %}
+
+            {% for party in ultimate_end_users %}
+                {% with document=party.documents.0 %}
+                    <tr class="govuk-table__row">
+                        <th scope="row" class="govuk-table__header">Upload an ultimate end-user document</th>
+                        <td class="govuk-table__cell">
+                            {% if document.safe %}
+                                <a target="_blank" href="{% url 'cases:document' queue_pk=queue.id pk=case.id file_pk=document.id %}" class="govuk-link--no-visited-state">
+                                    Ultimate end-user document ({{ document.name|document_extension|upper}} opens in new tab)
+                                </a>
+                            {% else %}
+                                {{ document.name }}
+                            {% endif %}
+                        </td>
+                    </tr>
+                {% endwith %}
+            {% endfor %}
+
+            {% for party in third_parties %}
+                {% with document=party.documents.0 %}
+                    <tr class="govuk-table__row">
+                        <th scope="row" class="govuk-table__header">Upload a third party ({{ party.role.key }}) document</th>
+                        <td class="govuk-table__cell">
+                            {% if document.safe %}
+                                <a target="_blank" href="{% url 'cases:document' queue_pk=queue.id pk=case.id file_pk=document.id %}" class="govuk-link--no-visited-state">
+                                    Third party document ({{ document.name|document_extension|upper}} opens in new tab)
+                                </a>
+                            {% else %}
+                                {{ document.name }}
+                            {% endif %}
+                        </td>
+                    </tr>
+                {% endwith %}
+            {% endfor %}
+
         </tbody>
     </table>
 {% endwith %}

--- a/exporter/core/views.py
+++ b/exporter/core/views.py
@@ -1,4 +1,3 @@
-from email.mime import application
 from json import JSONDecodeError
 
 from django.conf import settings


### PR DESCRIPTION
## Change description

Case summary page has a new section to show End-user documents. This is
added as part of English translation document changes but currently we also
show these details in destinations table on the same page so the designs
are updated to show all parties documents in this new section and remove
it from the destinations table.