### PR TITLE
LTD-1642: Provide option to upload EC3 document

### DIFF
--- a/caseworker/cases/views/main.py
+++ b/caseworker/cases/views/main.py
@@ -162,8 +162,8 @@ class CaseDetail(CaseView):
         self.slices = [
             Slices.GOODS,
             Slices.DESTINATIONS,
-            Slices.DENIAL_MATCHES,
-            Slices.SANCTION_MATCHES,
+            conditional(self.case.data["denial_matches"], Slices.DENIAL_MATCHES),
+            conditional(self.case.data["sanction_matches"], Slices.SANCTION_MATCHES),
             conditional(self.case.data["end_user"], Slices.END_USER_DOCUMENTS),
             conditional(self.case.data["inactive_parties"], Slices.DELETED_ENTITIES),
             Slices.LOCATIONS,

--- a/caseworker/templates/case/slices/end-user-documents.html
+++ b/caseworker/templates/case/slices/end-user-documents.html
@@ -69,6 +69,32 @@
                 </tr>
             {% endif %}
 
+            {% if end_user.documents|length %}
+                {% for document in end_user.documents %}
+                    {% if document.type == "end_user_ec3_document" %}
+                        <tr class="govuk-table__row">
+                            <th scope="row" class="govuk-table__header">Upload an EC3 form</th>
+                            <td class="govuk-table__cell">
+                                {% if document.safe %}
+                                    <a target="_blank" href="{% url 'cases:document' queue_pk=queue.id pk=case.id file_pk=document.id %}" class="govuk-link--no-visited-state">
+                                        EC3 form ({{ document.name|document_extension|upper}} opens in new tab)
+                                    </a>
+                                {% else %}
+                                    {{ document.name }}
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% endif %}
+                {% endfor %}
+            {% endif %}
+
+            {% if end_user.ec3_missing_reason %}
+                <tr class="govuk-table__row">
+                    <th scope="row" class="govuk-table__header">If you do not have an EC3 form, explain why (optional)</th>
+                    <td class="govuk-table__cell">{{ end_user.ec3_missing_reason }}</td>
+                </tr>
+            {% endif %}
+
             {% if consignee and consignee.documents|length %}
                 {% with document=consignee.documents.0 %}
                     <tr class="govuk-table__row">

--- a/exporter/applications/forms/parties.py
+++ b/exporter/applications/forms/parties.py
@@ -453,3 +453,38 @@ class PartyCompanyLetterheadDocumentUploadForm(forms.Form):
             "party_letterhead_document",
             Submit("submit", "Continue"),
         )
+
+
+class PartyEC3DocumentUploadForm(forms.Form):
+    title = "Upload an EC3 form (optional)"
+    party_ec3_document = forms.FileField(label="", required=False)
+    ec3_missing_reason = forms.CharField(
+        widget=forms.Textarea(attrs={"rows": "5"}),
+        label="",
+        help_text="If you do not have an EC3 form, explain why (optional)",
+        required=False,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.helper = FormHelper()
+        self.helper.attrs = {"enctype": "multipart/form-data"}
+        self.helper.layout = Layout(
+            HTML.h1(self.title),
+            HTML.p(
+                "An EC3 form is required if you are exporting firearm products from Northern Ireland to a country within the European Union."
+            ),
+            "party_ec3_document",
+            "ec3_missing_reason",
+            HTML.details(
+                "Help with the EC3 form and exemptions",
+                """You do not require an EC3 form to export weapons sights, sound suppressors or silencers, magazines, antique firearms
+                 manufactured before 1890 (including parts and components for those firearms) and items which will be used by
+                 police, armed forces or public authorities.<br><br>
+                <a class="govuk-link" target="_blank" href="https://www.gov.uk/government/publications/end-user-undertaking-euu-form">
+                Guidance on the EC3 form (opens in new tab)</a>
+            """,
+            ),
+            Submit("submit", "Continue"),
+        )

--- a/exporter/applications/helpers/parties.py
+++ b/exporter/applications/helpers/parties.py
@@ -1,3 +1,6 @@
+from exporter.core.constants import FirearmsProductType
+
+
 def party_requires_ec3_document(application):
     """
     Helper function to determine EC3 document requirement status for End-user
@@ -25,13 +28,17 @@ def party_requires_ec3_document(application):
         eu_destination = True
 
     ec3_product_types = {
-        "firearms",
-        "components_for_firearms",
-        "ammunition",
-        "components_for_ammunition",
-        "firearms_accessory",
+        FirearmsProductType.FIREARMS,
+        FirearmsProductType.AMMUNITION,
+        FirearmsProductType.COMPONENTS_FOR_FIREARMS,
+        FirearmsProductType.COMPONENTS_FOR_AMMUNITION,
+        FirearmsProductType.FIREARMS_ACCESSORY,
     }
-    product_types = {product["firearm_details"]["type"]["key"] for product in application.get("goods", [])}
-    firearms_products = bool(ec3_product_types.intersection(product_types))
+    product_types = {
+        product["firearm_details"]["type"]["key"]
+        for product in application.get("goods", [])
+        if product.get("firearm_details")
+    }
+    firearms_products = ec3_product_types.intersection(product_types)
 
     return goods_from_NI and eu_destination and firearms_products

--- a/exporter/applications/helpers/parties.py
+++ b/exporter/applications/helpers/parties.py
@@ -1,0 +1,37 @@
+def party_requires_ec3_document(application):
+    """
+    Helper function to determine EC3 document requirement status for End-user
+
+    We only need to ask if the goods originate from NI, going to EU and the
+    product type is not software or technology related to firearms. If we have
+    atleast one other type included then we need to ask for this form provided
+    the other conditions satisfy.
+    Since the user may not have added the products before entering End-user details
+    and vice versa this needs checking in multiple places and accodingly notify user.
+    """
+
+    # user may not have completed the goods location section
+    goods_from_NI = application.get("goods_starting_point", "") == "NI"
+
+    # user may not have entered end-user details yet
+    eu_destination = False
+    destination = application.get("destinations", {})
+    if (
+        destination
+        and destination["type"] == "end_user"
+        and destination["data"]
+        and destination["data"]["country"]["is_eu"]
+    ):
+        eu_destination = True
+
+    ec3_product_types = {
+        "firearms",
+        "components_for_firearms",
+        "ammunition",
+        "components_for_ammunition",
+        "firearms_accessory",
+    }
+    product_types = {product["firearm_details"]["type"]["key"] for product in application.get("goods", [])}
+    firearms_products = bool(ec3_product_types.intersection(product_types))
+
+    return goods_from_NI and eu_destination and firearms_products

--- a/exporter/applications/helpers/task_lists.py
+++ b/exporter/applications/helpers/task_lists.py
@@ -5,6 +5,7 @@ from exporter.applications.helpers.check_your_answers import (
     _is_application_export_type_temporary,
     get_application_type_string,
 )
+from exporter.applications.helpers.parties import party_requires_ec3_document
 from exporter.applications.helpers.task_list_sections import (
     get_reference_number_description,
     get_edit_type,
@@ -25,6 +26,7 @@ from exporter.core.constants import (
     EXHIBITION,
     F680,
     GIFTING,
+    PartyDocumentType,
     Permissions,
     CaseTypes,
 )
@@ -67,6 +69,21 @@ def get_application_task_list(request, application, errors=None):
         "licence_type": get_application_type_string(application),
         "errors": errors,
     }
+
+    require_ec3 = party_requires_ec3_document(application)
+    end_user = application.get("end_user", {})
+    ec3_details_available = False
+    if end_user:
+        ec3_document_available = bool(
+            [
+                document
+                for document in end_user["documents"]
+                if document["type"] == PartyDocumentType.END_USER_EC3_DOCUMENT
+            ]
+        )
+        ec3_details_available = ec3_document_available or end_user["ec3_missing_reason"]
+
+    context["show_ec3_banner"] = require_ec3 and not ec3_details_available
 
     if application_type == HMRC:
         context["locations"] = application["goods_locations"] or application["have_goods_departed"]

--- a/exporter/applications/helpers/task_lists.py
+++ b/exporter/applications/helpers/task_lists.py
@@ -74,12 +74,8 @@ def get_application_task_list(request, application, errors=None):
     end_user = application.get("end_user", {})
     ec3_details_available = False
     if end_user:
-        ec3_document_available = bool(
-            [
-                document
-                for document in end_user["documents"]
-                if document["type"] == PartyDocumentType.END_USER_EC3_DOCUMENT
-            ]
+        ec3_document_available = any(
+            document["type"] == PartyDocumentType.END_USER_EC3_DOCUMENT for document in end_user["documents"]
         )
         ec3_details_available = ec3_document_available or end_user["ec3_missing_reason"]
 

--- a/exporter/applications/urls.py
+++ b/exporter/applications/urls.py
@@ -276,6 +276,11 @@ urlpatterns = [
         end_users.PartyDocumentEditView.as_view(),
         name="end_user_edit_document",
     ),
+    path(
+        "<uuid:pk>/end-user/<uuid:obj_pk>/ec3_document/",
+        end_users.PartyEC3DocumentView.as_view(),
+        name="end_user_ec3_document",
+    ),
     path("<uuid:pk>/end-user/<uuid:obj_pk>/copy/", end_users.CopyEndUserView.as_view(), name="copy_end_user"),
     path("<uuid:pk>/end-user/<uuid:obj_pk>/remove/", end_users.RemoveEndUserView.as_view(), name="remove_end_user"),
     path(

--- a/exporter/applications/views/parties/end_users.py
+++ b/exporter/applications/views/parties/end_users.py
@@ -19,6 +19,7 @@ from exporter.applications.forms.parties import (
     PartyDocumentUploadForm,
     PartyEnglishTranslationDocumentUploadForm,
     PartyCompanyLetterheadDocumentUploadForm,
+    PartyEC3DocumentUploadForm,
 )
 from exporter.applications.services import (
     copy_party,
@@ -563,3 +564,14 @@ class PartyDocumentDownloadView(LoginRequiredMixin, PartyContextMixin, TemplateV
 
         document = document[0]
         return download_document_from_s3(document["s3_key"], document["name"])
+
+
+class PartyEC3DocumentView(LoginRequiredMixin, PartyContextMixin, FormView):
+    form_class = PartyEC3DocumentUploadForm
+
+    def form_valid(self, form):
+        update_party(self.request, self.application_id, self.party_id, form.cleaned_data)
+        return super().form_valid(form)
+
+    def get_success_url(self):
+        return reverse("applications:end_user_summary", kwargs=self.kwargs)

--- a/exporter/applications/views/parties/end_users.py
+++ b/exporter/applications/views/parties/end_users.py
@@ -104,6 +104,40 @@ def _post_party_document(request, application_id, party_id, document_type, docum
     return response, status_code
 
 
+def party_requires_ec3_document(application):
+    """
+    Helper function to determine EC3 document requirement status for End-user
+
+    We only need to ask if the goods originate from NI, going to EU and the
+    product type is not software or technology related to firearms. If we have
+    atleast one other type included then we need to ask for this form provided
+    the other conditions satisfy.
+    Since the user may not have added the products before entering End-user details
+    and vice versa this needs checking in multiple places and accodingly notify user.
+    """
+
+    # user may not have completed the goods location section
+    goods_from_NI = application.get("goods_starting_point", "") == "NI"
+
+    # user may not have entered end-user details yet
+    eu_destination = False
+    destination = application.get("destinations", {})
+    if destination and destination["type"] == "end_user" and destination["data"]["country"]["is_eu"]:
+        eu_destination = True
+
+    ec3_product_types = {
+        "firearms",
+        "components_for_firearms",
+        "ammunition",
+        "components_for_ammunition",
+        "firearms_accessory",
+    }
+    product_types = {product["firearm_details"]["type"] for product in application.get("goods", [])}
+    firearms_products = bool(ec3_product_types.intersection(product_types))
+
+    return goods_from_NI and eu_destination and firearms_products
+
+
 class SetPartyView(LoginRequiredMixin, SessionWizardView):
     template_name = "core/form-wizard.html"
 
@@ -163,7 +197,11 @@ class SetPartyView(LoginRequiredMixin, SessionWizardView):
         return kwargs
 
     def get_success_url(self, party_id):
-        return reverse("applications:end_user_summary", kwargs={"pk": self.kwargs["pk"], "obj_pk": party_id})
+        application = get_application(self.request, self.kwargs["pk"])
+        if party_requires_ec3_document(application):
+            return reverse("applications:end_user_ec3_document", kwargs={"pk": self.kwargs["pk"], "obj_pk": party_id})
+        else:
+            return reverse("applications:end_user_summary", kwargs={"pk": self.kwargs["pk"], "obj_pk": party_id})
 
     def done(self, form_list, **kwargs):
         all_data = {k: v for form in form_list for k, v in form.cleaned_data.items()}

--- a/exporter/core/constants.py
+++ b/exporter/core/constants.py
@@ -140,6 +140,7 @@ FIREARMS_ALL_TYPES = [
 
 DOCUMENT_TYPE_PARAM_ENGLISH_TRANSLATION = "english_translation"
 DOCUMENT_TYPE_PARAM_COMPANY_LETTERHEAD = "company_letterhead"
+DOCUMENT_TYPE_PARAM_EC3_DOCUMENT = "ec3_document"
 
 
 class GoodsStartingPoint:
@@ -226,3 +227,4 @@ class PartyDocumentType:
     END_USER_UNDERTAKING_DOCUMENT = "end_user_undertaking_document"
     END_USER_ENGLISH_TRANSLATION_DOCUMENT = "end_user_english_translation_document"
     END_USER_COMPANY_LETTERHEAD_DOCUMENT = "end_user_company_letterhead_document"
+    END_USER_EC3_DOCUMENT = "end_user_ec3_document"

--- a/exporter/core/constants.py
+++ b/exporter/core/constants.py
@@ -110,6 +110,16 @@ class LocationType:
     LAND_BASED = "land_based"
 
 
+class FirearmsProductType:
+    FIREARMS = "firearms"
+    COMPONENTS_FOR_FIREARMS = "components_for_firearms"
+    AMMUNITION = "ammunition"
+    COMPONENTS_FOR_AMMUNITION = "components_for_ammunition"
+    FIREARMS_ACCESSORY = "firearms_accessory"
+    SOFTWARE_RELATED_TO_FIREARM = "software_related_to_firearms"
+    TECHNOLOGY_RELATED_TO_FIREARM = "technology_related_to_firearms"
+
+
 PRODUCT_CATEGORY_FIREARM = "group2_firearms"
 FIREARMS = "firearms"
 FIREARMS_ACCESSORY = "firearms_accessory"

--- a/exporter/core/helpers.py
+++ b/exporter/core/helpers.py
@@ -269,3 +269,4 @@ def is_document_in_english(wizard):
 def is_document_on_letterhead(wizard):
     cleaned_data = wizard.get_cleaned_data_for_step(SetPartyFormSteps.PARTY_DOCUMENT_UPLOAD)
     return str_to_bool(cleaned_data.get("document_on_letterhead"))
+

--- a/exporter/core/helpers.py
+++ b/exporter/core/helpers.py
@@ -269,4 +269,3 @@ def is_document_in_english(wizard):
 def is_document_on_letterhead(wizard):
     cleaned_data = wizard.get_cleaned_data_for_step(SetPartyFormSteps.PARTY_DOCUMENT_UPLOAD)
     return str_to_bool(cleaned_data.get("document_on_letterhead"))
-

--- a/exporter/templates/applications/party-summary.html
+++ b/exporter/templates/applications/party-summary.html
@@ -100,18 +100,31 @@
                 </dd>
             </div>
         {% if party.end_user_document_available %}
-            {% for document in party.documents %}
-                {% if document.type == "end_user_undertaking_document" %}
+            {% if end_user_undertaking_document %}
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        Upload an end-user document
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        {% if end_user_undertaking_document.safe %}
+                            <a href="{% url 'applications:party_document_download' pk obj_pk end_user_undertaking_document.id %}" class="govuk-link--no-visited-state">{{ end_user_undertaking_document.name }}</a>
+                        {% else %}
+                            {{ end_user_undertaking_document.name }}
+                        {% endif %}
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                        <a class="govuk-link" href="{% url 'applications:end_user_edit_undertaking_document' pk obj_pk %}">
+                            Change<span class="govuk-visually-hidden"> name</span>
+                        </a>
+                    </dd>
+                </div>
+                {% if party.product_differences_note %}
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">
-                            Upload an end-user document
+                            Describe any differences between products listed in the document and products on the application (optional)
                         </dt>
                         <dd class="govuk-summary-list__value">
-                            {% if document.safe %}
-                                <a href="{% url 'applications:party_document_download' pk obj_pk document.id %}" class="govuk-link--no-visited-state">{{ document.name }}</a>
-                            {% else %}
-                                {{ document.name }}
-                            {% endif %}
+                            {{ party.product_differences_note }}
                         </dd>
                         <dd class="govuk-summary-list__actions">
                             <a class="govuk-link" href="{% url 'applications:end_user_edit_undertaking_document' pk obj_pk %}">
@@ -119,64 +132,50 @@
                             </a>
                         </dd>
                     </div>
-                    {% if party.product_differences_note %}
-                        <div class="govuk-summary-list__row">
-                            <dt class="govuk-summary-list__key">
-                                Describe any differences between products listed in the document and products on the application (optional)
-                            </dt>
-                            <dd class="govuk-summary-list__value">
-                                {{ party.product_differences_note }}
-                            </dd>
-                            <dd class="govuk-summary-list__actions">
-                                <a class="govuk-link" href="{% url 'applications:end_user_edit_undertaking_document' pk obj_pk %}">
-                                    Change<span class="govuk-visually-hidden"> name</span>
-                                </a>
-                            </dd>
-                        </div>
-                    {% endif %}
                 {% endif %}
+            {% endif %}
 
-                {% if document.type == "end_user_english_translation_document" %}
-                    <div class="govuk-summary-list__row">
-                        <dt class="govuk-summary-list__key">
-                            Upload an English translation of the end-user document
-                        </dt>
-                        <dd class="govuk-summary-list__value">
-                            {% if document.safe %}
-                                <a href="{% url 'applications:party_document_download' pk obj_pk document.id %}" class="govuk-link--no-visited-state">{{ document.name }}</a>
-                            {% else %}
-                                {{ document.name }}
-                            {% endif %}
-                        </dd>
-                        <dd class="govuk-summary-list__actions">
-                            <a class="govuk-link" href="{% url 'applications:end_user_edit_document' pk obj_pk 'english_translation' %}">
-                                Change<span class="govuk-visually-hidden"> name</span>
+            {% if end_user_english_translation_document %}
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        Upload an English translation of the end-user document
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        {% if end_user_english_translation_document.safe %}
+                            <a href="{% url 'applications:party_document_download' pk obj_pk end_user_english_translation_document.id %}" class="govuk-link--no-visited-state">
+                                {{ end_user_english_translation_document.name }}
                             </a>
-                        </dd>
-                    </div>
-                {% endif %}
+                        {% else %}
+                            {{ end_user_english_translation_document.name }}
+                        {% endif %}
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                        <a class="govuk-link" href="{% url 'applications:end_user_edit_document' pk obj_pk 'english_translation' %}">
+                            Change<span class="govuk-visually-hidden"> name</span>
+                        </a>
+                    </dd>
+                </div>
+            {% endif %}
 
-                {% if document.type == "end_user_company_letterhead_document" %}
-                    <div class="govuk-summary-list__row">
-                        <dt class="govuk-summary-list__key">
-                            Upload a document on company letterhead
-                        </dt>
-                        <dd class="govuk-summary-list__value">
-                            {% if document.safe %}
-                                <a href="{% url 'applications:party_document_download' pk obj_pk document.id %}" class="govuk-link--no-visited-state">{{ document.name }}</a>
-                            {% else %}
-                                {{ document.name }}
-                            {% endif %}
-                        </dd>
-                        <dd class="govuk-summary-list__actions">
-                            <a class="govuk-link" href="{% url 'applications:end_user_edit_document' pk obj_pk 'company_letterhead' %}">
-                                Change<span class="govuk-visually-hidden"> name</span>
-                            </a>
-                        </dd>
-                    </div>
-                {% endif %}
-
-            {% endfor %}
+            {% if end_user_company_letterhead_document %}
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        Upload a document on company letterhead
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        {% if end_user_company_letterhead_document.safe %}
+                            <a href="{% url 'applications:party_document_download' pk obj_pk end_user_company_letterhead_document.id %}" class="govuk-link--no-visited-state">{{ end_user_company_letterhead_document.name }}</a>
+                        {% else %}
+                            {{ end_user_company_letterhead_document.name }}
+                        {% endif %}
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                        <a class="govuk-link" href="{% url 'applications:end_user_edit_document' pk obj_pk 'company_letterhead' %}">
+                            Change<span class="govuk-visually-hidden"> name</span>
+                        </a>
+                    </dd>
+                </div>
+            {% endif %}
         {% else %}
             <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">
@@ -193,17 +192,42 @@
             </div>
         {% endif %}
 
-        {% for document in party.documents %}
-            {% if document.type == "end_user_ec3_document" %}
+        {% if not end_user_ec3_document and not party.ec3_missing_reason %}
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    Upload an EC3 form (optional)
+                </dt>
+                <dd class="govuk-summary-list__value">
+                </dd>
+                <dd class="govuk-summary-list__actions">
+                    <a class="govuk-link" href="{% url 'applications:end_user_ec3_document' pk obj_pk %}">
+                        Change<span class="govuk-visually-hidden"> name</span>
+                    </a>
+                </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    If you do not have an EC3 form, explain why (optional)
+                </dt>
+                <dd class="govuk-summary-list__value">
+                </dd>
+                <dd class="govuk-summary-list__actions">
+                    <a class="govuk-link" href="{% url 'applications:end_user_ec3_document' pk obj_pk %}">
+                        Change<span class="govuk-visually-hidden"> name</span>
+                    </a>
+                </dd>
+            </div>
+        {% else %}
+            {% if end_user_ec3_document %}
                 <div class="govuk-summary-list__row">
                     <dt class="govuk-summary-list__key">
                         Upload an EC3 form (optional)
                     </dt>
                     <dd class="govuk-summary-list__value">
-                        {% if document.safe %}
-                            <a href="{% url 'applications:party_document_download' pk obj_pk document.id %}" class="govuk-link--no-visited-state">{{ document.name }}</a>
+                        {% if end_user_ec3_document.safe %}
+                            <a href="{% url 'applications:party_document_download' pk obj_pk end_user_ec3_document.id %}" class="govuk-link--no-visited-state">{{ end_user_ec3_document.name }}</a>
                         {% else %}
-                            {{ document.name }}
+                            {{ end_user_ec3_document.name }}
                         {% endif %}
                     </dd>
                     <dd class="govuk-summary-list__actions">
@@ -213,25 +237,23 @@
                     </dd>
                 </div>
             {% endif %}
-        {% endfor %}
 
-        {% if party.ec3_missing_reason %}
-            <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">
-                    If you do not have an EC3 form, explain why (optional)
-                </dt>
-                <dd class="govuk-summary-list__value">
-                    {{ party.ec3_missing_reason }}
-                </dd>
-                <dd class="govuk-summary-list__actions">
-                    <a class="govuk-link" href="{% url 'applications:end_user_ec3_document' pk obj_pk %}">
-                        Change<span class="govuk-visually-hidden"> name</span>
-                    </a>
-                </dd>
-            </div>
+            {% if party.ec3_missing_reason %}
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        If you do not have an EC3 form, explain why (optional)
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        {{ party.ec3_missing_reason }}
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                        <a class="govuk-link" href="{% url 'applications:end_user_ec3_document' pk obj_pk %}">
+                            Change<span class="govuk-visually-hidden"> name</span>
+                        </a>
+                    </dd>
+                </div>
+            {% endif %}
         {% endif %}
-
-
     </div>
 
     <div>

--- a/exporter/templates/applications/party-summary.html
+++ b/exporter/templates/applications/party-summary.html
@@ -192,6 +192,46 @@
                 </dd>
             </div>
         {% endif %}
+
+        {% for document in party.documents %}
+            {% if document.type == "end_user_ec3_document" %}
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        Upload an EC3 form (optional)
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        {% if document.safe %}
+                            <a href="{% url 'applications:party_document_download' pk obj_pk document.id %}" class="govuk-link--no-visited-state">{{ document.name }}</a>
+                        {% else %}
+                            {{ document.name }}
+                        {% endif %}
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                        <a class="govuk-link" href="{% url 'applications:end_user_ec3_document' pk obj_pk %}">
+                            Change<span class="govuk-visually-hidden"> name</span>
+                        </a>
+                    </dd>
+                </div>
+            {% endif %}
+        {% endfor %}
+
+        {% if party.ec3_missing_reason %}
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    If you do not have an EC3 form, explain why (optional)
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    {{ party.ec3_missing_reason }}
+                </dd>
+                <dd class="govuk-summary-list__actions">
+                    <a class="govuk-link" href="{% url 'applications:end_user_ec3_document' pk obj_pk %}">
+                        Change<span class="govuk-visually-hidden"> name</span>
+                    </a>
+                </dd>
+            </div>
+        {% endif %}
+
+
     </div>
 
     <div>

--- a/exporter/templates/layouts/task-list.html
+++ b/exporter/templates/layouts/task-list.html
@@ -41,6 +41,24 @@
 		</div>
 	{% endif %}
 
+	{% if show_ec3_banner %}
+		<div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+			<div class="govuk-notification-banner__header">
+			<h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+				Important
+			</h2>
+			</div>
+			<div class="govuk-notification-banner__content">
+			<p class="govuk-notification-banner__heading">
+				An EC3 form may be needed to export your products from Northern Ireland to the European Union.
+				<a class="govuk-notification-banner__link" href="{% url 'applications:end_user_ec3_document' application.id application.end_user.id %}">
+					Upload an EC3 form (optional)
+				</a>.
+			</p>
+			</div>
+		</div>
+	{% endif %}
+
 	<h1 class="govuk-heading-l govuk-!-margin-bottom-2">
 		{% block title %}{% endblock %}
 	</h1>

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -496,6 +496,7 @@ def data_standard_case():
                     "product_differences_note": "",
                     "document_in_english": True,
                     "document_on_letterhead": True,
+                    "ec3_missing_reason": "",
                     "role": {"key": "other", "value": "Other"},
                     "role_other": None,
                     "flags": [],

--- a/unit_tests/exporter/applications/views/parties/test_end_users.py
+++ b/unit_tests/exporter/applications/views/parties/test_end_users.py
@@ -374,6 +374,14 @@ def test_edit_end_user_document(
             {
                 "goods_starting_point": "NI",
                 "destinations": {"type": "end_user", "data": {"country": {"is_eu": True}}},
+                "goods": [],
+            },
+            False,
+        ),
+        (
+            {
+                "goods_starting_point": "NI",
+                "destinations": {"type": "end_user", "data": {"country": {"is_eu": True}}},
                 "goods": [
                     {"firearm_details": {"type": {"key": "software_related_to_firearms"}}},
                     {"firearm_details": {"type": {"key": "technology_related_to_firearms"}}},
@@ -406,7 +414,7 @@ def test_edit_end_user_document(
     ),
 )
 def test_party_requires_ec3_document(application_data, ec3_expected_status):
-    assert ec3_expected_status == party_requires_ec3_document(application_data)
+    assert ec3_expected_status == bool(party_requires_ec3_document(application_data))
 
 
 def test_edit_end_user_ec3_document(requests_mock, authorized_client, data_standard_case, end_user_documents):
@@ -421,8 +429,7 @@ def test_edit_end_user_ec3_document(requests_mock, authorized_client, data_stand
     response = authorized_client.post(ec3_edit_url, data=data)
     assert response.status_code == 302
 
-    _ = requests_mock.request_history.pop()
-    actual = requests_mock.request_history.pop().json()
+    actual = requests_mock.request_history.pop(-2).json()
     assert actual == {
         "type": PartyDocumentType.END_USER_EC3_DOCUMENT,
         "name": actual["name"],


### PR DESCRIPTION
## Change description

An exporter may need to provide End-user EC3 document depending on goods starting location, destination and product type.
End-user journey is updated to ask for this document if the above conditions are met.
We only need this if goods are starting from NI, going to EU and firearms type is not software or technology related.
User can either upload a document or give an explanation for not having it. But both of these are optional.

The details required to determine (location, destination, type) are not all captured in one place, since user can complete these details in any order it is not possible to determine this requirement when user entering end-user details because he may not have added product details or starting location etc hence we display a banner notifying the user that he may need to provide these details. Once the details are provided then banner is also not shown.