### PR TITLE
use lite-db image within private gcp registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,6 +246,7 @@ jobs:
     steps:
       - checkout
       - run: git submodule update --init
+      - run: cat $GCLOUD_SERVICE_KEY | docker login -u _json_key --password-stdin https://eu.gcr.io/sre-docker-registry
       - run_make:
           label: Run caseworker e2e tests
           target: start-caseworker caseworker-e2e-selenium-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,7 +246,7 @@ jobs:
     steps:
       - checkout
       - run: git submodule update --init
-      - run: cat $GCLOUD_SERVICE_KEY | docker login -u _json_key --password-stdin https://eu.gcr.io/sre-docker-registry
+      - run: echo $GCLOUD_SERVICE_KEY | docker login -u _json_key --password-stdin https://eu.gcr.io/sre-docker-registry
       - run_make:
           label: Run caseworker e2e tests
           target: start-caseworker caseworker-e2e-selenium-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,6 +259,7 @@ jobs:
     steps:
       - checkout
       - run: git submodule update --init
+      - run: echo $GCLOUD_SERVICE_KEY | docker login -u _json_key --password-stdin https://eu.gcr.io/sre-docker-registry
       - run_make:
           label: Run exporter e2e tests
           target: start-exporter exporter-e2e-test

--- a/docker-compose.api.yml
+++ b/docker-compose.api.yml
@@ -26,7 +26,7 @@ services:
     tty: true
 
   db:
-    image: gcr.io/sre-docker-registry/lite-db:latest
+    image: eu.gcr.io/sre-docker-registry/lite-db:latest
     environment:
       - POSTGRES_PASSWORD=password
       - POSTGRES_DB=lite-api


### PR DESCRIPTION
While working on LTD-2359, realised that current lite-db image, that we use to run e2e tests, is hosted in GCP public registry. Although data is anonymised, we don't want to expose our database over public domain. So moving this to private gcp registry instead.

You can check in circle ci logs for this entry, that downloads image from newer location:
`Status: Downloaded newer image for eu.gcr.io/*******************/lite-db:latest`
