### PR TITLE
Allow unsafe application documents to be retrieved

### DIFF
--- a/exporter/applications/services.py
+++ b/exporter/applications/services.py
@@ -305,8 +305,12 @@ def delete_additional_document(request, pk, doc_pk):
     return data.status_code
 
 
-def get_application_documents(request, pk, good_pk):
-    response = client.get(request, f"/applications/{pk}/goods/{good_pk}/documents/")
+def get_application_documents(request, pk, good_pk, include_unsafe=False):
+    params = ""
+    if include_unsafe:
+        params = "?include_unsafe=1"
+    url = f"/applications/{pk}/goods/{good_pk}/documents/{params}"
+    response = client.get(request, url)
     response.raise_for_status()
     return response.json(), response.status_code
 

--- a/exporter/applications/views/goods/add_good_firearm/views/summary.py
+++ b/exporter/applications/views/goods/add_good_firearm/views/summary.py
@@ -66,6 +66,7 @@ class BaseProductOnApplicationSummary(
             self.request,
             self.application["id"],
             self.good["id"],
+            include_unsafe=True,
         )
         application_documents = application_documents["documents"]
 


### PR DESCRIPTION
There is a point in time where an uploaded document is being virus scanned asynchronously.

It's highly likely that the user has been presented with a summary screen whilst this asynchronous task is occurring and as such the document won't have been marked safe yet. In this case we still want to display the name of the file even though we can't provide the download link.

This allows us to explicitly retrieve unsafe documents as well as safe ones but makes it an explicit flag to maintain backwards compatibility with anything that was expecting the old behaviour of unsafe documents being already filtered out.