### PR TITLE
Ltd 2601 error when attaching an existing product

### DIFF
--- a/exporter/applications/views/goods/add_good_firearm/views/attach.py
+++ b/exporter/applications/views/goods/add_good_firearm/views/attach.py
@@ -65,7 +65,7 @@ from .mixins import ApplicationMixin, GoodMixin, Product2FlagMixin
 from .payloads import (
     AttachFirearmToApplicationGoodPayloadBuilder,
     AttachFirearmToApplicationGoodOnApplicationPayloadBuilder,
-    FirearmsActPayloadBuilder,
+    FirearmsActSection5PayloadBuilder,
 )
 
 
@@ -203,7 +203,7 @@ class AttachFirearmToApplication(
 
     def get_firearm_to_application_payload(self, form_dict):
         good_payload = AttachFirearmToApplicationGoodOnApplicationPayloadBuilder().build(form_dict)
-        firearms_act_payload = FirearmsActPayloadBuilder(
+        firearms_act_payload = FirearmsActSection5PayloadBuilder(
             self.application,
             good_payload["firearm_details"],
         ).build(form_dict)

--- a/exporter/applications/views/goods/add_good_firearm/views/attach.py
+++ b/exporter/applications/views/goods/add_good_firearm/views/attach.py
@@ -1,5 +1,6 @@
 import logging
 
+from deepmerge import always_merger
 from http import HTTPStatus
 from urllib.parse import urlencode
 
@@ -64,6 +65,7 @@ from .mixins import ApplicationMixin, GoodMixin, Product2FlagMixin
 from .payloads import (
     AttachFirearmToApplicationGoodPayloadBuilder,
     AttachFirearmToApplicationGoodOnApplicationPayloadBuilder,
+    AttachFirearmSection5PayloadBuilder,
 )
 
 
@@ -178,17 +180,22 @@ class AttachFirearmToApplication(
             raise service_error
         return error_page(self.request, service_error.user_message)
 
-    def get_edit_firearm_payload(self, form_dict):
-        return AttachFirearmToApplicationGoodPayloadBuilder().build(form_dict)
+    def get_edit_firearm_payload(self, application, good, form_dict):
+        good_payload = AttachFirearmToApplicationGoodPayloadBuilder().build(form_dict)
+        section_5_payload = AttachFirearmSection5PayloadBuilder(application, good).build(form_dict)
+
+        payload = always_merger.merge(good_payload, section_5_payload)
+
+        return payload
 
     @expect_status(
         HTTPStatus.OK,
         "Error updating firearm",
         "Unexpected error updating firearm",
     )
-    def edit_firearm(self, good_pk, form_dict):
-        payload = self.get_edit_firearm_payload(form_dict)
-        return edit_firearm_for_attaching(self.request, good_pk, payload)
+    def edit_firearm(self, application, good, form_dict):
+        payload = self.get_edit_firearm_payload(application, good, form_dict)
+        return edit_firearm_for_attaching(self.request, good["id"], payload)
 
     def is_rfd_invalid(self, form_dict):
         if AttachFirearmToApplicationSteps.IS_RFD_CERTIFICATE_VALID not in form_dict:
@@ -200,9 +207,7 @@ class AttachFirearmToApplication(
         return is_rfd_certificate_data.get("is_rfd_certificate_valid") is False
 
     def get_firearm_to_application_payload(self, form_dict):
-        payload = AttachFirearmToApplicationGoodOnApplicationPayloadBuilder().build(form_dict)
-
-        return payload
+        return AttachFirearmToApplicationGoodOnApplicationPayloadBuilder().build(form_dict)
 
     @expect_status(
         HTTPStatus.CREATED,
@@ -279,8 +284,7 @@ class AttachFirearmToApplication(
             return error_page(self.request, "RFD invalid. Cannot submit.")
 
         try:
-            self.edit_firearm(self.good["id"], form_dict)
-
+            self.edit_firearm(self.application, self.good, form_dict)
             if self.has_existing_valid_organisation_rfd_certificate(self.application):
                 self.attach_rfd_certificate_to_application(self.application)
 

--- a/exporter/applications/views/goods/add_good_firearm/views/attach.py
+++ b/exporter/applications/views/goods/add_good_firearm/views/attach.py
@@ -1,6 +1,5 @@
 import logging
 
-from deepmerge import always_merger
 from http import HTTPStatus
 from urllib.parse import urlencode
 
@@ -65,7 +64,6 @@ from .mixins import ApplicationMixin, GoodMixin, Product2FlagMixin
 from .payloads import (
     AttachFirearmToApplicationGoodPayloadBuilder,
     AttachFirearmToApplicationGoodOnApplicationPayloadBuilder,
-    FirearmsActSection5PayloadBuilder,
 )
 
 
@@ -202,13 +200,7 @@ class AttachFirearmToApplication(
         return is_rfd_certificate_data.get("is_rfd_certificate_valid") is False
 
     def get_firearm_to_application_payload(self, form_dict):
-        good_payload = AttachFirearmToApplicationGoodOnApplicationPayloadBuilder().build(form_dict)
-        firearms_act_payload = FirearmsActSection5PayloadBuilder(
-            self.application,
-            good_payload["firearm_details"],
-        ).build(form_dict)
-
-        payload = always_merger.merge(good_payload, firearms_act_payload)
+        payload = AttachFirearmToApplicationGoodOnApplicationPayloadBuilder().build(form_dict)
 
         return payload
 

--- a/exporter/applications/views/goods/add_good_firearm/views/payloads.py
+++ b/exporter/applications/views/goods/add_good_firearm/views/payloads.py
@@ -228,31 +228,26 @@ class FirearmsActPayloadBuilder:
         return firearms_act_section == section_value and attach_step_name not in form_dict
 
     def get_payload(self, form_dict):
-        if not self.firearm_details.get("is_covered_by_firearm_act_section_one_two_or_five") == "Yes":
+        if self.firearm_details.get("is_covered_by_firearm_act_section_one_two_or_five") != "Yes":
             return {}
 
-        for section_value, attach_step_name, document_type in (
-            (
-                FirearmsActSections.SECTION_5,
-                AddGoodFirearmSteps.ATTACH_SECTION_5_LETTER_OF_AUTHORITY,
-                FirearmsActDocumentType.SECTION_5,
-            ),
+        if not self.has_skipped_firearms_attach_step(
+            form_dict,
+            self.firearm_details,
+            FirearmsActSections.SECTION_5,
+            AddGoodFirearmSteps.ATTACH_SECTION_5_LETTER_OF_AUTHORITY,
         ):
-            if not self.has_skipped_firearms_attach_step(
-                form_dict, self.firearm_details, section_value, attach_step_name
-            ):
-                continue
+            return {}
 
-            certificate = get_organisation_documents(self.application)[document_type]
-            return {
-                "section_certificate_missing": False,
-                "section_certificate_number": certificate["reference_code"],
-                "section_certificate_date_of_expiry": convert_api_date_string_to_date(
-                    certificate["expiry_date"]
-                ).isoformat(),
-            }
+        certificate = get_organisation_documents(self.application)[FirearmsActDocumentType.SECTION_5]
 
-        return {}
+        return {
+            "section_certificate_missing": False,
+            "section_certificate_number": certificate["reference_code"],
+            "section_certificate_date_of_expiry": convert_api_date_string_to_date(
+                certificate["expiry_date"]
+            ).isoformat(),
+        }
 
     def build(self, form_dict):
         return {"firearm_details": self.get_payload(form_dict)}

--- a/unit_tests/exporter/applications/views/test_attach_firearm_to_application.py
+++ b/unit_tests/exporter/applications/views/test_attach_firearm_to_application.py
@@ -667,3 +667,547 @@ def test_add_firearm_to_application_end_to_end_firearm_certificate(
         "s3_key": "certificate.pdf",
         "size": 0,
     }
+
+
+def test_attach_firearm_to_application_end_to_end_section_5_good_with_section_5_details(
+    application,
+    post_to_step,
+    good,
+    mock_good_attaching_put,
+    mock_good_on_application_post,
+    good_on_application,
+    application_with_rfd_and_section_5_document,
+    attach_product_on_application_summary_url,
+    requests_mock,
+    data_standard_case,
+):
+    good = data_standard_case["case"]["data"]["goods"][0]
+    good["good"].update(
+        {
+            "is_pv_graded": {"key": "yes", "value": "Yes"},
+            "is_covered_by_firearm_act_section_one_two_or_five": "Yes",
+        }
+    )
+    good["good"]["firearm_details"].update(
+        {
+            "is_covered_by_firearm_act_section_one_two_or_five": "Yes",
+            "is_covered_by_firearm_act_section_one_two_or_five_explanation": "",
+            "section_certificate_date_of_expiry": "2024-09-30",
+            "section_certificate_missing": False,
+            "section_certificate_missing_reason": "",
+            "section_certificate_number": "5555",
+        }
+    )
+    url = client._build_absolute_uri(f'/goods/{good["good"]["id"]}/')
+    requests_mock.get(url=url, json=good)
+
+    post_application_document_matcher = requests_mock.post(
+        f"/applications/{application['id']}/documents/",
+        status_code=201,
+        json={},
+    )
+
+    response = post_to_step(
+        AttachFirearmToApplicationSteps.IS_RFD_CERTIFICATE_VALID,
+        data={
+            "is_rfd_certificate_valid": True,
+        },
+    )
+    assert response.status_code == 200
+    assert not response.context["form"].errors
+    assert isinstance(response.context["form"], FirearmMadeBefore1938Form)
+
+    response = post_to_step(
+        AttachFirearmToApplicationSteps.MADE_BEFORE_1938,
+        {"is_made_before_1938": True},
+    )
+    assert response.status_code == 200
+    assert not response.context["form"].errors
+    assert isinstance(response.context["form"], FirearmYearOfManufactureForm)
+
+    response = post_to_step(
+        AttachFirearmToApplicationSteps.YEAR_OF_MANUFACTURE,
+        {"year_of_manufacture": 1937},
+    )
+    assert response.status_code == 200
+    assert not response.context["form"].errors
+    assert isinstance(response.context["form"], FirearmOnwardExportedForm)
+
+    response = post_to_step(
+        AttachFirearmToApplicationSteps.ONWARD_EXPORTED,
+        {"is_onward_exported": True},
+    )
+    assert response.status_code == 200
+    assert not response.context["form"].errors
+    assert isinstance(response.context["form"], FirearmOnwardAlteredProcessedForm)
+
+    response = post_to_step(
+        AttachFirearmToApplicationSteps.ONWARD_ALTERED_PROCESSED,
+        {"is_onward_altered_processed": True, "is_onward_altered_processed_comments": "processed comments"},
+    )
+    assert response.status_code == 200
+    assert not response.context["form"].errors
+    assert isinstance(response.context["form"], FirearmOnwardIncorporatedForm)
+
+    response = post_to_step(
+        AttachFirearmToApplicationSteps.ONWARD_INCORPORATED,
+        {"is_onward_incorporated": True, "is_onward_incorporated_comments": "incorporated comments"},
+    )
+    assert response.status_code == 200
+    assert not response.context["form"].errors
+    assert isinstance(response.context["form"], FirearmIsDeactivatedForm)
+
+    response = post_to_step(
+        AttachFirearmToApplicationSteps.IS_DEACTIVATED,
+        {"is_deactivated": True},
+    )
+    assert response.status_code == 200
+    assert not response.context["form"].errors
+    assert isinstance(response.context["form"], FirearmDeactivationDetailsForm)
+
+    response = post_to_step(
+        AttachFirearmToApplicationSteps.IS_DEACTIVATED_TO_STANDARD,
+        {
+            "date_of_deactivation_0": "12",
+            "date_of_deactivation_1": "11",
+            "date_of_deactivation_2": "2007",
+            "is_deactivated_to_standard": True,
+        },
+    )
+    assert response.status_code == 200
+    assert not response.context["form"].errors
+    assert isinstance(response.context["form"], FirearmQuantityAndValueForm)
+
+    response = post_to_step(
+        AttachFirearmToApplicationSteps.QUANTITY_AND_VALUE,
+        {"number_of_items": "2", "value": "16.32"},
+    )
+    assert response.status_code == 200
+    assert not response.context["form"].errors
+    assert isinstance(response.context["form"], FirearmSerialIdentificationMarkingsForm)
+
+    response = post_to_step(
+        AttachFirearmToApplicationSteps.SERIAL_IDENTIFICATION_MARKING,
+        {"serial_numbers_available": "AVAILABLE"},
+    )
+    assert response.status_code == 200
+    assert not response.context["form"].errors
+    assert isinstance(response.context["form"], FirearmSerialNumbersForm)
+
+    response = post_to_step(
+        AttachFirearmToApplicationSteps.SERIAL_NUMBERS,
+        {
+            "serial_numbers_0": "s111",
+            "serial_numbers_1": "s222",
+        },
+    )
+
+    assert response.status_code == 302
+    assert response.url == f"{attach_product_on_application_summary_url}?confirmed_rfd_validity=True"
+
+    assert mock_good_attaching_put.called_once
+    assert mock_good_attaching_put.last_request.json() == {
+        "firearm_details": {
+            "is_rfd_certificate_valid": True,
+        },
+    }
+
+    assert mock_good_on_application_post.last_request.json() == {
+        "firearm_details": {
+            "is_made_before_1938": True,
+            "year_of_manufacture": 1937,
+            "is_onward_exported": True,
+            "is_onward_altered_processed": True,
+            "is_onward_altered_processed_comments": "processed comments",
+            "is_onward_incorporated": True,
+            "is_onward_incorporated_comments": "incorporated comments",
+            "is_deactivated": True,
+            "date_of_deactivation": "2007-11-12",
+            "is_deactivated_to_standard": True,
+            "not_deactivated_to_standard_comments": "",
+            "number_of_items": 2,
+            "serial_numbers_available": "AVAILABLE",
+            "no_identification_markings_details": "",
+            "serial_numbers": ["s111", "s222"],
+        },
+        "good_id": good["good"]["id"],
+        "is_good_incorporated": True,
+        "quantity": 2,
+        "unit": "NAR",
+        "value": "16.32",
+    }
+
+    assert post_application_document_matcher.called_once
+    assert post_application_document_matcher.last_request.json() == {
+        "description": "Registered firearm dealer certificate",
+        "document_type": "rfd-certificate",
+        "name": "rfd_certificate.txt",
+        "s3_key": "rfd_certificate.txt.s3_key",
+        "safe": True,
+        "size": 3,
+    }
+
+
+def test_attach_firearm_to_application_end_to_end_section_5_good_without_section_5_details(
+    application,
+    post_to_step,
+    good,
+    mock_good_attaching_put,
+    mock_good_on_application_post,
+    good_on_application,
+    application_with_rfd_and_section_5_document,
+    attach_product_on_application_summary_url,
+    requests_mock,
+    data_standard_case,
+):
+    # There is a case where goods that were made prior to the firearm changes were saved without section 5 details.
+    # In this case we will save the data back to the good to work around this.
+
+    good = data_standard_case["case"]["data"]["goods"][0]
+    good["good"].update(
+        {
+            "is_pv_graded": {"key": "yes", "value": "Yes"},
+            "is_covered_by_firearm_act_section_one_two_or_five": "Yes",
+        }
+    )
+    good["good"]["firearm_details"].update(
+        {
+            "is_covered_by_firearm_act_section_one_two_or_five": "Yes",
+            "is_covered_by_firearm_act_section_one_two_or_five_explanation": "",
+            "section_certificate_date_of_expiry": None,
+            "section_certificate_missing": None,
+            "section_certificate_missing_reason": "",
+            "section_certificate_number": None,
+        }
+    )
+    url = client._build_absolute_uri(f'/goods/{good["good"]["id"]}/')
+    requests_mock.get(url=url, json=good)
+
+    post_application_document_matcher = requests_mock.post(
+        f"/applications/{application['id']}/documents/",
+        status_code=201,
+        json={},
+    )
+
+    response = post_to_step(
+        AttachFirearmToApplicationSteps.IS_RFD_CERTIFICATE_VALID,
+        data={
+            "is_rfd_certificate_valid": True,
+        },
+    )
+    assert response.status_code == 200
+    assert not response.context["form"].errors
+    assert isinstance(response.context["form"], FirearmMadeBefore1938Form)
+
+    response = post_to_step(
+        AttachFirearmToApplicationSteps.MADE_BEFORE_1938,
+        {"is_made_before_1938": True},
+    )
+    assert response.status_code == 200
+    assert not response.context["form"].errors
+    assert isinstance(response.context["form"], FirearmYearOfManufactureForm)
+
+    response = post_to_step(
+        AttachFirearmToApplicationSteps.YEAR_OF_MANUFACTURE,
+        {"year_of_manufacture": 1937},
+    )
+    assert response.status_code == 200
+    assert not response.context["form"].errors
+    assert isinstance(response.context["form"], FirearmOnwardExportedForm)
+
+    response = post_to_step(
+        AttachFirearmToApplicationSteps.ONWARD_EXPORTED,
+        {"is_onward_exported": True},
+    )
+    assert response.status_code == 200
+    assert not response.context["form"].errors
+    assert isinstance(response.context["form"], FirearmOnwardAlteredProcessedForm)
+
+    response = post_to_step(
+        AttachFirearmToApplicationSteps.ONWARD_ALTERED_PROCESSED,
+        {"is_onward_altered_processed": True, "is_onward_altered_processed_comments": "processed comments"},
+    )
+    assert response.status_code == 200
+    assert not response.context["form"].errors
+    assert isinstance(response.context["form"], FirearmOnwardIncorporatedForm)
+
+    response = post_to_step(
+        AttachFirearmToApplicationSteps.ONWARD_INCORPORATED,
+        {"is_onward_incorporated": True, "is_onward_incorporated_comments": "incorporated comments"},
+    )
+    assert response.status_code == 200
+    assert not response.context["form"].errors
+    assert isinstance(response.context["form"], FirearmIsDeactivatedForm)
+
+    response = post_to_step(
+        AttachFirearmToApplicationSteps.IS_DEACTIVATED,
+        {"is_deactivated": True},
+    )
+    assert response.status_code == 200
+    assert not response.context["form"].errors
+    assert isinstance(response.context["form"], FirearmDeactivationDetailsForm)
+
+    response = post_to_step(
+        AttachFirearmToApplicationSteps.IS_DEACTIVATED_TO_STANDARD,
+        {
+            "date_of_deactivation_0": "12",
+            "date_of_deactivation_1": "11",
+            "date_of_deactivation_2": "2007",
+            "is_deactivated_to_standard": True,
+        },
+    )
+    assert response.status_code == 200
+    assert not response.context["form"].errors
+    assert isinstance(response.context["form"], FirearmQuantityAndValueForm)
+
+    response = post_to_step(
+        AttachFirearmToApplicationSteps.QUANTITY_AND_VALUE,
+        {"number_of_items": "2", "value": "16.32"},
+    )
+    assert response.status_code == 200
+    assert not response.context["form"].errors
+    assert isinstance(response.context["form"], FirearmSerialIdentificationMarkingsForm)
+
+    response = post_to_step(
+        AttachFirearmToApplicationSteps.SERIAL_IDENTIFICATION_MARKING,
+        {"serial_numbers_available": "AVAILABLE"},
+    )
+    assert response.status_code == 200
+    assert not response.context["form"].errors
+    assert isinstance(response.context["form"], FirearmSerialNumbersForm)
+
+    response = post_to_step(
+        AttachFirearmToApplicationSteps.SERIAL_NUMBERS,
+        {
+            "serial_numbers_0": "s111",
+            "serial_numbers_1": "s222",
+        },
+    )
+
+    assert response.status_code == 302
+    assert response.url == f"{attach_product_on_application_summary_url}?confirmed_rfd_validity=True"
+
+    assert mock_good_attaching_put.called_once
+    assert mock_good_attaching_put.last_request.json() == {
+        "firearm_details": {
+            "is_rfd_certificate_valid": True,
+            "section_certificate_missing": False,
+            "section_certificate_missing_reason": "",
+            "section_certificate_number": "section 5 ref",
+            "section_certificate_date_of_expiry": "2024-09-30",
+        },
+    }
+
+    assert mock_good_on_application_post.last_request.json() == {
+        "firearm_details": {
+            "is_made_before_1938": True,
+            "year_of_manufacture": 1937,
+            "is_onward_exported": True,
+            "is_onward_altered_processed": True,
+            "is_onward_altered_processed_comments": "processed comments",
+            "is_onward_incorporated": True,
+            "is_onward_incorporated_comments": "incorporated comments",
+            "is_deactivated": True,
+            "date_of_deactivation": "2007-11-12",
+            "is_deactivated_to_standard": True,
+            "not_deactivated_to_standard_comments": "",
+            "number_of_items": 2,
+            "serial_numbers_available": "AVAILABLE",
+            "no_identification_markings_details": "",
+            "serial_numbers": ["s111", "s222"],
+        },
+        "good_id": good["good"]["id"],
+        "is_good_incorporated": True,
+        "quantity": 2,
+        "unit": "NAR",
+        "value": "16.32",
+    }
+
+    assert post_application_document_matcher.called_once
+    assert post_application_document_matcher.last_request.json() == {
+        "description": "Registered firearm dealer certificate",
+        "document_type": "rfd-certificate",
+        "name": "rfd_certificate.txt",
+        "s3_key": "rfd_certificate.txt.s3_key",
+        "safe": True,
+        "size": 3,
+    }
+
+
+def test_attach_firearm_to_application_end_to_end_section_5_good_without_section_5_details_and_without_section_5_certificate(
+    application,
+    post_to_step,
+    good,
+    mock_good_attaching_put,
+    mock_good_on_application_post,
+    good_on_application,
+    application_with_organisation_rfd_document,
+    attach_product_on_application_summary_url,
+    requests_mock,
+    data_standard_case,
+):
+    good = data_standard_case["case"]["data"]["goods"][0]
+    good["good"].update(
+        {
+            "is_pv_graded": {"key": "yes", "value": "Yes"},
+            "is_covered_by_firearm_act_section_one_two_or_five": "Yes",
+        }
+    )
+    good["good"]["firearm_details"].update(
+        {
+            "is_covered_by_firearm_act_section_one_two_or_five": "Yes",
+            "is_covered_by_firearm_act_section_one_two_or_five_explanation": "",
+            "section_certificate_date_of_expiry": None,
+            "section_certificate_missing": None,
+            "section_certificate_missing_reason": "",
+            "section_certificate_number": None,
+        }
+    )
+    url = client._build_absolute_uri(f'/goods/{good["good"]["id"]}/')
+    requests_mock.get(url=url, json=good)
+
+    post_application_document_matcher = requests_mock.post(
+        f"/applications/{application['id']}/documents/",
+        status_code=201,
+        json={},
+    )
+
+    response = post_to_step(
+        AttachFirearmToApplicationSteps.IS_RFD_CERTIFICATE_VALID,
+        data={
+            "is_rfd_certificate_valid": True,
+        },
+    )
+    assert response.status_code == 200
+    assert not response.context["form"].errors
+    assert isinstance(response.context["form"], FirearmMadeBefore1938Form)
+
+    response = post_to_step(
+        AttachFirearmToApplicationSteps.MADE_BEFORE_1938,
+        {"is_made_before_1938": True},
+    )
+    assert response.status_code == 200
+    assert not response.context["form"].errors
+    assert isinstance(response.context["form"], FirearmYearOfManufactureForm)
+
+    response = post_to_step(
+        AttachFirearmToApplicationSteps.YEAR_OF_MANUFACTURE,
+        {"year_of_manufacture": 1937},
+    )
+    assert response.status_code == 200
+    assert not response.context["form"].errors
+    assert isinstance(response.context["form"], FirearmOnwardExportedForm)
+
+    response = post_to_step(
+        AttachFirearmToApplicationSteps.ONWARD_EXPORTED,
+        {"is_onward_exported": True},
+    )
+    assert response.status_code == 200
+    assert not response.context["form"].errors
+    assert isinstance(response.context["form"], FirearmOnwardAlteredProcessedForm)
+
+    response = post_to_step(
+        AttachFirearmToApplicationSteps.ONWARD_ALTERED_PROCESSED,
+        {"is_onward_altered_processed": True, "is_onward_altered_processed_comments": "processed comments"},
+    )
+    assert response.status_code == 200
+    assert not response.context["form"].errors
+    assert isinstance(response.context["form"], FirearmOnwardIncorporatedForm)
+
+    response = post_to_step(
+        AttachFirearmToApplicationSteps.ONWARD_INCORPORATED,
+        {"is_onward_incorporated": True, "is_onward_incorporated_comments": "incorporated comments"},
+    )
+    assert response.status_code == 200
+    assert not response.context["form"].errors
+    assert isinstance(response.context["form"], FirearmIsDeactivatedForm)
+
+    response = post_to_step(
+        AttachFirearmToApplicationSteps.IS_DEACTIVATED,
+        {"is_deactivated": True},
+    )
+    assert response.status_code == 200
+    assert not response.context["form"].errors
+    assert isinstance(response.context["form"], FirearmDeactivationDetailsForm)
+
+    response = post_to_step(
+        AttachFirearmToApplicationSteps.IS_DEACTIVATED_TO_STANDARD,
+        {
+            "date_of_deactivation_0": "12",
+            "date_of_deactivation_1": "11",
+            "date_of_deactivation_2": "2007",
+            "is_deactivated_to_standard": True,
+        },
+    )
+    assert response.status_code == 200
+    assert not response.context["form"].errors
+    assert isinstance(response.context["form"], FirearmQuantityAndValueForm)
+
+    response = post_to_step(
+        AttachFirearmToApplicationSteps.QUANTITY_AND_VALUE,
+        {"number_of_items": "2", "value": "16.32"},
+    )
+    assert response.status_code == 200
+    assert not response.context["form"].errors
+    assert isinstance(response.context["form"], FirearmSerialIdentificationMarkingsForm)
+
+    response = post_to_step(
+        AttachFirearmToApplicationSteps.SERIAL_IDENTIFICATION_MARKING,
+        {"serial_numbers_available": "AVAILABLE"},
+    )
+    assert response.status_code == 200
+    assert not response.context["form"].errors
+    assert isinstance(response.context["form"], FirearmSerialNumbersForm)
+
+    response = post_to_step(
+        AttachFirearmToApplicationSteps.SERIAL_NUMBERS,
+        {
+            "serial_numbers_0": "s111",
+            "serial_numbers_1": "s222",
+        },
+    )
+
+    assert response.status_code == 302
+    assert response.url == f"{attach_product_on_application_summary_url}?confirmed_rfd_validity=True"
+
+    assert mock_good_attaching_put.called_once
+    assert mock_good_attaching_put.last_request.json() == {
+        "firearm_details": {
+            "is_rfd_certificate_valid": True,
+        },
+    }
+
+    assert mock_good_on_application_post.last_request.json() == {
+        "firearm_details": {
+            "is_made_before_1938": True,
+            "year_of_manufacture": 1937,
+            "is_onward_exported": True,
+            "is_onward_altered_processed": True,
+            "is_onward_altered_processed_comments": "processed comments",
+            "is_onward_incorporated": True,
+            "is_onward_incorporated_comments": "incorporated comments",
+            "is_deactivated": True,
+            "date_of_deactivation": "2007-11-12",
+            "is_deactivated_to_standard": True,
+            "not_deactivated_to_standard_comments": "",
+            "number_of_items": 2,
+            "serial_numbers_available": "AVAILABLE",
+            "no_identification_markings_details": "",
+            "serial_numbers": ["s111", "s222"],
+        },
+        "good_id": good["good"]["id"],
+        "is_good_incorporated": True,
+        "quantity": 2,
+        "unit": "NAR",
+        "value": "16.32",
+    }
+
+    assert post_application_document_matcher.called_once
+    assert post_application_document_matcher.last_request.json() == {
+        "description": "Registered firearm dealer certificate",
+        "document_type": "rfd-certificate",
+        "name": "rfd_certificate.txt",
+        "s3_key": "rfd_certificate.txt.s3_key",
+        "safe": True,
+        "size": 3,
+    }


### PR DESCRIPTION
This handles the case where a good was made prior to the low RFI changes and didn't have the relevant section 5 details attached to it.

This copies those details to the original good if required. Essentially it's upgrading these goods to contain information that wasn't necessary before.