### PR TITLE
[LTD-2175] Links to documents

### DIFF
--- a/caseworker/tau/templates/tau/firearms_table.html
+++ b/caseworker/tau/templates/tau/firearms_table.html
@@ -78,7 +78,7 @@
       </tr>
       <tr class="govuk-table__row">
         <td class="govuk-table__header">Upload your section 5 letter of authority</td>
-        <td class="govuk-table__cell">{{ organisation_documents.section_5_certificate.document.name }}</td>
+        <td class="govuk-table__cell"><a target="_blank" href="{{ organisation_documents.section_5_certificate.url }}" class="govuk-link--no-visited-state">{{ organisation_documents.section_5_certificate.document.name }}</a></td>
       </tr>
       <tr class="govuk-table__row">
         <td class="govuk-table__header">Certificate number</td>

--- a/caseworker/tau/templates/tau/firearms_table.html
+++ b/caseworker/tau/templates/tau/firearms_table.html
@@ -7,7 +7,7 @@
         <td class="govuk-table__header">Product document</td>
         <td class="govuk-table__cell">
           {% for document in good.good.documents %}
-          {{ document.name }}
+          <a target="_blank" href="{{ document.url }}" class="govuk-link--no-visited-state">{{ document.name }}</a>
           {% endfor %}
         </td>
       </tr>

--- a/caseworker/tau/views.py
+++ b/caseworker/tau/views.py
@@ -50,9 +50,15 @@ class TAUMixin:
         goods = []
         precedents = get_recent_precedent(self.request, self.case)
         for item in self.case.goods:
+            # Populate precedents
             if precedents[item["id"]]:
                 precedents[item["id"]]["queue"] = precedents[item["id"]]["queue"] or ALL_CASES_QUEUE_ID
             item["precedent"] = precedents[item["id"]]
+            # Populate docuement urls
+            for document in item["good"]["documents"]:
+                document["url"] = reverse(
+                    "cases:document", kwargs={"queue_pk": self.queue_id, "pk": self.case.id, "file_pk": document["id"]}
+                )
             goods.append(item)
         return goods
 

--- a/caseworker/tau/views.py
+++ b/caseworker/tau/views.py
@@ -36,7 +36,14 @@ class TAUMixin:
     def organisation_documents(self):
         """This property will collect the org documents that we need to access
         in the template e.g. section 5 certificate etc."""
-        return {item["document_type"].replace("-", "_"): item for item in self.case.organisation["documents"]}
+        documents = {}
+        for item in self.case.organisation["documents"]:
+            key = item["document_type"].replace("-", "_")
+            documents[key] = item
+            documents[key]["url"] = reverse(
+                "cases:document", kwargs={"queue_pk": self.queue_id, "pk": self.case.id, "file_pk": item["id"]}
+            )
+        return documents
 
     @cached_property
     def goods(self):


### PR DESCRIPTION
This is meant as a short-term fix to get links to certain documents in TAU2.0.

I think I painted myself in a corner with the `GoodsMultipleSelect` widget - in that it's template doesn't have `queue_pk` and `case_pk` and therefore I cannot do a `{% url "cases:document" queue_pk case_pk document.id %}`.

This alleviated the problem but as Kevin suggested, given that we are not planning on reusing the widget, we should just `{% include good_field.html %}` instead.