### PR TITLE
Remove MANAGE_PICKLIST permission check from picklist json view

### DIFF
--- a/caseworker/picklists/urls.py
+++ b/caseworker/picklists/urls.py
@@ -8,11 +8,13 @@ app_name = "picklists"
 
 urlpatterns = [
     path("", views.Picklists.as_view(), name="picklists"),
-    path(".json", views.PicklistsJson.as_view(), name="picklists_json"),
     path("<uuid:pk>/", views.ViewPicklistItem.as_view(), name="picklist_item"),
     path("add/", views.AddPicklistItem.as_view(), name="add"),
     path("<uuid:pk>/edit/", views.EditPicklistItem.as_view(), name="edit"),
     path("<uuid:pk>/<str:status>/", views.ChangeStatusView.as_view(), name="change_status"),
 ]
+decorate_patterns_with_permission(urlpatterns, Permission.MANAGE_PICKLISTS)
 
-url_patterns = decorate_patterns_with_permission(urlpatterns, Permission.MANAGE_PICKLISTS)
+urlpatterns += [
+    path(".json", views.PicklistsJson.as_view(), name="picklists_json"),
+]

--- a/unit_tests/caseworker/conftest.py
+++ b/unit_tests/caseworker/conftest.py
@@ -12,7 +12,6 @@ from caseworker.advice.services import LICENSING_UNIT_TEAM
 
 application_id = "094eed9a-23cc-478a-92ad-9a05ac17fad0"
 second_application_id = "08e69b60-8fbd-4111-b6ae-096b565fe4ea"
-gov_uk_user_id = "2a43805b-c082-47e7-9188-c8b3e1a83cb0"
 
 
 DEFAULT_ENVFILE = "caseworker.env"
@@ -24,6 +23,11 @@ def pytest_configure(config):
     """
     if not os.environ.get("PIPENV_DOTENV_LOCATION"):
         load_dotenv(dotenv_path=DEFAULT_ENVFILE, override=True)
+
+
+@pytest.fixture
+def gov_uk_user_id():
+    return "2a43805b-c082-47e7-9188-c8b3e1a83cb0"
 
 
 @pytest.fixture
@@ -49,7 +53,7 @@ def data_case_types():
 
 
 @pytest.fixture
-def data_cases_search(data_open_case, data_standard_case, mock_case_statuses, data_case_types):
+def data_cases_search(data_open_case, data_standard_case, mock_case_statuses, data_case_types, gov_uk_user_id):
     return {
         "count": 2,
         "results": {
@@ -201,7 +205,7 @@ def mock_status_properties(requests_mock):
 
 
 @pytest.fixture
-def mock_gov_user(requests_mock, mock_notifications, mock_case_statuses):
+def mock_gov_user(requests_mock, mock_notifications, mock_case_statuses, gov_uk_user_id):
     url = client._build_absolute_uri("/gov-users/")
     data = {
         "user": {
@@ -261,7 +265,7 @@ def mock_gov_fcdo_user(requests_mock, mock_notifications, mock_case_statuses, mo
 
 
 @pytest.fixture
-def mock_gov_tau_user(requests_mock, mock_notifications, mock_case_statuses, mock_gov_user):
+def mock_gov_tau_user(requests_mock, mock_notifications, mock_case_statuses, mock_gov_user, gov_uk_user_id):
     mock_gov_user["user"]["team"] = {
         "id": "521154de-f39e-45bf-9922-baaaaaa",
         "name": "TAU",
@@ -274,7 +278,7 @@ def mock_gov_tau_user(requests_mock, mock_notifications, mock_case_statuses, moc
 
 
 @pytest.fixture
-def mock_gov_lu_user(requests_mock, mock_notifications, mock_case_statuses, mock_gov_user):
+def mock_gov_lu_user(requests_mock, mock_notifications, mock_case_statuses, mock_gov_user, gov_uk_user_id):
     mock_gov_user["user"]["team"] = {
         "id": "521154de-f39e-45bf-9922-baaaaaa",
         "name": "Licencing Unit",

--- a/unit_tests/caseworker/picklists/test_views.py
+++ b/unit_tests/caseworker/picklists/test_views.py
@@ -1,0 +1,45 @@
+import pytest
+import re
+
+from django.urls import reverse
+
+from core import client
+
+
+@pytest.fixture
+def picklists_json_url():
+    return reverse("picklists:picklists_json")
+
+
+@pytest.fixture
+def mock_picklist_get(requests_mock):
+    return requests_mock.get("/picklist/", json={"results": []})
+
+
+def test_picklist_json_view(authorized_client, picklists_json_url, mock_picklist_get):
+    response = authorized_client.get(picklists_json_url)
+    assert response.status_code == 200
+    assert mock_picklist_get.last_request.qs == {
+        "type": ["proviso"],
+        "page": ["1"],
+        "disable_pagination": ["false"],
+        "show_deactivated": ["false"],
+    }
+
+
+def test_picklist_json_view_permission_not_required(
+    authorized_client,
+    picklists_json_url,
+    mock_picklist_get,
+    mock_gov_user,
+    requests_mock,
+    gov_uk_user_id,
+):
+    mock_gov_user["user"]["role"]["permissions"] = []
+
+    url = client._build_absolute_uri("/gov-users/")
+    requests_mock.get(url=f"{url}me/", json=mock_gov_user)
+    requests_mock.get(url=re.compile(f"{url}{gov_uk_user_id}/"), json=mock_gov_user)
+
+    response = authorized_client.get(picklists_json_url)
+    assert response.status_code == 200


### PR DESCRIPTION
There was originally a permission check for all picklist related views that checked that a user had `MANAGE_PICKLIST` however this is just a readonly view of the picklist data so isn't just necessary for people who can add/edit those picklists.