### PR TITLE
LTD-2266: Use the correct template for the wizard

### DIFF
--- a/exporter/applications/views/parties/end_users.py
+++ b/exporter/applications/views/parties/end_users.py
@@ -363,6 +363,7 @@ class PartyDocumentOptionEditView(PartyEditView):
 
 
 class PartyUndertakingDocumentEditView(LoginRequiredMixin, PartyContextMixin, BaseSessionWizardView):
+    template_name = "core/form-wizard.html"
     form_list = [
         (SetPartyFormSteps.PARTY_DOCUMENT_UPLOAD, PartyDocumentUploadForm),
         (SetPartyFormSteps.PARTY_ENGLISH_TRANSLATION_UPLOAD, PartyEnglishTranslationDocumentUploadForm),


### PR DESCRIPTION
One of the entry point for this wizard is when user edits the End-user
document availability option. That form is a single template view so it
uses a different template_name and the same is being used in the wizard
also which causes management form errors so explicity override again
to use the correct name in this wizard.