### PR TITLE
LTD_2119 skipping serials that are not supplied

### DIFF
--- a/exporter/goods/services.py
+++ b/exporter/goods/services.py
@@ -113,7 +113,8 @@ def add_identification_marking_details(firearm_details, json):
 
         serial_numbers = []
         for i in range(number_of_items):
-            serial_numbers.append(json.get(f"serial_number_input_{i}", ""))
+            if json.get(f"serial_number_input_{i}", None):
+                serial_numbers.append(json[f"serial_number_input_{i}"])
         firearm_details["serial_numbers"] = serial_numbers
     elif firearm_details.get("serial_numbers_available") == "LATER":
         firearm_details["serial_numbers"] = []


### PR DESCRIPTION
Fixing issue where notification banner should show if exporter has chosen 'yes i can add serial numbers now' but left some numbers blank. This is done by skipping serials that are not supplied.