### PR TITLE
[LTD-2170] Regimes

### DIFF
--- a/caseworker/tau/forms.py
+++ b/caseworker/tau/forms.py
@@ -27,6 +27,11 @@ class TAUEditForm(forms.Form):
         required=False,
     )
 
+    is_wassenaar = forms.BooleanField(
+        label="This product falls under the WASSENAAR regime",
+        required=False,
+    )
+
     report_summary = forms.CharField(
         label="Select an annual report summary",
         help_text="Type to get suggestions. For example, components for body armour.",
@@ -47,6 +52,7 @@ class TAUEditForm(forms.Form):
         self.helper.layout = Layout(
             "control_list_entries",
             "does_not_have_control_list_entries",
+            "is_wassenaar",
             "report_summary",
             "comment",
             Submit("submit", "Submit"),

--- a/caseworker/tau/templates/tau/home.html
+++ b/caseworker/tau/templates/tau/home.html
@@ -70,7 +70,7 @@
                         {% for good in assessed_goods %}
                         <tr class="govuk-table__row">
                             <td class="govuk-table__cell">{{ forloop.counter }}</td>
-                            <td class="govuk-table__cell">{{ good.name }}</td>
+                            <td class="govuk-table__cell">{{ good.good.name }}</td>
                             <td class="govuk-table__cell">{{ good.quantity|floatformat }}</td>
                             <td class="govuk-table__cell">{{ good | get_clc | join:',' }}</td>
                             <td class="govuk-table__cell">{{ good.is_good_controlled.value }}</td>

--- a/caseworker/tau/views.py
+++ b/caseworker/tau/views.py
@@ -114,7 +114,8 @@ class TAUEdit(LoginRequiredMixin, TAUMixin, FormView):
         form_kwargs["data"] = self.request.POST or {
             "control_list_entries": [cle["rating"] for cle in good["control_list_entries"]],
             "does_not_have_control_list_entries": good["control_list_entries"] == [],
-            "report_summary": good["good"]["report_summary"],
+            "is_wassenaar": "WASSENAAR" in {flag["name"] for flag in good["flags"]},
+            "report_summary": good["report_summary"],
             "comment": good["comment"],
         }
         return form_kwargs

--- a/unit_tests/caseworker/tau/test_edit.py
+++ b/unit_tests/caseworker/tau/test_edit.py
@@ -80,4 +80,5 @@ def test_form(authorized_client, url, data_standard_case, requests_mock, mock_co
         "current_object": "6daad1c3-cf97-4aad-b711-d5c9a9f4586e",
         "objects": ["6a7fc61f-698b-46b6-9876-6ac0fddfb1a2"],
         "is_good_controlled": False,
+        "is_wassenaar": False,
     }

--- a/unit_tests/caseworker/tau/test_forms.py
+++ b/unit_tests/caseworker/tau/test_forms.py
@@ -52,6 +52,28 @@ from caseworker.tau import forms
             True,
             [],
         ),
+        # Set is_wassenaar to False
+        (
+            {
+                "report_summary": "test",
+                "does_not_have_control_list_entries": False,
+                "control_list_entries": ["test-rating"],
+                "is_wassenaar": False,
+            },
+            True,
+            [],
+        ),
+        # Set is_wassenaar to False
+        (
+            {
+                "report_summary": "test",
+                "does_not_have_control_list_entries": False,
+                "control_list_entries": ["test-rating"],
+                "is_wassenaar": True,
+            },
+            True,
+            [],
+        ),
     ),
 )
 def test_tau_assessment_form(data, valid, errors):
@@ -97,6 +119,28 @@ def test_tau_assessment_form(data, valid, errors):
                 "report_summary": "test",
                 "does_not_have_control_list_entries": False,
                 "control_list_entries": ["test-rating"],
+            },
+            True,
+            [],
+        ),
+        # Set is_wassenaar to False
+        (
+            {
+                "report_summary": "test",
+                "does_not_have_control_list_entries": False,
+                "control_list_entries": ["test-rating"],
+                "is_wassenaar": False,
+            },
+            True,
+            [],
+        ),
+        # Set is_wassenaar to True
+        (
+            {
+                "report_summary": "test",
+                "does_not_have_control_list_entries": False,
+                "control_list_entries": ["test-rating"],
+                "is_wassenaar": True,
             },
             True,
             [],

--- a/unit_tests/caseworker/tau/test_home.py
+++ b/unit_tests/caseworker/tau/test_home.py
@@ -103,7 +103,7 @@ def test_home_content(authorized_client, url, data_queue, data_standard_case, mo
     assert soup.find(id="subtitle").text == "Assess 1 product(s) going from Great Britain to Abu Dhabi, United Kingdom"
     assert get_cells(soup, "assessed-products") == [
         "1",
-        "",
+        "p2",
         "444",
         "",
         "No",
@@ -158,6 +158,7 @@ def test_form(authorized_client, url, data_standard_case, requests_mock, mock_co
         "current_object": "0bedd1c3-cf97-4aad-b711-d5c9a9f4586e",
         "objects": ["8b730c06-ab4e-401c-aeb0-32b3c92e912c"],
         "is_good_controlled": False,
+        "is_wassenaar": False,
     }
 
 


### PR DESCRIPTION
Adds the `is_wassenaar` field that is chucked to the API which sets the corresponding flag. 

It is a boolean field for now but as we introduce more regimes, it may end up becoming a `MultipleChoiceField`. Didn't want to jump the gun though so keeping it simple for now.

P.S. Also fixed a small bug in the first commit.