### PR TITLE
Fix Jenkins UI tests job to run against a specified LITE API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,12 +9,19 @@ parameters:
   api_git_tag:
     type: string
     default: latest
+  environment:
+    type: string
+    default: devdata
 
 ###############################################################################
 # Env vars
 ###############################################################################
 common_env_vars: &common_env_vars
+  ENVIRONMENT: << pipeline.parameters.environment >>
+  LITE_API_URL: https://lite-api-<< pipeline.parameters.environment >>.london.cloudapps.digital/
   PIPENV_VENV_IN_PROJECT: true
+  LITE_INTERNAL_HAWK_KEY: $LITE_INTERNAL_HAWK_KEY_<< pipeline.parameters.environment >>
+  LITE_EXPORTER_HAWK_KEY: $LITE_EXPORTER_HAWK_KEY_<< pipeline.parameters.environment >>
 
 ###############################################################################
 # Images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,19 +12,12 @@ parameters:
   api_git_tag:
     type: string
     default: latest
-  environment:
-    type: string
-    default: devdata
 
 ###############################################################################
 # Env vars
 ###############################################################################
 common_env_vars: &common_env_vars
-  ENVIRONMENT: << pipeline.parameters.environment >>
-  LITE_API_URL: https://lite-api-<< pipeline.parameters.environment >>.apps.internal:8080/
   PIPENV_VENV_IN_PROJECT: true
-  LITE_INTERNAL_HAWK_KEY: $LITE_INTERNAL_HAWK_KEY_<< pipeline.parameters.environment >>
-  LITE_EXPORTER_HAWK_KEY: $LITE_EXPORTER_HAWK_KEY_<< pipeline.parameters.environment >>
 
 ###############################################################################
 # Images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 parameters:
+  run_auto_ui_tests:
+    type: boolean
+    default: false
   run_ui_tests:
     type: boolean
     default: false
@@ -15,7 +18,7 @@ parameters:
 ###############################################################################
 common_env_vars: &common_env_vars
   ENVIRONMENT: << pipeline.parameters.environment >>
-  LITE_API_URL: https://lite-api-<< pipeline.parameters.environment >>.london.cloudapps.digital/
+  LITE_API_URL: https://lite-api-<< pipeline.parameters.environment >>.apps.internal:8080/
   PIPENV_VENV_IN_PROJECT: true
   LITE_INTERNAL_HAWK_KEY: $LITE_INTERNAL_HAWK_KEY_<< pipeline.parameters.environment >>
   LITE_EXPORTER_HAWK_KEY: $LITE_EXPORTER_HAWK_KEY_<< pipeline.parameters.environment >>
@@ -236,6 +239,24 @@ jobs:
       - unit_tests:
           alias: core
 
+  caseworker_ui_test:
+    machine:
+      image: ubuntu-2004:202008-01
+      docker_layer_caching: true
+    environment:
+      <<: *common_env_vars
+      # not set PIPENV_DOTENV_LOCATION - instead set the env vars in circle
+      DJANGO_SETTINGS_MODULE: conf.caseworker
+      PYTEST_ADDOPTS: ui_tests/caseworker --capture=no --nomigrations -n3
+    steps:
+      - run: sudo apt-get update
+      - run: sudo apt-get --only-upgrade install google-chrome-stable
+      - run: pyenv install 3.7.0
+      - run: pyenv global 3.7.0
+      - run: pip install pipenv
+      - setup_code
+      - ui_tests
+
   exporter_ui_test:
     machine:
       image: ubuntu-2004:202008-01
@@ -296,3 +317,8 @@ workflows:
     jobs:
       - caseworker_e2e_test
       - exporter_e2e_test
+  auto_ui_tests:
+    when: << pipeline.parameters.run_auto_ui_tests >>
+    jobs:
+      - caseworker_ui_test
+      - exporter_ui_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,9 @@ parameters:
   run_unit_tests:
     type: boolean
     default: true
+  api_git_tag:
+    type: string
+    default: latest
   environment:
     type: string
     default: devdata
@@ -285,7 +288,7 @@ jobs:
       - run: echo $GCLOUD_SERVICE_KEY | docker login -u _json_key --password-stdin https://eu.gcr.io/sre-docker-registry
       - run_make:
           label: Run caseworker e2e tests
-          target: start-caseworker caseworker-e2e-selenium-test
+          target: start-caseworker caseworker-e2e-selenium-test API_GIT_TAG="<< pipeline.parameters.api_git_tag >>"
       - store_playwright_artifacts
 
   exporter_e2e_test:
@@ -298,7 +301,7 @@ jobs:
       - run: echo $GCLOUD_SERVICE_KEY | docker login -u _json_key --password-stdin https://eu.gcr.io/sre-docker-registry
       - run_make:
           label: Run exporter e2e tests
-          target: start-exporter exporter-e2e-test
+          target: start-exporter exporter-e2e-test API_GIT_TAG="<< pipeline.parameters.api_git_tag >>"
       - store_playwright_artifacts
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,5 @@
 version: 2.1
 parameters:
-  run_auto_ui_tests:
-    type: boolean
-    default: false
   run_ui_tests:
     type: boolean
     default: false
@@ -313,8 +310,3 @@ workflows:
     jobs:
       - caseworker_e2e_test
       - exporter_e2e_test
-  auto_ui_tests:
-    when: << pipeline.parameters.run_auto_ui_tests >>
-    jobs:
-      - caseworker_ui_test
-      - exporter_ui_test

--- a/docker-compose.api.yml
+++ b/docker-compose.api.yml
@@ -2,7 +2,7 @@ version: '3.2'
 
 services:
   api:
-    image: gcr.io/sre-docker-registry/github.com/uktrade/lite-api:latest
+    image: gcr.io/sre-docker-registry/github.com/uktrade/lite-api:${API_GIT_TAG}
     environment:
       # Below values can be found in vault
       AV_SERVICE_PASSWORD: ${AV_SERVICE_PASSWORD}

--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 ARGUMENTS = $(filter-out $@,$(MAKECMDGOALS)) $(filter-out --,$(MAKEFLAGS))
 
-docker-e2e-caseworker = docker-compose -p lite -f docker-compose.base.yml -f docker-compose.api.yml -f docker-compose.caseworker.yml
-docker-e2e-exporter = docker-compose -p lite -f docker-compose.base.yml -f docker-compose.api.yml -f docker-compose.exporter.yml
+docker-e2e-caseworker = API_GIT_TAG="$(API_GIT_TAG)" docker-compose -p lite -f docker-compose.base.yml -f docker-compose.api.yml -f docker-compose.caseworker.yml
+docker-e2e-exporter = API_GIT_TAG="$(API_GIT_TAG)" docker-compose -p lite -f docker-compose.base.yml -f docker-compose.api.yml -f docker-compose.exporter.yml
 wait-for-caseworker = dockerize -wait http://localhost:8200/healthcheck -timeout 5m -wait-retry-interval 5s
 wait-for-exporter = dockerize -wait http://localhost:8300/healthcheck -timeout 5m -wait-retry-interval 5s
 

--- a/pipeline/Jenkinsfile
+++ b/pipeline/Jenkinsfile
@@ -1,13 +1,13 @@
 import groovy.json.JsonSlurper
 import groovy.json.JsonOutput
 
-def triggerBuild(branch, environment)
+def triggerBuild(branch, api_git_tag, environment)
 {
     withCredentials([string(credentialsId: 'lite-circle-ci', variable: 'TOKEN')]) {
 
         def body = JsonOutput.toJson([
             branch: branch,
-            parameters: [run_auto_ui_tests: true, run_unit_tests: false, environment: environment]
+            parameters: [run_auto_ui_tests: false, run_ui_tests: true, run_unit_tests: false, api_git_tag: api_git_tag, environment: environment]
         ])
 
         def response = httpRequest (
@@ -60,6 +60,7 @@ pipeline {
     parameters {
         choice(name: 'ENVIRONMENT', description: 'choose what environment to run in', choices: 'dev\nuat\ndevdata\ndemo')
         string(name: 'BRANCH', defaultValue: 'master', description: 'choose branch to run against')
+        string(name: 'API_GIT_TAG', defaultValue: 'latest', description: 'GIT Release Tag for LITE API')
     }
 
     agent any
@@ -69,7 +70,7 @@ pipeline {
             steps{
                 script{
                     println "Triggering UI tests"
-                    (status, number) = triggerBuild(params.BRANCH, params.ENVIRONMENT)
+                    (status, number) = triggerBuild(params.BRANCH, params.API_GIT_TAG, params.ENVIRONMENT)
                     println "Triggered UI tests"
 
                     status = waitForBuildStatusToChange(number, status, ['queued', 'not_running', 'pending'], "waiting for job to start")

--- a/pipeline/Jenkinsfile
+++ b/pipeline/Jenkinsfile
@@ -7,7 +7,7 @@ def triggerBuild(branch, environment)
 
         def body = JsonOutput.toJson([
             branch: branch,
-            parameters: [run_ui_tests: true, run_unit_tests: false, environment: environment]
+            parameters: [run_auto_ui_tests: true, run_unit_tests: false, environment: environment]
         ])
 
         def response = httpRequest (

--- a/pipeline/Jenkinsfile
+++ b/pipeline/Jenkinsfile
@@ -7,7 +7,7 @@ def triggerBuild(branch, api_git_tag, environment)
 
         def body = JsonOutput.toJson([
             branch: branch,
-            parameters: [run_auto_ui_tests: false, run_ui_tests: true, run_unit_tests: false, api_git_tag: api_git_tag, environment: environment]
+            parameters: [run_auto_ui_tests: false, run_ui_tests: true, run_unit_tests: false, api_git_tag: api_git_tag]
         ])
 
         def response = httpRequest (
@@ -58,7 +58,6 @@ def waitForBuildStatusToChange(number, status, wait_states, msg){
 pipeline {
 
     parameters {
-        choice(name: 'ENVIRONMENT', description: 'choose what environment to run in', choices: 'dev\nuat\ndevdata\ndemo')
         string(name: 'BRANCH', defaultValue: 'master', description: 'choose branch to run against')
         string(name: 'API_GIT_TAG', defaultValue: 'latest', description: 'GIT Release Tag for LITE API')
     }
@@ -70,7 +69,7 @@ pipeline {
             steps{
                 script{
                     println "Triggering UI tests"
-                    (status, number) = triggerBuild(params.BRANCH, params.API_GIT_TAG, params.ENVIRONMENT)
+                    (status, number) = triggerBuild(params.BRANCH, params.API_GIT_TAG)
                     println "Triggered UI tests"
 
                     status = waitForBuildStatusToChange(number, status, ['queued', 'not_running', 'pending'], "waiting for job to start")

--- a/pipeline/Jenkinsfile
+++ b/pipeline/Jenkinsfile
@@ -1,7 +1,7 @@
 import groovy.json.JsonSlurper
 import groovy.json.JsonOutput
 
-def triggerBuild(branch, api_git_tag, environment)
+def triggerBuild(branch, api_git_tag)
 {
     withCredentials([string(credentialsId: 'lite-circle-ci', variable: 'TOKEN')]) {
 
@@ -58,8 +58,8 @@ def waitForBuildStatusToChange(number, status, wait_states, msg){
 pipeline {
 
     parameters {
-        string(name: 'BRANCH', defaultValue: 'master', description: 'choose branch to run against')
-        string(name: 'API_GIT_TAG', defaultValue: 'latest', description: 'GIT Release Tag for LITE API')
+        string(name: 'BRANCH', defaultValue: 'master', description: 'choose branch or release tag to run against')
+        string(name: 'API_GIT_TAG', defaultValue: 'latest', description: 'Type in API branch or release tag for LITE GCR image')
     }
 
     agent any

--- a/pipeline/Jenkinsfile
+++ b/pipeline/Jenkinsfile
@@ -7,7 +7,7 @@ def triggerBuild(branch, api_git_tag, environment)
 
         def body = JsonOutput.toJson([
             branch: branch,
-            parameters: [run_ui_tests: true, run_unit_tests: false, api_git_tag: api_git_tag]
+            parameters: [run_ui_tests: true, run_unit_tests: false, api_git_tag: api_git_tag, environment: environment]
         ])
 
         def response = httpRequest (

--- a/pipeline/Jenkinsfile
+++ b/pipeline/Jenkinsfile
@@ -7,7 +7,7 @@ def triggerBuild(branch, api_git_tag, environment)
 
         def body = JsonOutput.toJson([
             branch: branch,
-            parameters: [run_auto_ui_tests: false, run_ui_tests: true, run_unit_tests: false, api_git_tag: api_git_tag]
+            parameters: [run_ui_tests: true, run_unit_tests: false, api_git_tag: api_git_tag]
         ])
 
         def response = httpRequest (

--- a/pipeline/Jenkinsfile
+++ b/pipeline/Jenkinsfile
@@ -1,7 +1,7 @@
 import groovy.json.JsonSlurper
 import groovy.json.JsonOutput
 
-def triggerBuild(branch, api_git_tag)
+def triggerBuild(branch, api_git_tag, environment)
 {
     withCredentials([string(credentialsId: 'lite-circle-ci', variable: 'TOKEN')]) {
 
@@ -58,6 +58,7 @@ def waitForBuildStatusToChange(number, status, wait_states, msg){
 pipeline {
 
     parameters {
+        choice(name: 'ENVIRONMENT', description: '(not used)', choices: 'dev\nuat\ndevdata\ndemo')
         string(name: 'BRANCH', defaultValue: 'master', description: 'choose branch or release tag to run against')
         string(name: 'API_GIT_TAG', defaultValue: 'latest', description: 'Type in API branch or release tag for LITE GCR image')
     }
@@ -69,7 +70,7 @@ pipeline {
             steps{
                 script{
                     println "Triggering UI tests"
-                    (status, number) = triggerBuild(params.BRANCH, params.API_GIT_TAG)
+                    (status, number) = triggerBuild(params.BRANCH, params.API_GIT_TAG, params.ENVIRONMENT)
                     println "Triggered UI tests"
 
                     status = waitForBuildStatusToChange(number, status, ['queued', 'not_running', 'pending'], "waiting for job to start")


### PR DESCRIPTION
Current automated tests that we run in parallel of manual regression tests are running against LITE API latest master image. What we want is to run a specified FE release against a specified API release, using Release Tags that we create during deployment.

This PR fixes that issue. Process is that when we create a Github Release Tag, GCR event is triggered that builds an image that is tagged with the release string. This image will be used during the setup of UI e2e tests.

![image](https://user-images.githubusercontent.com/1433053/176153536-a4f06c59-9a38-446d-9c58-3ff27ffd7d61.png)
