### PR TITLE
LTD-2201: Add UI test for adding serial numbers later

### DIFF
--- a/ui_tests/exporter/conftest.py
+++ b/ui_tests/exporter/conftest.py
@@ -834,6 +834,11 @@ def specify_serial_numbers_available(driver):  # noqa
     specify_serial_number_of_other_identification_details(driver, has_markings="AVAILABLE", details=None)
 
 
+@when("I choose to add serial numbers later")
+def specify_serial_numbers_later(driver):  # noqa
+    specify_serial_number_of_other_identification_details(driver, has_markings="LATER", details=None)
+
+
 @when(parsers.parse('I enter "{number_of_items}" for number of items'))
 def specify_number_of_items(driver, number_of_items):  # noqa
     good_details_page = AddGoodDetails(driver)

--- a/ui_tests/exporter/features/submit_standard_application.feature
+++ b/ui_tests/exporter/features/submit_standard_application.feature
@@ -85,6 +85,103 @@ Feature: I want to indicate the standard licence I want
     When I click continue
     And I agree to the declaration
     Then application is submitted
+    When I go to exporter homepage
+
+
+  @serial_numbers_later
+  Scenario: Submit standard application when serial numbers are not available
+    Given I signin and go to exporter homepage and choose Test Org
+    When I click apply
+    And I select export licence
+    And I select SIEL
+    And I enter "application1" as name
+    And I select "no" to receiving a letter
+    And I click on "Tell us about the products"
+    And I click on "Add a new product"
+    And I select product type "Firearm"
+    And I enter "4" for number of items
+    And I choose to add serial numbers later
+    And I enter "name" as name, "ML1a" for control list, and "no it doesn’t need one" for security grading
+    And I enter "2015" as the year of manufacture
+    And I select "no" to a replica firearm
+    And I enter ".22" as the calibre
+    And I select "no" to registered firearms dealer
+    And I select "I don't know" to section 1 of the firearms act
+    And I click on "Continue"
+    And I select no to product document and enter "reason"
+    And I enter "20" as value, "no" for incorporation, "no" for deactivation, and "yes" for proof marks
+    And I click on "Back to application overview"
+    And I click on "End use details"
+    And I enter "end use details" for the intended end use
+    And I select "no" to informed by ECJU to apply
+    And I select "no" to informed by ECJU about WMD use
+    And I select "no" to suspected WMD use
+    And I select "no" to products received under transfer licence from the EU
+    And I click save and continue
+    And I click on "Provide product location and journey"
+    And I select "Great Britain" to where products begin export journey
+    And I select "yes" to permanently exported
+    And I select "yes" to shipping air waybill or lading
+    And I select "directly to the end-user" to who products are going
+    And I click on "Submit"
+    And I click on "End user"
+    And I select "no" to reusing an existing party
+    And I select "commercial organisation" as the type of end user
+    And I enter the "Joe Bloggs" as end user name
+    And I click continue
+    And I enter "123 Main Street" and "France" for end user address
+    And I enter "Joe Bloggs" for signatory name
+    And I select no and enter "reason" for end user document
+    And I click on "Submit"
+    And I submit the application
+    Then my answers are played back to me
+    And I see "Standard Individual Export Licence" as the Licence
+    And I see "Standard Licence" as the type
+    And I see "application1" as reference name
+    And I see "No" as informed to apply
+    And I see "Great Britain" as product journey origin
+    And I see "Yes" as product permanently exported
+    And I see "Yes" as way bill
+    And I see "Direct to end user" as who are the products going to
+    And I see "name" as name
+    And I see "N/A" as part number
+    And I see "Yes" as controlled
+    And I see "ML1a" as control list entry
+    And I see "No" as incorporated
+    And I see "4 items" as quantity
+    And I see "£20.00" as value
+    And I see "end use details" as intended end use
+    And I see "No" for informed to apply
+    And I see "No" for informed WMD
+    And I see "No" for suspect WMD
+    And I see "No" for EU transfer
+    And I see "Joe Bloggs" for end user name
+    And I see "Commercial Organisation" for type
+    And I see "123 Main Street, France" as address
+    And I see "N/A" as website
+    And I see "Joe Bloggs" as signatory
+    And I see "No, I do not have an end-user undertaking or stockist undertaking" for end user document
+    And I see "reason" for the explanation
+    And I see "No information added to this section." for "Consignee"
+    And I see "No information added to this section." for "Third parties"
+    And I see "No information added to this section." for "Supporting documents"
+    And I see "No information added to this section." for Notes
+    When I click continue
+    And I agree to the declaration
+    Then application is submitted
+    When I go to exporter homepage
+    Then I see a banner reminding me to add serial numbers
+    When I click on "Add serial number"
+    And I click on "Add serial numbers"
+    And I input "1234" as serial numbers for items "1,2,3" and press submit
+    When I go to exporter homepage
+    Then I see a banner reminding me to add serial numbers
+    When I click on "Add serial number"
+    And I click on "Add serial numbers"
+    Then I see serial numbers for items "1,2,3" as "1234"
+    When I input "1234" as serial numbers for items "4" and press submit
+    And I go to exporter homepage
+    Then I don't see a banner reminding me to add serial numbers
 
 
   @skip @legacy


### PR DESCRIPTION
## Change description
Add UI test that verifies the functionality of adding serial numbers later.
Application is initially submitted without adding serial numbers then user is prompted to add them using a banner.
The test checks for the presence of banner and after all serial numbers are provided then it checks that banner is no longer shown.