### PR TITLE
Skip tests that are affected by firearms 2.0 changes

### DIFF
--- a/ui_tests/conftest.py
+++ b/ui_tests/conftest.py
@@ -1,7 +1,17 @@
 import os
+import pytest
 
 import tests_common.tools.helpers as utils
 
+from environ import Env
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+ENV_FILE = os.path.join(BASE_DIR, ".env")
+if os.path.exists(ENV_FILE):
+    Env.read_env(ENV_FILE)
+
+environ = Env()
 
 STEP_THROUGH = False  # Gives a prompt for every step in the terminal
 STEP_VERBOSE = STEP_THROUGH  # Shows info as a banner for every step
@@ -20,6 +30,16 @@ def pytest_bdd_before_step_call(request, feature, scenario, step, step_func, ste
         import IPython
 
         IPython.embed(using=False)
+
+
+def pytest_bdd_apply_tag(tag, function):
+    if tag == "skip_feature_flag_product_2_0":
+        feature_flag_product_2_0 = environ.bool("FEATURE_FLAG_PRODUCT_2_0", False)
+        if feature_flag_product_2_0:
+            marker = pytest.mark.skip(reason="Feature flag for product 2.0 disabled")
+            marker(function)
+            return True
+    return None
 
 
 def pytest_configure(config):

--- a/ui_tests/exporter/features/submit_standard_application.feature
+++ b/ui_tests/exporter/features/submit_standard_application.feature
@@ -4,6 +4,7 @@ Feature: I want to indicate the standard licence I want
   I want to indicate the kind of licence I want
   So that I am more likely to get the correct kind of licence or the kind of licence I would like
 
+  @skip_feature_flag_product_2_0
   Scenario: Submit standard application
     Given I signin and go to exporter homepage and choose Test Org
     When I click apply
@@ -88,7 +89,7 @@ Feature: I want to indicate the standard licence I want
     When I go to exporter homepage
 
 
-  @serial_numbers_later
+  @serial_numbers_later @skip_feature_flag_product_2_0
   Scenario: Submit standard application when serial numbers are not available
     Given I signin and go to exporter homepage and choose Test Org
     When I click apply


### PR DESCRIPTION
This just skips the tests that will fail for now because trying to write a test that works with the feature switch is going to be too complex

What we will do for now is temporarily skip the test but have a fixed test waiting in the wings, when we first deploy the tests will be skipped but we can then follow up with deploying the fixed test