### PR TITLE
[LTD-2369] Add product assessment tab and remove TAU 1.0 links

### DIFF
--- a/caseworker/advice/templates/advice/case-tabs.html
+++ b/caseworker/advice/templates/advice/case-tabs.html
@@ -22,6 +22,9 @@
 			<a id="tab-advice" href="{% url 'cases:case' queue.id case.id 'advice' %}" class="lite-tabs__tab lite-tabs__tab--selected">
 				Recommendations and decision
 			</a>
+			<a id="tab-assessment" href="{% url 'cases:tau:home' queue.id case.id %}" class="lite-tabs__tab">
+				Product Assessment
+			</a>
 		</div>
 	</div>
 </div>

--- a/caseworker/cases/helpers/case.py
+++ b/caseworker/cases/helpers/case.py
@@ -163,3 +163,11 @@ class CaseView(TemplateView):
             get_advice_tab_context(self.case, data["user"], str(self.kwargs["queue_pk"]))["url"],
             has_template=False,
         )
+
+    def get_assessment_tab(self):
+        return Tab(
+            "assessment",
+            "Product Assessment",
+            "cases:tau:home",
+            has_template=False,
+        )

--- a/caseworker/cases/views/main.py
+++ b/caseworker/cases/views/main.py
@@ -158,6 +158,7 @@ class CaseDetail(CaseView):
         self.tabs = self.get_tabs()
         self.tabs.insert(1, Tabs.LICENCES)
         self.tabs.append(self.get_advice_tab())
+        self.tabs.append(self.get_assessment_tab())
         self.slices = [
             Slices.GOODS,
             Slices.DESTINATIONS,

--- a/caseworker/tau/templates/tau/case_tabs.html
+++ b/caseworker/tau/templates/tau/case_tabs.html
@@ -1,0 +1,30 @@
+<div id="tab-bar" class="app-case-tab-bar">
+	<div class="govuk-width-container lite-tabs__container">
+		<div class="lite-tabs ">
+			<a id="tab-details" href="{% url 'cases:case' queue.id case.id 'details' %}" class="lite-tabs__tab">
+				Details
+			</a>
+			<a id="tab-licences" href="{% url 'cases:case' queue.id case.id 'licences' %}" class="lite-tabs__tab ">
+				Licences
+			</a>
+			<a id="tab-additional-contacts" href="{% url 'cases:case' queue.id case.id 'contacts' %}" class="lite-tabs__tab ">
+				Contacts
+			</a>
+			<a id="tab-ecju-queries" href="{% url 'cases:case' queue.id case.id 'ecju-queries' %}" class="lite-tabs__tab ">
+				Queries
+			</a>
+			<a id="tab-documents" href="{% url 'cases:case' queue.id case.id 'documents' %}" class="lite-tabs__tab ">
+				Documents
+			</a>
+			<a id="tab-activity" href="{% url 'cases:case' queue.id case.id 'activity' %}" class="lite-tabs__tab ">
+				Notes and timeline
+			</a>
+			<a id="tab-advice" href="{% url 'cases:case' queue.id case.id 'advice' %}" class="lite-tabs__tab">
+				Recommendations and decision
+			</a>
+			<a id="tab-assessment" href="{% url 'cases:tau:home' queue.id case.id %}" class="lite-tabs__tab lite-tabs__tab--selected">
+				Product Assessment
+			</a>
+		</div>
+	</div>
+</div>

--- a/caseworker/tau/templates/tau/home.html
+++ b/caseworker/tau/templates/tau/home.html
@@ -2,7 +2,11 @@
 
 {% load static custom_tags crispy_forms_tags advice_tags tau_tags %}
 
-{% block body %}
+{% block header_tabs %}
+	{% include "tau/case_tabs.html" with case=case queue=queue %}
+{% endblock %}
+
+{% block full_width %}
 
 <div class="govuk-width-container">
     <main class="govuk-main-wrapper tau">

--- a/caseworker/templates/case/slices/goods.html
+++ b/caseworker/templates/case/slices/goods.html
@@ -6,18 +6,6 @@
 	{% if not hide_controls %}
 		<form method="get">
 			<div class="lite-buttons-row" data-enable-on-checkboxes="#table-goods">
-				{% if 'REVIEW_GOODS' in permissions and not is_terminal %}
-					{% if goods.0.good  %}
-						<button id="button-review-goods" formaction="{% url 'cases:review_standard_application_goods' queue.id case.id %}" class="govuk-button" data-module="govuk-button">
-							Review goods
-						</button>
-					{% else %}
-						<button id="button-review-goods" formaction="{% url 'cases:review_open_application_goods' queue.id case.id %}" class="govuk-button" data-module="govuk-button">
-							Review goods
-						</button>
-					{% endif %}
-
-				{% endif %}
 				<button id="button-edit-goods-flags" formaction="{% url 'cases:assign_flags' queue.id case.id %}" class="govuk-button" data-module="govuk-button">
 					Edit goods flags
 				</button>

--- a/ui_tests/caseworker/features/review_goods.feature
+++ b/ui_tests/caseworker/features/review_goods.feature
@@ -5,7 +5,7 @@ Feature: I want to review, amend where required and confirm the goods ratings an
   So that I can confirm the goods are correctly described
 
 
-  @review_good
+  @skip @review_good
   Scenario: Gov user can review product in an application
     Given I sign in to SSO or am signed into SSO
     And I create an application with <name>,<product>,<part_number>,<clc_rating>,<end_user_name>,<end_user_address>,<consignee_name>,<consignee_address>,<country>,<end_use>


### PR DESCRIPTION
1. Put TAU 2.0 in a tab
2. Remove "Review goods" button (which links to TAU 1.0) on the case details tab
3. Remove checkboxes because they are useless without the "Review goods" button

Update - scratch (3) because we have "Edit goods flags" button as well, I have 2xC with Jess and it seems we need to keep the checkboxes for now.
