### PR TITLE
Make "enter" on keyboard take user to next step instead of previous

### DIFF
--- a/exporter/core/templates/core/form-wizard.html
+++ b/exporter/core/templates/core/form-wizard.html
@@ -20,24 +20,24 @@
             </p>
         </div>
 
+        <section aria-label="banner">
+            {% if wizard.steps.prev %}
+                <form action="" method="post">
+                    {% csrf_token %}
+                    <button name="wizard_goto_step" type="submit" value="{{ wizard.steps.prev }}" class="govuk-back-link">{{ back_link_text|default:"Back" }}</button>
+                </form>
+            {% elif back_link_url %}
+                <a href="{{ back_link_url }}" class="govuk-back-link">{{ back_link_text|default:"Back" }}</a>
+            {% endif %}
+        </section>
+
         <form action="" method="post"{% if form.helper.attrs.enctype %} enctype="{{ form.helper.attrs.enctype }}"{% endif %}>
             {% csrf_token %}
-
-            <section aria-label="banner">
-                {% if wizard.steps.prev %}
-                    <button name="wizard_goto_step" type="submit" value="{{ wizard.steps.prev }}" class="govuk-back-link">{{ back_link_text|default:"Back" }}</button>
-                {% elif back_link_url %}
-                    <a href="{{ back_link_url }}" class="govuk-back-link">{{ back_link_text|default:"Back" }}</a>
-                {% endif %}
-            </section>
-
+            {{ wizard.management_form }}
             <div class="govuk-main-wrapper " id="main-content" role="main">
                 {% include "gds/layout/error_summary.html" %}
                 <div class="govuk-grid-row">
                     <div class="govuk-grid-column-two-thirds">
-
-                        {{ wizard.management_form }}
-
                         {% if wizard.form.forms %}
                             {{ wizard.form.management_form }}
                             {% for form in wizard.form.forms %}


### PR DESCRIPTION
The issue here was that the when the user would hit enter the browser would select the first submit button as the button to submit

In our case the first submit button is actually the "back" button

Wrapping the back button in its own separate form rectifies this issue