### PR TITLE
LTD-2483: Fix I'm done button for LU users

### DIFF
--- a/caseworker/cases/helpers/case.py
+++ b/caseworker/cases/helpers/case.py
@@ -100,7 +100,7 @@ class CaseView(TemplateView):
         return self.caseworker["team"]["alias"] == LU_ALIAS
 
     def is_only_on_post_circ_queue(self):
-        queue_alias = tuple(queue["alias"] for queue in self.case.queue_details if queue.get("alias"))
+        queue_alias = tuple(queue.get("alias") for queue in self.case.queue_details)
         return self.is_lu_user() and queue_alias == (LU_POST_CIRC_FINALISE_QUEUE_ALIAS,)
 
     def get_context(self):


### PR DESCRIPTION
## Change description

We want to remove I'm done button for LU users if the case is only
on Licensing unit post circulation queue. The current code uses
queue alias to determine this but it is checking whether alias is
valid before taking this value. This condition is actually not
required because the problem with this is that alias is not defined
for all queues, eg if it is on team leader to countersign queue for
which the alias is not defined then the current code filters this
out and removes the button in this case also which is not correct.