### PR TITLE
Remove the rfd certificate if user marks it as invalid

### DIFF
--- a/conf/exporter.py
+++ b/conf/exporter.py
@@ -10,6 +10,7 @@ ROOT_URLCONF = "exporter.urls"
 
 INSTALLED_APPS += [
     "exporter.core",
+    "exporter.applications",
     "exporter.organisation",
 ]
 

--- a/exporter/applications/templatetags/additional_documents.py
+++ b/exporter/applications/templatetags/additional_documents.py
@@ -1,0 +1,11 @@
+from django import template
+
+from exporter.core.constants import DocumentType
+
+
+register = template.Library()
+
+
+@register.filter(name="is_system_document")
+def is_system_document(document):
+    return document.get("document_type") in [DocumentType.RFD_CERTIFICATE]

--- a/exporter/applications/views/goods/add_good_firearm.py
+++ b/exporter/applications/views/goods/add_good_firearm.py
@@ -376,6 +376,8 @@ class AddGoodFirearm(LoginRequiredMixin, BaseSessionWizardView):
 
         rfd_certificate_payload = {
             **get_document_data(cert_file),
+            "description": "Registered firearm dealer certificate",
+            "document_type": "rfd-certificate",
             "document_on_organisation": {
                 "expiry_date": expiry_date.isoformat(),
                 "reference_code": reference_code,
@@ -465,6 +467,8 @@ class AddGoodFirearm(LoginRequiredMixin, BaseSessionWizardView):
                 "s3_key": document["s3_key"],
                 "safe": document["safe"],
                 "size": document["size"],
+                "document_type": "rfd-certificate",
+                "description": "Registered firearm dealer certificate",
             },
         )
         if status_code != HTTPStatus.CREATED:

--- a/exporter/applications/views/goods/add_good_firearm.py
+++ b/exporter/applications/views/goods/add_good_firearm.py
@@ -16,6 +16,7 @@ from core.auth.views import LoginRequiredMixin
 
 from exporter.applications.services import get_application, post_additional_document, post_application_document
 from exporter.core.constants import (
+    DocumentType,
     FirearmsActSections,
     FirearmsActDocumentType,
 )
@@ -102,7 +103,7 @@ def has_application_rfd_certificate(wizard):
         return False
 
     for additional_document in additional_documents:
-        if additional_document.get("document_type") == "rfd-certificate":
+        if additional_document.get("document_type") == DocumentType.RFD_CERTIFICATE:
             return True
 
     return False
@@ -394,11 +395,11 @@ class AddGoodFirearm(LoginRequiredMixin, BaseSessionWizardView):
         rfd_certificate_payload = {
             **get_document_data(cert_file),
             "description": "Registered firearm dealer certificate",
-            "document_type": "rfd-certificate",
+            "document_type": DocumentType.RFD_CERTIFICATE,
             "document_on_organisation": {
                 "expiry_date": expiry_date.isoformat(),
                 "reference_code": reference_code,
-                "document_type": "rfd-certificate",
+                "document_type": DocumentType.RFD_CERTIFICATE,
             },
         }
         return rfd_certificate_payload
@@ -484,7 +485,7 @@ class AddGoodFirearm(LoginRequiredMixin, BaseSessionWizardView):
                 "s3_key": document["s3_key"],
                 "safe": document["safe"],
                 "size": document["size"],
-                "document_type": "rfd-certificate",
+                "document_type": DocumentType.RFD_CERTIFICATE,
                 "description": "Registered firearm dealer certificate",
             },
         )

--- a/exporter/applications/views/goods/goods.py
+++ b/exporter/applications/views/goods/goods.py
@@ -194,7 +194,7 @@ class RegisteredFirearmDealersMixin:
             "document_on_organisation": {
                 "expiry_date": format_date(self.request.POST, "expiry_date_"),
                 "reference_code": self.request.POST["reference_code"],
-                "document_type": "rfd-certificate",
+                "document_type": constants.DocumentType.RFD_CERTIFICATE,
             },
         }
 
@@ -372,7 +372,7 @@ class AddGood(LoginRequiredMixin, BaseSessionWizardView):
                 "document_on_organisation": {
                     "expiry_date": format_date(all_data, "expiry_date_"),
                     "reference_code": all_data["reference_code"],
-                    "document_type": "rfd-certificate",
+                    "document_type": constants.DocumentType.RFD_CERTIFICATE,
                 },
             }
 
@@ -853,7 +853,7 @@ class AddGoodToApplication(SectionDocumentMixin, LoginRequiredMixin, BaseSession
                 "document_on_organisation": {
                     "expiry_date": format_date(all_data, "expiry_date_"),
                     "reference_code": all_data["reference_code"],
-                    "document_type": "rfd-certificate",
+                    "document_type": constants.DocumentType.RFD_CERTIFICATE,
                 },
             }
 

--- a/exporter/core/constants.py
+++ b/exporter/core/constants.py
@@ -240,6 +240,10 @@ class PartyDocumentType:
     END_USER_EC3_DOCUMENT = "end_user_ec3_document"
 
 
+class DocumentType:
+    RFD_CERTIFICATE = "rfd-certificate"
+
+
 class FirearmsActDocumentType:
     SECTION_1 = "section-one-certificate"
     SECTION_2 = "section-two-certificate"

--- a/exporter/core/helpers.py
+++ b/exporter/core/helpers.py
@@ -243,7 +243,7 @@ def get_organisation_documents(application):
 
 def get_rfd_certificate(application):
     documents = get_organisation_documents(application)
-    return documents.get("rfd-certificate")
+    return documents.get(constants.DocumentType.RFD_CERTIFICATE)
 
 
 def is_end_user_document_available(wizard):

--- a/exporter/organisation/services.py
+++ b/exporter/organisation/services.py
@@ -11,3 +11,9 @@ def get_document_on_organisation(request, organisation_id, document_id):
     response = client.get(request, f"/organisations/{organisation_id}/document/{document_id}/")
     response.raise_for_status()
     return response
+
+
+def delete_document_on_organisation(request, organisation_id, document_id):
+    response = client.delete(request, f"/organisations/{organisation_id}/document/{document_id}/")
+    response.raise_for_status()
+    return response.status_code

--- a/exporter/organisation/views.py
+++ b/exporter/organisation/views.py
@@ -3,7 +3,7 @@ from django.shortcuts import render
 from django.urls import reverse, reverse_lazy
 from django.views.generic import FormView, TemplateView, RedirectView
 
-from exporter.core.constants import Permissions
+from exporter.core.constants import DocumentType, Permissions
 from exporter.core.objects import Tab
 from exporter.core.services import get_organisation
 from lite_content.lite_exporter_frontend.organisation import Tabs
@@ -100,7 +100,7 @@ class UploadFirearmsCertificate(AbstractOrganisationUpload):
     template_name = "core/form.html"
     form_class = forms.UploadFirearmsCertificateForm
     success_url = reverse_lazy("organisation:details")
-    document_type = "rfd-certificate"
+    document_type = DocumentType.RFD_CERTIFICATE
 
     def get_context_data(self, *args, **kwargs):
         return super().get_context_data(

--- a/exporter/templates/applications/additional-documents/additional-documents.html
+++ b/exporter/templates/applications/additional-documents/additional-documents.html
@@ -1,6 +1,6 @@
 {% extends 'layouts/base.html' %}
 
-{% load svg %}
+{% load additional_documents svg %}
 
 {% block back_link %}
 	<a href="{% url 'applications:task_list' application_id %}#supporting-documents" id="back-link" class="govuk-back-link">{% lcs 'AdditionalDocuments.BACK' %}</a>
@@ -47,7 +47,7 @@
 						{% endif %}
 					</td>
 					<td class="govuk-table__cell govuk-table__cell--numeric">
-						{% if editable %}
+						{% if editable and not additional_document|is_system_document %}
 							<a href="{% url 'applications:delete_additional_document' application_id additional_document.id %}" id="document_delete" class='govuk-link govuk-link--no-visited-state'>
 								{% lcs 'AdditionalDocuments.Documents.DELETE_DOCUMENT' %}
 							</a>

--- a/unit_tests/exporter/applications/views/test_add_good_firearm.py
+++ b/unit_tests/exporter/applications/views/test_add_good_firearm.py
@@ -626,6 +626,8 @@ def test_add_good_firearm_with_rfd_document_submission(
     assert post_applications_document_matcher.called_once
     application_doc_request = post_applications_document_matcher.last_request
     assert application_doc_request.json() == {
+        "description": "Registered firearm dealer certificate",
+        "document_type": "rfd-certificate",
         "name": "rfd_certificate.txt",
         "s3_key": "rfd_certificate.txt.s3_key",
         "safe": True,
@@ -873,14 +875,16 @@ def test_add_good_firearm_without_rfd_document_submission_registered_firearms_de
     assert post_additional_document_matcher.called_once
     last_request = post_additional_document_matcher.last_request
     assert last_request.json() == {
-        "name": file_name,
-        "s3_key": file_name,
-        "size": 0,
+        "description": "Registered firearm dealer certificate",
         "document_on_organisation": {
             "expiry_date": expiry_date.isoformat(),
             "reference_code": "12345",
             "document_type": "rfd-certificate",
         },
+        "document_type": "rfd-certificate",
+        "name": file_name,
+        "s3_key": file_name,
+        "size": 0,
     }
 
 
@@ -1502,6 +1506,8 @@ def test_add_good_firearm_with_rfd_document_submission_section_5(
     assert post_applications_document_matcher.called_once
     application_doc_request = post_applications_document_matcher.last_request
     assert application_doc_request.json() == {
+        "description": "Registered firearm dealer certificate",
+        "document_type": "rfd-certificate",
         "name": "rfd_certificate.txt",
         "s3_key": "rfd_certificate.txt.s3_key",
         "safe": True,
@@ -1610,6 +1616,8 @@ def test_add_good_firearm_with_rfd_document_submission_section_5_with_current_se
     assert post_applications_document_matcher.called_once
     application_doc_request = post_applications_document_matcher.last_request
     assert application_doc_request.json() == {
+        "description": "Registered firearm dealer certificate",
+        "document_type": "rfd-certificate",
         "name": "rfd_certificate.txt",
         "s3_key": "rfd_certificate.txt.s3_key",
         "safe": True,

--- a/unit_tests/exporter/applications/views/test_add_good_firearm.py
+++ b/unit_tests/exporter/applications/views/test_add_good_firearm.py
@@ -85,6 +85,7 @@ def rfd_certificate():
         },
         "document_type": "rfd-certificate",
         "is_expired": False,
+        "organisation": str(uuid.uuid4()),
     }
 
 
@@ -630,6 +631,137 @@ def test_add_good_firearm_with_rfd_document_submission(
         "safe": True,
         "size": 3,
     }
+
+
+def test_add_good_firearm_with_rfd_document_marked_as_invalid_submission(
+    authorized_client,
+    new_good_firearm_url,
+    post_to_step,
+    requests_mock,
+    data_standard_case,
+    control_list_entries,
+    pv_gradings,
+    application_with_rfd_document,
+    good_id,
+    rfd_certificate,
+):
+    authorized_client.get(new_good_firearm_url)
+
+    post_goods_matcher = requests_mock.post(
+        f"/goods/",
+        status_code=201,
+        json={
+            "good": {
+                "id": good_id,
+            },
+        },
+    )
+
+    document_id = rfd_certificate["id"]
+    organisation_id = rfd_certificate["organisation"]
+    post_applications_document_matcher = requests_mock.delete(
+        f"/organisations/{organisation_id}/document/{document_id}/",
+        status_code=204,
+        json={},
+    )
+
+    post_to_step(
+        AddGoodFirearmSteps.CATEGORY,
+        {"category": ["NON_AUTOMATIC_SHOTGUN"]},
+    )
+    post_to_step(
+        AddGoodFirearmSteps.NAME,
+        {"name": "TEST NAME"},
+    )
+    post_to_step(
+        AddGoodFirearmSteps.PRODUCT_CONTROL_LIST_ENTRY,
+        {
+            "is_good_controlled": True,
+            "control_list_entries": [
+                "ML1",
+                "ML1a",
+            ],
+        },
+    )
+    post_to_step(
+        AddGoodFirearmSteps.PV_GRADING,
+        {"is_pv_graded": True},
+    )
+    post_to_step(
+        AddGoodFirearmSteps.PV_GRADING_DETAILS,
+        {
+            "prefix": "NATO",
+            "grading": "official",
+            "issuing_authority": "Government entity",
+            "reference": "GR123",
+            "date_of_issue_0": "20",
+            "date_of_issue_1": "02",
+            "date_of_issue_2": "2020",
+        },
+    )
+    post_to_step(
+        AddGoodFirearmSteps.CALIBRE,
+        {"calibre": "calibre 123"},
+    )
+    post_to_step(
+        AddGoodFirearmSteps.IS_REPLICA,
+        {"is_replica": True, "replica_description": "This is a replica"},
+    )
+    post_to_step(
+        AddGoodFirearmSteps.IS_RFD_CERTIFICATE_VALID,
+        {"is_rfd_certificate_valid": False},
+    )
+    post_to_step(
+        AddGoodFirearmSteps.IS_REGISTERED_FIREARMS_DEALER,
+        {"is_registered_firearm_dealer": False},
+    )
+    post_to_step(
+        AddGoodFirearmSteps.FIREARM_ACT_1968,
+        {"firearms_act_section": "no"},
+    )
+    response = post_to_step(
+        AddGoodFirearmSteps.PRODUCT_DOCUMENT_AVAILABILITY,
+        {"is_document_available": False, "no_document_comments": "product not manufactured yet"},
+    )
+
+    assert response.status_code == 302
+    assert response.url == reverse(
+        "applications:product_summary",
+        kwargs={
+            "pk": data_standard_case["case"]["id"],
+            "good_pk": good_id,
+        },
+    )
+
+    assert post_goods_matcher.called_once
+    last_request = post_goods_matcher.last_request
+    assert last_request.json() == {
+        "firearm_details": {
+            "calibre": "calibre 123",
+            "category": ["NON_AUTOMATIC_SHOTGUN"],
+            "is_covered_by_firearm_act_section_one_two_or_five": "No",
+            "is_registered_firearm_dealer": False,
+            "is_replica": True,
+            "is_rfd_certificate_valid": False,
+            "replica_description": "This is a replica",
+            "type": "firearms",
+        },
+        "control_list_entries": ["ML1", "ML1a"],
+        "name": "TEST NAME",
+        "is_good_controlled": True,
+        "is_pv_graded": "yes",
+        "prefix": "NATO",
+        "grading": "official",
+        "suffix": "",
+        "issuing_authority": "Government entity",
+        "reference": "GR123",
+        "date_of_issue": "2020-02-20",
+        "item_category": "group2_firearms",
+        "is_document_available": False,
+        "no_document_comments": "product not manufactured yet",
+    }
+
+    assert post_applications_document_matcher.called_once
 
 
 def test_add_good_firearm_without_rfd_document_submission_registered_firearms_dealer(

--- a/unit_tests/exporter/applications/views/test_add_good_firearm.py
+++ b/unit_tests/exporter/applications/views/test_add_good_firearm.py
@@ -78,7 +78,10 @@ def rfd_certificate():
     return {
         "id": str(uuid.uuid4()),
         "document": {
-            "name": "testdocument.txt",
+            "name": "rfd_certificate.txt",
+            "s3_key": "rfd_certificate.txt.s3_key",
+            "safe": True,
+            "size": 3,
         },
         "document_type": "rfd-certificate",
         "is_expired": False,
@@ -509,6 +512,12 @@ def test_add_good_firearm_with_rfd_document_submission(
         json={},
     )
 
+    post_applications_document_matcher = requests_mock.post(
+        f"/applications/{data_standard_case['case']['id']}/documents/",
+        status_code=201,
+        json={},
+    )
+
     post_to_step(
         AddGoodFirearmSteps.CATEGORY,
         {"category": ["NON_AUTOMATIC_SHOTGUN"]},
@@ -610,8 +619,17 @@ def test_add_good_firearm_with_rfd_document_submission(
     }
 
     assert post_good_document_matcher.called_once
-    doc_request = post_good_document_matcher.last_request
-    assert doc_request.json() == [{"name": "data sheet", "s3_key": "data sheet", "size": 0, "description": ""}]
+    good_doc_request = post_good_document_matcher.last_request
+    assert good_doc_request.json() == [{"name": "data sheet", "s3_key": "data sheet", "size": 0, "description": ""}]
+
+    assert post_applications_document_matcher.called_once
+    application_doc_request = post_applications_document_matcher.last_request
+    assert application_doc_request.json() == {
+        "name": "rfd_certificate.txt",
+        "s3_key": "rfd_certificate.txt.s3_key",
+        "safe": True,
+        "size": 3,
+    }
 
 
 def test_add_good_firearm_without_rfd_document_submission_registered_firearms_dealer(
@@ -1245,8 +1263,14 @@ def test_add_good_firearm_with_rfd_document_submission_section_5(
         },
     )
 
-    post_application_document_matcher = requests_mock.post(
+    post_application_goods_document_matcher = requests_mock.post(
         f"/applications/{data_standard_case['case']['id']}/goods/{good_id}/documents/",
+        status_code=201,
+        json={},
+    )
+
+    post_applications_document_matcher = requests_mock.post(
+        f"/applications/{data_standard_case['case']['id']}/documents/",
         status_code=201,
         json={},
     )
@@ -1330,8 +1354,8 @@ def test_add_good_firearm_with_rfd_document_submission_section_5(
         "no_document_comments": "product not manufactured yet",
     }
 
-    assert post_application_document_matcher.called_once
-    last_request = post_application_document_matcher.last_request
+    assert post_application_goods_document_matcher.called_once
+    last_request = post_application_goods_document_matcher.last_request
     assert last_request.json() == {
         "document_on_organisation": {
             "document_type": "section-five-certificate",
@@ -1341,6 +1365,15 @@ def test_add_good_firearm_with_rfd_document_submission_section_5(
         "name": "letter_of_authority.pdf",
         "s3_key": "letter_of_authority.pdf",
         "size": 0,
+    }
+
+    assert post_applications_document_matcher.called_once
+    application_doc_request = post_applications_document_matcher.last_request
+    assert application_doc_request.json() == {
+        "name": "rfd_certificate.txt",
+        "s3_key": "rfd_certificate.txt.s3_key",
+        "safe": True,
+        "size": 3,
     }
 
 
@@ -1367,6 +1400,12 @@ def test_add_good_firearm_with_rfd_document_submission_section_5_with_current_se
                 "id": good_id,
             },
         },
+    )
+
+    post_applications_document_matcher = requests_mock.post(
+        f"/applications/{data_standard_case['case']['id']}/documents/",
+        status_code=201,
+        json={},
     )
 
     post_to_step(
@@ -1434,6 +1473,15 @@ def test_add_good_firearm_with_rfd_document_submission_section_5_with_current_se
         "item_category": "group2_firearms",
         "is_document_available": False,
         "no_document_comments": "product not manufactured yet",
+    }
+
+    assert post_applications_document_matcher.called_once
+    application_doc_request = post_applications_document_matcher.last_request
+    assert application_doc_request.json() == {
+        "name": "rfd_certificate.txt",
+        "s3_key": "rfd_certificate.txt.s3_key",
+        "safe": True,
+        "size": 3,
     }
 
 


### PR DESCRIPTION
This updates the flow for when the exporter is asked to add and/or validate their RFD certificate.

In particular this is to handle the following:
  - When an exporter marks their firearm certificate as invalid we remove it from the organisation
  - When an exporter marks their firearm certificate as valid we also attach it as a supporting document
  - When an exporter adds a new firearm certificate we add it to the organisation and attach it as a supporting document
  - The system attached firearm certificate is not able to be deleted by the user