### PR TITLE
LTD-2373: Product details table changes

### DIFF
--- a/caseworker/templates/case/slices/goods.html
+++ b/caseworker/templates/case/slices/goods.html
@@ -28,16 +28,11 @@
 						<th scope="col" class="govuk-table__header">Type</th>
 					{% endif %}
 					<th scope="col" class="govuk-table__header">Licence required</th>
-					<th scope="col" class="govuk-table__header">Rating</th>
+					<th scope="col" class="govuk-table__header">Control entry</th>
 					{% if not hide_status %}
-						<th scope="col" class="govuk-table__header">Status</th>
+						<th scope="col" class="govuk-table__header">Report summary</th>
 					{% endif %}
 					<th scope="col" class="govuk-table__header">Flags</th>
-					{% if not hide_status %}
-						<th scope="col" class="govuk-table__header">ARS</th>
-					{% endif %}
-					<th scope="col" class="govuk-table__header">Comments</th>
-					<th scope="col" class="govuk-table__header"></th>
 				</tr>
 			</thead>
 			<tbody class="govuk-table__body">
@@ -54,7 +49,11 @@
 						<td class="govuk-table__cell govuk-table__cell--line-number {% if show_advice %}lite-!-no-border{% endif %}">{{ forloop.counter }}.</td>
 						<td class="govuk-table__cell govuk-table__cell--max-width-400 {% if show_advice %}lite-!-no-border{% endif %}">
 							<span class="govuk-table__header" aria-hidden="false">Name</span>
-							<span data-max-length="200">{% if good.good.name %} {{ good.good.name }} {% else %} {{ good.good.description }} {% endif %}</span>
+							<span>
+								<a class="govuk-link govuk-link--no-visited-state" href="{% url 'cases:good' queue_pk=queue.id pk=case.id good_pk=good.id %}">		
+									{% if good.good.name %} {{ good.good.name }} {% else %} {{ good.good.description }} {% endif %}
+								</a>
+							</span>
 						</td>
 						<td class="govuk-table__cell govuk-table__cell--max-width-400 {% if show_advice %}lite-!-no-border{% endif %}">
 							<span class="govuk-table__header" aria-hidden="false">Quantity</span>
@@ -80,7 +79,7 @@
 							{% endif %}
 						</td>
 						<td class="govuk-table__cell {% if show_advice %}lite-!-no-border{% endif %}">
-							<span class="govuk-table__header" aria-hidden="false">Rating</span>
+							<span class="govuk-table__header" aria-hidden="false">Control entry</span>
 							{# if good.is_good_controlled is anything other than None, this indicates the caseworker has reviewed the good-on-application level, so use that as source of truth #}
 							{% if good.is_good_controlled is not None %}
 								{% include 'includes/control-list-entries.html' with control_list_entries=good.control_list_entries end_use_control=good.end_use_control %}
@@ -92,34 +91,13 @@
 						</td>
 						{% if not hide_status %}
 							<td class="govuk-table__cell {% if show_advice %}lite-!-no-border{% endif %}">
-								<span class="govuk-table__header" aria-hidden="false">Status</span>
-								{% if good.good.status.key == 'verified' %}
-									<div class="lite-vertical-align">
-										{% svg 'verified' %}
-										<span class="govuk-!-margin-left-1">{{ good.good.status.value }}</span>
-									</div>
-								{% else %}
-									{{ good.good.status.value }}
-								{% endif %}
-							</td>
-						{% endif %}
-							<td class="govuk-table__cell {% if show_advice %}lite-!-no-border{% endif %}">
-								<span class="govuk-table__header" aria-hidden="false">Flags</span>
-								{% include 'includes/flags.html' with flags=good.good.flags list=True %}
-							</td>
-						{% if not hide_status %}
-							<td class="govuk-table__cell {% if show_advice %}lite-!-no-border{% endif %}">
 								<span class="govuk-table__header" aria-hidden="false">ARS</span>
 								{{ good.report_summary|default_if_none:'Not added' }}
 							</td>
 						{% endif %}
-							<td class="govuk-table__cell {% if show_advice %}lite-!-no-border{% endif %}">
-								<span class="govuk-table__header" aria-hidden="false">Comments</span>
-								{{ good.comment|default_if_none:'Not added' }}
-								{% if good.comment == '' %}None{% endif %}
-							</td>
-						<td class="govuk-table__cell {% if show_advice %}lite-!-no-border{% endif %}" id="view-good-details">
-							<a class="govuk-link govuk-link--no-visited-state" href="{% url 'cases:good' queue_pk=queue.id pk=case.id good_pk=good.id %}">View full product details</a>
+						<td class="govuk-table__cell {% if show_advice %}lite-!-no-border{% endif %}">
+							<span class="govuk-table__header" aria-hidden="false">Flags</span>
+							{% include 'includes/flags.html' with flags=good.good.flags list=True %}
 						</td>
 					</tr>
 					{% if show_advice %}

--- a/ui_tests/caseworker/features/give_advice.feature
+++ b/ui_tests/caseworker/features/give_advice.feature
@@ -273,9 +273,9 @@ Feature: I want to record my user advice and any comments and conditions relatin
     And I change my team to "Licensing Unit" and default queue to "Licensing Unit Post-circulation Cases to Finalise"
     And I go to my case list
     And I click the application previously created
-    Then for the first good I see "N/A" for "Rating"
+    Then for the first good I see "N/A" for "Control entry"
     And for the first good I see "No" for "Licence required"
-    And for the first good I see "ARS" for "ARS"
+    And for the first good I see "ARS" for "Report summary"
     When I click the recommendations and decision tab
     And I click "Review and combine"
     And I enter "reason for approving" as the reasons for approving


### PR DESCRIPTION
## Change description

 - Remove "status" column so users assess all products every time.
 - Rename Rating => Control entry
 - Rename ARS => Report summary
 - Move flags column to the end so that Report summary comes first
 - Hyperlink product name and remove "View full product details" link