### PR TITLE
LTD-2274: Allow for env specific HAWK keys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,8 @@ common_env_vars: &common_env_vars
   ENVIRONMENT: << pipeline.parameters.environment >>
   LITE_API_URL: https://lite-api-<< pipeline.parameters.environment >>.london.cloudapps.digital/
   PIPENV_VENV_IN_PROJECT: true
+  LITE_INTERNAL_HAWK_KEY: $LITE_INTERNAL_HAWK_KEY_<< pipeline.parameters.environment >>
+  LITE_EXPORTER_HAWK_KEY: $LITE_EXPORTER_HAWK_KEY_<< pipeline.parameters.environment >>
 
 ###############################################################################
 # Images

--- a/ui_tests/caseworker/step_defs/test_enforcement.py
+++ b/ui_tests/caseworker/step_defs/test_enforcement.py
@@ -128,7 +128,7 @@ def i_attach_updated_file(driver):  # noqa
     file_input = driver.find_element(by=By.NAME, value="file")
     file_input.clear()
     file_input.send_keys("/tmp/enforcement_check_import.xml")
-    upload_btn = driver.find_element(by=By.CLASS_NAME, value="govuk-button")
+    upload_btn = driver.find_element(by=By.XPATH, value="//button[@type='submit']")
     upload_btn.click()
 
     banner = driver.find_element(by=By.CLASS_NAME, value="app-snackbar__content")


### PR DESCRIPTION
HAWK keys are environment specific so this PR enables the lookup of keys with an environment suffix in the format:
```
LITE_INTERNAL_HAWK_KEY_env
LITE_EXPORTER_HAWK_KEY_env
```
where `env` is substituted with the real environment name, e.g. `devdata`.

This is necessary so that the UI tests running in Circle can use the appropriate HAWK key for the environment being tested.