### PR TITLE
Add view to support editing of product document

### DIFF
--- a/exporter/applications/urls.py
+++ b/exporter/applications/urls.py
@@ -47,6 +47,7 @@ from exporter.applications.views.goods.add_good_firearm import (
     FirearmEditPvGrading,
     FirearmEditProductDocumentView,
     FirearmEditProductDocumentSensitivity,
+    FirearmEditProductDocumentAvailability,
 )
 
 app_name = "applications"
@@ -110,6 +111,11 @@ urlpatterns = [
         "<uuid:pk>/goods/<uuid:good_pk>/firearm/edit/pv-grading/",
         FirearmEditPvGrading.as_view(),
         name="firearm_edit_pv_grading",
+    ),
+    path(
+        "<uuid:pk>/goods/<uuid:good_pk>/firearm/edit/product-document-availability/",
+        FirearmEditProductDocumentAvailability.as_view(),
+        name="firearm_edit_product_document_availability",
     ),
     path(
         "<uuid:pk>/goods/<uuid:good_pk>/firearm/edit/product-document-sensitivity/",

--- a/exporter/applications/urls.py
+++ b/exporter/applications/urls.py
@@ -46,6 +46,7 @@ from exporter.applications.views.goods.add_good_firearm import (
     FirearmEditReplica,
     FirearmEditPvGrading,
     FirearmEditProductDocumentView,
+    FirearmEditProductDocumentSensitivity,
 )
 
 app_name = "applications"
@@ -109,6 +110,11 @@ urlpatterns = [
         "<uuid:pk>/goods/<uuid:good_pk>/firearm/edit/pv-grading/",
         FirearmEditPvGrading.as_view(),
         name="firearm_edit_pv_grading",
+    ),
+    path(
+        "<uuid:pk>/goods/<uuid:good_pk>/firearm/edit/product-document-sensitivity/",
+        FirearmEditProductDocumentSensitivity.as_view(),
+        name="firearm_edit_product_document_sensitivity",
     ),
     path(
         "<uuid:pk>/goods/<uuid:good_pk>/firearm/edit/product-document/",

--- a/exporter/applications/urls.py
+++ b/exporter/applications/urls.py
@@ -45,6 +45,7 @@ from exporter.applications.views.goods.add_good_firearm import (
     FirearmProductSummary,
     FirearmEditReplica,
     FirearmEditPvGrading,
+    FirearmEditProductDocumentView,
 )
 
 app_name = "applications"
@@ -108,6 +109,11 @@ urlpatterns = [
         "<uuid:pk>/goods/<uuid:good_pk>/firearm/edit/pv-grading/",
         FirearmEditPvGrading.as_view(),
         name="firearm_edit_pv_grading",
+    ),
+    path(
+        "<uuid:pk>/goods/<uuid:good_pk>/firearm/edit/product-document/",
+        FirearmEditProductDocumentView.as_view(),
+        name="firearm_edit_product_document",
     ),
     path(
         "<uuid:pk>/goods/<uuid:good_pk>/edit-software-technology/",

--- a/exporter/applications/views/goods/add_good_firearm.py
+++ b/exporter/applications/views/goods/add_good_firearm.py
@@ -54,6 +54,7 @@ from exporter.goods.forms.firearms import (
     FirearmSection5Form,
 )
 from exporter.goods.services import (
+    edit_good,
     post_firearm,
     post_good_documents,
     delete_good_document,
@@ -945,8 +946,201 @@ class FirearmEditProductDocumentView(BaseGoodEditView):
                 raise ServiceError(
                     status_code,
                     api_resp_data,
-                    "Error deleting the product document - response was: %s - %s",
-                    "Unexpected error deleting product document",
+                    "Error updating the product document description - response was: %s - %s",
+                    "Unexpected error updating product document description",
                 )
+
+        return redirect(self.get_success_url())
+
+
+class FirearmEditProductDocumentSensitivity(LoginRequiredMixin, BaseSessionWizardView):
+    form_list = [
+        (AddGoodFirearmSteps.PRODUCT_DOCUMENT_SENSITIVITY, FirearmDocumentSensitivityForm),
+        (AddGoodFirearmSteps.PRODUCT_DOCUMENT_UPLOAD, FirearmDocumentUploadForm),
+    ]
+
+    condition_dict = {
+        AddGoodFirearmSteps.PRODUCT_DOCUMENT_UPLOAD: C(is_product_document_available) & ~C(is_document_sensitive),
+    }
+
+    payload_dict = {
+        AddGoodFirearmSteps.PRODUCT_DOCUMENT_SENSITIVITY: get_cleaned_data,
+    }
+
+    @cached_property
+    def application_id(self):
+        return str(self.kwargs["pk"])
+
+    @cached_property
+    def good_id(self):
+        return str(self.kwargs["good_pk"])
+
+    @cached_property
+    def good(self):
+        try:
+            good = get_good(self.request, self.good_id, full_detail=True)[0]
+        except requests.exceptions.HTTPError:
+            raise Http404
+
+        return good
+
+    def dispatch(self, request, *args, **kwargs):
+        if not settings.FEATURE_FLAG_PRODUCT_2_0:
+            raise Http404
+
+        return super().dispatch(request, *args, **kwargs)
+
+    @cached_property
+    def product_document(self):
+        is_document_available = self.good["is_document_available"]
+        is_document_sensitive = self.good["is_document_sensitive"]
+        if not is_document_available or is_document_sensitive:
+            return None
+
+        if not self.good["documents"]:
+            return None
+
+        # when creating new product we can only add one document but we save it as
+        # a list because from the product detail page user can add multiple documents
+        return self.good["documents"][0]
+
+    def get_form_kwargs(self, step=None):
+        kwargs = super().get_form_kwargs(step)
+
+        if step == AddGoodFirearmSteps.PRODUCT_DOCUMENT_UPLOAD:
+            kwargs["good_id"] = self.good_id
+            kwargs["document"] = self.product_document
+
+        return kwargs
+
+    def get_context_data(self, form, **kwargs):
+        ctx = super().get_context_data(form, **kwargs)
+
+        ctx["hide_step_count"] = True
+        ctx["back_link_url"] = reverse("applications:product_summary", kwargs=self.kwargs)
+        ctx["title"] = form.Layout.TITLE
+        return ctx
+
+    def get_form_initial(self, step):
+        return {
+            "is_document_available": self.good["is_document_available"],
+            "is_document_sensitive": self.good["is_document_sensitive"],
+            "description": self.product_document["description"] if self.product_document else "",
+        }
+
+    def get_cleaned_data_for_step(self, step):
+        cleaned_data = super().get_cleaned_data_for_step(step)
+        return {**cleaned_data, "is_document_available": True}
+
+    def get_success_url(self):
+        return reverse("applications:product_summary", kwargs=self.kwargs)
+
+    def existing_product_document(self):
+        return self.product_document
+
+    def has_updated_product_documentation(self):
+        data = self.get_cleaned_data_for_step(AddGoodFirearmSteps.PRODUCT_DOCUMENT_UPLOAD)
+        return data.get("product_document", None)
+
+    def get_product_document_payload(self):
+        data = self.get_cleaned_data_for_step(AddGoodFirearmSteps.PRODUCT_DOCUMENT_UPLOAD)
+        document = data["product_document"]
+        payload = {
+            **get_document_data(document),
+            "description": data["description"],
+        }
+        return payload
+
+    def get_payload(self, form_dict):
+        payload = {}
+        for step_name, payload_func in self.payload_dict.items():
+            form = form_dict.get(step_name)
+            if form:
+                always_merger.merge(payload, payload_func(form))
+
+        return payload
+
+    def post_product_documentation(self, good_pk):
+        document_payload = self.get_product_document_payload()
+        api_resp_data, status_code = post_good_documents(
+            request=self.request,
+            pk=good_pk,
+            json=document_payload,
+        )
+        if status_code != HTTPStatus.CREATED:
+            raise ServiceError(
+                status_code,
+                api_resp_data,
+                "Error product document when creating firearm - response was: %s - %s",
+                "Unexpected error adding document to firearm",
+            )
+
+    def delete_product_documentation(self, good_pk, document_pk):
+        api_resp_data, status_code = delete_good_document(self.request, good_pk, document_pk)
+        if status_code != HTTPStatus.OK:
+            raise ServiceError(
+                status_code,
+                api_resp_data,
+                "Error deleting the product document - response was: %s - %s",
+                "Unexpected error deleting product document",
+            )
+
+    def update_product_document_data(self, good_pk, document_pk, payload):
+        api_resp_data, status_code = update_good_document_data(self.request, good_pk, document_pk, payload)
+        if status_code != HTTPStatus.OK:
+            raise ServiceError(
+                status_code,
+                api_resp_data,
+                "Error updating the product document description - response was: %s - %s",
+                "Unexpected error updating product document description",
+            )
+
+    def edit_firearm(self, good_pk, form_dict):
+        payload = self.get_payload(form_dict)
+        api_resp_data, status_code = edit_firearm(
+            self.request,
+            good_pk,
+            payload,
+        )
+        if status_code != HTTPStatus.OK:
+            raise ServiceError(
+                status_code,
+                api_resp_data,
+                "Error updating firearm - response was: %s - %s",
+                "Unexpected error updating firearm",
+            )
+
+    def handle_service_error(self, service_error):
+        logger.error(
+            service_error.log_message,
+            service_error.status_code,
+            service_error.response,
+            exc_info=True,
+        )
+        return error_page(self.request, service_error.user_message)
+
+    def done(self, form_list, form_dict, **kwargs):
+        all_data = {k: v for form in form_list for k, v in form.cleaned_data.items()}
+        is_document_sensitive = all_data.pop("is_document_sensitive", None)
+
+        try:
+            self.edit_firearm(self.good_id, form_dict)
+
+            existing_product_document = self.product_document
+            if is_document_sensitive:
+                if existing_product_document:
+                    self.delete_product_documentation(self.good_id, existing_product_document["id"])
+            else:
+                description = all_data.pop("description", "")
+                if self.has_updated_product_documentation():
+                    self.post_product_documentation(self.good_id)
+                    if existing_product_document:
+                        self.delete_product_documentation(self.good_id, existing_product_document["id"])
+                elif existing_product_document and existing_product_document["description"] != description:
+                    payload = {"description": description}
+                    self.update_product_document_data(self.good_id, existing_product_document["id"], payload)
+
+        except ServiceError as e:
+            return self.handle_service_error(e)
 
         return redirect(self.get_success_url())

--- a/exporter/core/templates/goods/forms/firearms/product_document_download_link.html
+++ b/exporter/core/templates/goods/forms/firearms/product_document_download_link.html
@@ -1,1 +1,5 @@
-<a class="govuk-link" href="{{ url }}">{{ name }}</a>
+{% if safe %}
+    <a class="govuk-link" href="{{ url }}">{{ name }}</a>
+{% else %}
+    {{ name }}
+{% endif %}

--- a/exporter/core/templates/goods/forms/firearms/product_document_download_link.html
+++ b/exporter/core/templates/goods/forms/firearms/product_document_download_link.html
@@ -1,0 +1,1 @@
+<a class="govuk-link" href="{{ url }}">{{ name }}</a>

--- a/exporter/goods/forms/firearms.py
+++ b/exporter/goods/forms/firearms.py
@@ -582,9 +582,8 @@ class FirearmDocumentUploadForm(BaseFirearmForm):
         required=False,
     )
 
-    def __init__(self, *args, **kwargs):
-        good_id = kwargs.pop("good_id", None)
-        self.document = kwargs.pop("document", None)
+    def __init__(self, *args, good_id=None, document=None, **kwargs):
+        self.document = document
         if self.document:
             self.product_document_download_url = reverse(
                 "goods:document",
@@ -606,6 +605,7 @@ class FirearmDocumentUploadForm(BaseFirearmForm):
                     render_to_string(
                         "goods/forms/firearms/product_document_download_link.html",
                         {
+                            "safe": self.document.get("safe", False),
                             "url": self.product_document_download_url,
                             "name": self.document_name,
                         },

--- a/exporter/goods/forms/firearms.py
+++ b/exporter/goods/forms/firearms.py
@@ -579,11 +579,38 @@ class FirearmDocumentUploadForm(BaseFirearmForm):
         required=False,
     )
 
+    def __init__(self, *args, **kwargs):
+        good_id = kwargs.pop("good_id", None)
+        self.document = kwargs.pop("document", None)
+        if self.document:
+            self.product_document_download_url = reverse(
+                "goods:document",
+                kwargs={
+                    "pk": good_id,
+                    "file_pk": self.document["id"],
+                },
+            )
+            self.document_name = self.document["name"]
+
+        super().__init__(*args, **kwargs)
+
     def get_layout_fields(self):
-        return (
-            "product_document",
-            "description",
-        )
+        layout_fields = ("product_document", "description")
+        if self.document:
+            self.fields["product_document"].required = False
+            layout_fields = (
+                HTML.p(
+                    render_to_string(
+                        "goods/forms/firearms/product_document_download_link.html",
+                        {
+                            "url": self.product_document_download_url,
+                            "name": self.document_name,
+                        },
+                    ),
+                ),
+            ) + layout_fields
+
+        return layout_fields
 
 
 class FirearmFirearmAct1968Form(BaseFirearmForm):

--- a/exporter/goods/forms/firearms.py
+++ b/exporter/goods/forms/firearms.py
@@ -529,6 +529,9 @@ class FirearmDocumentAvailability(BaseFirearmForm):
                 "Enter a reason why you cannot upload a product document",
             )
 
+        if cleaned_data.get("is_document_available") is True:
+            cleaned_data["no_document_comments"] = ""
+
         return cleaned_data
 
 

--- a/exporter/goods/services.py
+++ b/exporter/goods/services.py
@@ -257,6 +257,11 @@ def delete_good_document(request, pk, doc_pk):
     return data.json(), data.status_code
 
 
+def update_good_document_data(request, pk, doc_pk, data):
+    response = client.put(request, f"/goods/{pk}/documents/{doc_pk}/", data)
+    response.raise_for_status()
+    return response.json(), response.status_code
+
 # Document Sensitivity
 def get_document_missing_reasons(request):
     data = client.get(request, "/static/missing-document-reasons/")

--- a/exporter/goods/services.py
+++ b/exporter/goods/services.py
@@ -262,6 +262,7 @@ def update_good_document_data(request, pk, doc_pk, data):
     response.raise_for_status()
     return response.json(), response.status_code
 
+
 # Document Sensitivity
 def get_document_missing_reasons(request):
     data = client.get(request, "/static/missing-document-reasons/")

--- a/exporter/templates/applications/goods/firearms/product-summary.html
+++ b/exporter/templates/applications/goods/firearms/product-summary.html
@@ -227,6 +227,7 @@
                     {{ good.is_document_available|yesno|title }}
                 </dd>
                 <dd class="govuk-summary-list__actions">
+                    <a class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:firearm_edit_product_document_availability' application_id good.id %}">Change</a>
                 </dd>
             </div>
             {% if good.is_document_available %}

--- a/exporter/templates/applications/goods/firearms/product-summary.html
+++ b/exporter/templates/applications/goods/firearms/product-summary.html
@@ -238,6 +238,7 @@
                         {{ good.is_document_sensitive|yesno|title }}
                     </dd>
                     <dd class="govuk-summary-list__actions">
+                        <a class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:firearm_edit_product_document_sensitivity' application_id good.id %}">Change</a>
                     </dd>
                 </div>
                 {% if not good.is_document_sensitive %}

--- a/exporter/templates/applications/goods/firearms/product-summary.html
+++ b/exporter/templates/applications/goods/firearms/product-summary.html
@@ -257,8 +257,9 @@
                             {% endfor %}
                         </dd>
                         <dd class="govuk-summary-list__actions">
+                            <a class="govuk-link govuk-link--no-visited-state" href="{% url 'applications:firearm_edit_product_document' application_id good.id %}">Change</a>
                         </dd>
-                        </div>
+                    </div>
                 {% endif %}
             {% endif %}
         </dl>

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -567,10 +567,19 @@ def data_standard_case():
                             "is_good_controlled": {"key": "True", "value": "Yes"},
                             "report_summary": "scale compelling technologies",
                             "flags": [],
-                            "documents": [],
                             "is_pv_graded": None,
+                            "documents": [
+                                {
+                                    "id": "6c48a2cc-1ed9-49a5-8ca7-df8af5fc2335",
+                                    "name": "data_sheet.pdf",
+                                    "description": "product data sheet",
+                                }
+                            ],
                             "grading_comment": None,
                             "pv_grading_details": None,
+                            "is_document_available": True,
+                            "no_document_comments": "",
+                            "is_document_sensitive": False,
                             "status": {"key": "verified", "value": "Verified"},
                             "item_category": {"key": "group1_device", "value": "Device, equipment or object"},
                             "is_military_use": {"key": "no", "value": "No"},

--- a/unit_tests/exporter/applications/views/conftest.py
+++ b/unit_tests/exporter/applications/views/conftest.py
@@ -3,6 +3,13 @@ from core import client
 
 
 @pytest.fixture
+def mock_application_get(requests_mock, data_standard_case):
+    application = data_standard_case["case"]["data"]
+    url = client._build_absolute_uri(f'/applications/{application["id"]}/')
+    yield requests_mock.get(url=url, json={})
+
+
+@pytest.fixture
 def mock_good_get(requests_mock, data_standard_case):
     good = data_standard_case["case"]["data"]["goods"][0]
     good["good"]["is_pv_graded"] = {"key": "no", "value": "No"}

--- a/unit_tests/exporter/applications/views/conftest.py
+++ b/unit_tests/exporter/applications/views/conftest.py
@@ -29,3 +29,26 @@ def pv_gradings(requests_mock):
         "/static/private-venture-gradings/v2/",
         json={"pv_gradings": [{"official": "Official"}, {"restricted": "Restricted"}]},
     )
+
+
+@pytest.fixture
+def mock_good_document_post(requests_mock, data_standard_case):
+    good = data_standard_case["case"]["data"]["goods"][0]["good"]
+    url = client._build_absolute_uri(f'/goods/{good["id"]}/documents/')
+    yield requests_mock.post(url=url, json={}, status_code=201)
+
+
+@pytest.fixture
+def mock_good_document_put(requests_mock, data_standard_case):
+    good = data_standard_case["case"]["data"]["goods"][0]["good"]
+    document_pk = good["documents"][0]["id"]
+    url = client._build_absolute_uri(f'/goods/{good["id"]}/documents/{document_pk}/')
+    yield requests_mock.put(url=url, json={})
+
+
+@pytest.fixture
+def mock_good_document_delete(requests_mock, data_standard_case):
+    good = data_standard_case["case"]["data"]["goods"][0]["good"]
+    document_pk = good["documents"][0]["id"]
+    url = client._build_absolute_uri(f'/goods/{good["id"]}/documents/{document_pk}/')
+    yield requests_mock.delete(url=url, json={})

--- a/unit_tests/exporter/applications/views/test_edit_firearm.py
+++ b/unit_tests/exporter/applications/views/test_edit_firearm.py
@@ -2,17 +2,15 @@ import pytest
 
 from django.core.files.storage import Storage
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import override_settings
 from django.urls import reverse
 from unittest.mock import patch
-
-from exporter.applications.views.goods.add_good_firearm import AddGoodFirearmSteps
 
 from exporter.applications.views.goods.add_good_firearm import AddGoodFirearmSteps
 
 
 @pytest.fixture(autouse=True)
 def setup(
+    mock_application_get,
     mock_good_get,
     mock_good_put,
     mock_control_list_entries_get,
@@ -33,7 +31,7 @@ def setup(
         def delete(self, name):
             pass
 
-    with override_settings(FEATURE_FLAG_ONLY_ALLOW_FIREARMS_PRODUCTS=False), patch(
+    with patch(
         "exporter.applications.views.goods.add_good_firearm.FirearmEditProductDocumentSensitivity.file_storage",
         new=NoOpStorage(),
     ), patch(


### PR DESCRIPTION
## Change description

Add view to edit product document options i.e., 1. editing product document, 2. editing document sensitivity option, 3. editing document availability option.
The questions 2 and 3 trigger subsequent questions so they are implemented as separate mini-wizards.
The common bits are refactored into a Document specific class and also generic wizard common bits are moved to another class with the idea being this serves as common base for the remaining wizards.

Add unit tests to cover various combinations,
 - uploading new document deletes existing one
 - marking document as sensitive deletes any existing document
 - marking document not available deletes any existing document
 - marking document available but sensitive deletes any existing document