### PR TITLE
Remove raising potential exception coming from API when posting firearms on application

### DIFF
--- a/exporter/applications/services.py
+++ b/exporter/applications/services.py
@@ -142,7 +142,6 @@ def post_firearm_good_on_application(request, pk, good_id, json):
         **json,
     }
     response = client.post(request, f"/applications/{pk}/goods/", json)
-    response.raise_for_status()
     return response.json(), response.status_code
 
 

--- a/exporter/applications/views/goods/add_good_firearm/views/add.py
+++ b/exporter/applications/views/goods/add_good_firearm/views/add.py
@@ -456,7 +456,7 @@ class AddGoodFirearmToApplication(
             service_error.response,
             exc_info=True,
         )
-        if settings.DEBUG:
+        if settings.DEBUG:  # pragma: no cover
             raise service_error
         return error_page(self.request, service_error.user_message)
 

--- a/exporter/applications/views/goods/add_good_firearm/views/add.py
+++ b/exporter/applications/views/goods/add_good_firearm/views/add.py
@@ -449,6 +449,17 @@ class AddGoodFirearmToApplication(
 
         return ctx
 
+    def handle_service_error(self, service_error):
+        logger.error(
+            service_error.log_message,
+            service_error.status_code,
+            service_error.response,
+            exc_info=True,
+        )
+        if settings.DEBUG:
+            raise service_error
+        return error_page(self.request, service_error.user_message)
+
     def done(self, form_list, form_dict, **kwargs):
         try:
             good_on_application, _ = self.post_firearm_to_application(form_dict)


### PR DESCRIPTION
There is an issue where we are receiving a 400 back from the API, however the details of the error message are getting swallowed up due to the 400 only raising a generic exception

In the actual usage of this function in the wizard there is already a decorator in place to handle checking of the status code and raising a more appropriate error and log providing us with more information as to what actually happened