### PR TITLE
[LTD-1990] Add aria-label tags to explain disabled content for screen readers

### DIFF
--- a/caseworker/templates/case/tabs/final-advice.html
+++ b/caseworker/templates/case/tabs/final-advice.html
@@ -19,7 +19,7 @@
 					List view
 				</a>
 			{% endif %}
-			<div class="lite-!-display-inline lite-buttons-row {% if 'final' not in current_advice_level %}app-advice__disabled-buttons{% endif %}">
+			<div class="lite-!-display-inline lite-buttons-row {% if 'final' not in current_advice_level %}app-advice__disabled-buttons{% endif %}" {% if 'final' not in current_advice_level %}aria-label="Content currently unavailable"{% endif %}>
 				{% if 'final' in current_advice_level %}
 					<div data-enable-on-checkboxes="#form-final-advice-container" class="lite-buttons-row lite-!-display-inline">
 						<button id="button-give-final-advice" name="action" value="give-advice" type="submit" class="govuk-button" data-module="govuk-button">
@@ -36,7 +36,7 @@
 			</div>
 		</div>
 
-		<div class="{% if not can_finalise %}app-advice__disabled-buttons{% endif %}">
+		<div {% if not can_finalise %}class="app-advice__disabled-buttons" aria-label="Content currently unavailable"{% endif %}>
 			{% make_list queue.id case.id as button_params %}
 			{% if case.data.case_type.sub_type.key == 'open' %}
 				{% govuk_link_button id='finalise' text='advice.FinalAdvicePage.FINALISED_GOODS_AND_COUNTRIES_BUTTON' url='cases:finalise_goods_countries' url_param=button_params show_chevron=True %}

--- a/caseworker/templates/case/tabs/team-advice.html
+++ b/caseworker/templates/case/tabs/team-advice.html
@@ -19,14 +19,14 @@
 					List view
 				</a>
 			{% endif %}
-			<div class="lite-!-display-inline lite-buttons-row {% if 'team' not in current_advice_level %}app-advice__disabled-buttons{% endif %}">
+			<div class="lite-!-display-inline lite-buttons-row {% if 'team' not in current_advice_level %}app-advice__disabled-buttons{% endif %}" {% if 'team' not in current_advice_level %}aria-label="Content currently unavailable"{% endif %}>
 				{% if 'team' in current_advice_level %}
 					<div data-enable-on-checkboxes="#form-team-advice-container" class="lite-buttons-row lite-!-display-inline">
 						<button id="button-give-team-advice" name="action" value="give-advice" type="submit" class="govuk-button" data-module="govuk-button">
 							Give or change advice
 						</button>
 					</div>
-					<span class="{% if not case.advice|filter_advice_by_team_id:current_user.team.id %}app-advice__disabled-buttons{% endif %}">
+					<span {% if not case.advice|filter_advice_by_team_id:current_user.team.id %}class="app-advice__disabled-buttons" aria-label="Content currently unavailable"{% endif %}>
 						<button form="form-team-advice" id="button-clear-team-advice" name="action" value="delete" type="submit" class="govuk-button" data-module="govuk-button">
 							Clear advice
 						</button>
@@ -35,7 +35,7 @@
 			</div>
 		</div>
 
-		<div class="{% if 'team' not in current_advice_level or not case.advice|filter_advice_by_team_id:current_user.team.id %}app-advice__disabled-buttons{% endif %}">
+		<div {% if 'team' not in current_advice_level or not case.advice|filter_advice_by_team_id:current_user.team.id %}class="app-advice__disabled-buttons" aria-label="Content currently unavailable"{% endif %}>
 			<a class="govuk-button" href="{% url 'cases:coalesce_team_advice' queue.id case.id %}{{ CURRENT_PATH_ONLY_PARAMS }}" id="button-combine-team-advice">
 				Combine all into final decision
 				<svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="13" height="15" viewBox="0 0 33 43" aria-hidden="true" focusable="false">

--- a/caseworker/templates/case/tabs/user-advice.html
+++ b/caseworker/templates/case/tabs/user-advice.html
@@ -25,7 +25,7 @@
 					</button>
 				</div>
 		</div>
-		<div class="{% if not case.advice or not case.advice|filter_advice_by_team_id:current_user.team.id %}app-advice__disabled-buttons{% endif %}">
+		<div {% if not case.advice or not case.advice|filter_advice_by_team_id:current_user.team.id %}class="app-advice__disabled-buttons" aria-label="Content currently unavailable"{% endif %}>
 			<button form="form-user-advice" id="button-combine-user-advice" type="submit" class="govuk-button" data-module="govuk-button">
 				Combine all into team advice
 				<svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="13" height="15" viewBox="0 0 33 43" aria-hidden="true" focusable="false">

--- a/exporter/templates/core/hub.html
+++ b/exporter/templates/core/hub.html
@@ -165,7 +165,7 @@
 			</div>
 		{% endif %}
 
-		<section class="app-tiles">
+		<section class="app-tiles" {% if FEATURE_FLAG_ONLY_ALLOW_SIEL %}aria-label="Content currently unavailable"{% endif %}>
 			{# Compliance licence tile #}
 			<div class="app-tile{% if FEATURE_FLAG_ONLY_ALLOW_SIEL %} app-tile__disabled{% endif %}">
 				{% if FEATURE_FLAG_ONLY_ALLOW_SIEL %}

--- a/unit_tests/caseworker/cases/test_templates.py
+++ b/unit_tests/caseworker/cases/test_templates.py
@@ -75,7 +75,7 @@ def test_advice_section_no_user_advice_checkboxes_visible_no_combine_button(data
     context["current_advice_level"] = ["user"]
     html = render_to_string("case/tabs/user-advice.html", context)
     soup = BeautifulSoup(html, "html.parser")
-    assert "app-advice__disabled-buttons" in soup.find(id="button-combine-user-advice").parent["class"]
+    assert "app-advice__disabled-buttons" in soup.find(id="button-combine-user-advice").parent.get("class", "")
     assert soup.find(id="link-select-all-goods")
     assert soup.find(id="link-select-all-destinations")
 
@@ -98,7 +98,7 @@ def test_advice_section_no_user_advice_checkboxes_visible_no_combine_button_grou
 
     html = render_to_string("case/tabs/user-advice.html", context=context, request=request)
     soup = BeautifulSoup(html, "html.parser")
-    assert "app-advice__disabled-buttons" in soup.find(id="button-combine-user-advice").parent["class"]
+    assert "app-advice__disabled-buttons" in soup.find(id="button-combine-user-advice").parent.get("class", "")
     assert soup.find(id="button-select-all-no_advice")
 
 
@@ -113,7 +113,7 @@ def test_advice_section_user_can_combine_advice_from_own_team(data_standard_case
 
     html = render_to_string("case/tabs/user-advice.html", context)
     soup = BeautifulSoup(html, "html.parser")
-    assert "app-advice__disabled-buttons" not in soup.find(id="button-combine-user-advice").parent["class"]
+    assert "app-advice__disabled-buttons" not in soup.find(id="button-combine-user-advice").parent.get("class", "")
 
 
 def test_advice_section_user_cannot_combine_advice_from_other_team(data_standard_case, rf, client):
@@ -128,7 +128,7 @@ def test_advice_section_user_cannot_combine_advice_from_other_team(data_standard
 
     html = render_to_string("case/tabs/user-advice.html", context)
     soup = BeautifulSoup(html, "html.parser")
-    assert "app-advice__disabled-buttons" in soup.find(id="button-combine-user-advice").parent["class"]
+    assert "app-advice__disabled-buttons" in soup.find(id="button-combine-user-advice").parent.get("class", "")
 
 
 def test_advice_section_user_can_clear_advice_from_own_team(data_standard_case, rf, client):
@@ -144,7 +144,7 @@ def test_advice_section_user_can_clear_advice_from_own_team(data_standard_case, 
 
     html = render_to_string("case/tabs/team-advice.html", context)
     soup = BeautifulSoup(html, "html.parser")
-    assert "app-advice__disabled-buttons" not in soup.find(id="button-clear-team-advice").parent["class"]
+    assert "app-advice__disabled-buttons" not in soup.find(id="button-clear-team-advice").parent.get("class", "")
 
 
 def test_advice_section_user_cannot_clear_advice_from_other_team(data_standard_case, rf, client):
@@ -160,7 +160,7 @@ def test_advice_section_user_cannot_clear_advice_from_other_team(data_standard_c
 
     html = render_to_string("case/tabs/team-advice.html", context)
     soup = BeautifulSoup(html, "html.parser")
-    assert "app-advice__disabled-buttons" in soup.find(id="button-clear-team-advice").parent["class"]
+    assert "app-advice__disabled-buttons" in soup.find(id="button-clear-team-advice").parent.get("class", "")
 
 
 def test_advice_section_user_cannot_clear_if_no_team_advice(data_standard_case, rf, client):
@@ -192,7 +192,7 @@ def test_advice_section_user_can_combine_team_advice_from_own_team(data_standard
 
     html = render_to_string("case/tabs/team-advice.html", context)
     soup = BeautifulSoup(html, "html.parser")
-    assert "app-advice__disabled-buttons" not in soup.find(id="button-combine-team-advice").parent["class"]
+    assert "app-advice__disabled-buttons" not in soup.find(id="button-combine-team-advice").parent.get("class", "")
 
 
 def test_advice_section_user_cannot_combine_team_advice_if_no_advice_from_own_team(data_standard_case, rf, client):
@@ -208,7 +208,7 @@ def test_advice_section_user_cannot_combine_team_advice_if_no_advice_from_own_te
 
     html = render_to_string("case/tabs/team-advice.html", context)
     soup = BeautifulSoup(html, "html.parser")
-    assert "app-advice__disabled-buttons" in soup.find(id="button-combine-team-advice").parent["class"]
+    assert "app-advice__disabled-buttons" in soup.find(id="button-combine-team-advice").parent.get("class", "")
 
 
 def test_advice_section_user_can_clear_final_advice_from_own_team(data_standard_case, rf, client):
@@ -273,7 +273,7 @@ def test_advice_section_user_cannot_finalise(data_standard_case, rf, client):
 
     html = render_to_string("case/tabs/final-advice.html", context)
     soup = BeautifulSoup(html, "html.parser")
-    assert "app-advice__disabled-buttons" in soup.find(id="button-finalise").parent["class"]
+    assert "app-advice__disabled-buttons" in soup.find(id="button-finalise").parent.get("class", "")
 
 
 def test_advice_section_user_can_finalise(data_standard_case, rf, client):
@@ -290,7 +290,7 @@ def test_advice_section_user_can_finalise(data_standard_case, rf, client):
 
     html = render_to_string("case/tabs/final-advice.html", context)
     soup = BeautifulSoup(html, "html.parser")
-    assert "app-advice__disabled-buttons" not in soup.find(id="button-finalise").parent["class"]
+    assert "app-advice__disabled-buttons" not in soup.find(id="button-finalise").get("class", "")
 
 
 def test_good_on_application_detail_unverified_product(


### PR DESCRIPTION
This change adds aria-label tags to call out disabled content as "unavailable" for screen readers.  As part of this work, some tests using beautiful soup needed updating to still work if the `class` attribute was missing from a tag.