### PR TITLE
Ltd 2647 fix advice tab destination

### DIFF
--- a/caseworker/activities/templates/activities/notes-and-timeline.html
+++ b/caseworker/activities/templates/activities/notes-and-timeline.html
@@ -1,7 +1,13 @@
 {% extends 'layouts/case.html' %}
 
 {% block header_tabs %}
-    {% include "includes/case-tabs.html" with case=case queue=queue selected_tab="activities" %}
+    <div id="tab-bar" class="app-case-tab-bar">
+        <div class="govuk-width-container lite-tabs__container">
+            <div class="lite-tabs ">
+                {% include "includes/case-tabs.html" %}
+            </div>
+        </div>
+    </div>
 {% endblock %}
 
 {% block details %}

--- a/caseworker/activities/views.py
+++ b/caseworker/activities/views.py
@@ -11,10 +11,11 @@ from caseworker.cases.services import (
     get_activity_filters,
     get_case,
 )
+from caseworker.cases.views.main import CaseTabsMixin
 from caseworker.queues.services import get_queue
 
 
-class NotesAndTimeline(LoginRequiredMixin, TemplateView):
+class NotesAndTimeline(LoginRequiredMixin, CaseTabsMixin, TemplateView):
     template_name = "activities/notes-and-timeline.html"
 
     @cached_property
@@ -72,4 +73,6 @@ class NotesAndTimeline(LoginRequiredMixin, TemplateView):
             "filtering_by": list(self.request.GET.keys()),
             "queue": self.queue,
             "team_filters": self.get_team_filters(),
+            "tabs": self.get_standard_application_tabs(),
+            "current_tab": "cases:activities:notes-and-timeline",
         }

--- a/caseworker/advice/templates/advice/view-advice.html
+++ b/caseworker/advice/templates/advice/view-advice.html
@@ -4,7 +4,13 @@
 {% load crispy_forms_tags %}
 
 {% block header_tabs %}
-	{% include "includes/case-tabs.html" with case=case queue=queue selected_tab="advice" %}
+    <div id="tab-bar" class="app-case-tab-bar">
+        <div class="govuk-width-container lite-tabs__container">
+            <div class="lite-tabs ">
+                {% include "includes/case-tabs.html" %}
+            </div>
+        </div>
+    </div>
 {% endblock %}
 
 {% block full_width %}

--- a/caseworker/advice/templates/advice/view_countersign.html
+++ b/caseworker/advice/templates/advice/view_countersign.html
@@ -4,7 +4,13 @@
 {% load crispy_forms_tags %}
 
 {% block header_tabs %}
-	{% include "includes/case-tabs.html" with case=case queue=queue selected_tab="advice" %}
+  <div id="tab-bar" class="app-case-tab-bar">
+    <div class="govuk-width-container lite-tabs__container">
+        <div class="lite-tabs ">
+            {% include "includes/case-tabs.html" %}
+        </div>
+    </div>
+  </div>
 {% endblock %}
 
 {% block body %}

--- a/caseworker/advice/templates/advice/view_my_advice.html
+++ b/caseworker/advice/templates/advice/view_my_advice.html
@@ -2,7 +2,13 @@
 {% load crispy_forms_tags %}
 
 {% block header_tabs %}
-  {% include "includes/case-tabs.html" with case=case queue=queue selected_tab="advice" %}
+  <div id="tab-bar" class="app-case-tab-bar">
+    <div class="govuk-width-container lite-tabs__container">
+        <div class="lite-tabs ">
+            {% include "includes/case-tabs.html" %}
+        </div>
+    </div>
+  </div>
 {% endblock %}
 
 {% block body %}

--- a/caseworker/cases/helpers/case.py
+++ b/caseworker/cases/helpers/case.py
@@ -6,7 +6,6 @@ from django.views.generic import TemplateView
 
 from core.constants import CaseStatusEnum
 
-from caseworker.advice.services import get_advice_tab_context
 from caseworker.cases.helpers.ecju_queries import get_ecju_queries
 from caseworker.cases.objects import Slice, Case
 from caseworker.cases.services import (
@@ -162,38 +161,3 @@ class CaseView(TemplateView):
         else:
             getattr(self, "get_" + self.case.sub_type)()
         return render(request, "case/case.html", self.get_context())
-
-    def get_tabs(self):
-        tabs = [
-            Tabs.DETAILS,
-            Tabs.ADDITIONAL_CONTACTS,
-            Tabs.ECJU_QUERIES,
-            Tabs.DOCUMENTS,
-        ]
-
-        return tabs
-
-    def get_advice_tab(self):
-        data, _ = get_gov_user(self.request, str(self.request.session["lite_api_user_id"]))
-        return Tab(
-            "advice",
-            "Recommendations and decision",
-            get_advice_tab_context(self.case, data["user"], str(self.kwargs["queue_pk"]))["url"],
-            has_template=False,
-        )
-
-    def get_assessment_tab(self):
-        return Tab(
-            "assessment",
-            "Product Assessment",
-            "cases:tau:home",
-            has_template=False,
-        )
-
-    def get_notes_and_timelines_tab(self):
-        return Tab(
-            "activities",
-            CasePage.Tabs.CASE_NOTES_AND_TIMELINE,
-            "cases:activities:notes-and-timeline",
-            has_template=False,
-        )

--- a/caseworker/cases/views/main.py
+++ b/caseworker/cases/views/main.py
@@ -13,13 +13,18 @@ from core.builtins.custom_tags import filter_advice_by_level
 from core.file_handler import s3_client
 
 from lite_content.lite_internal_frontend import cases
-from lite_content.lite_internal_frontend.cases import DoneWithCaseOnQueueForm, Manage
+from lite_content.lite_internal_frontend.cases import (
+    CasePage,
+    DoneWithCaseOnQueueForm,
+    Manage,
+)
 
 from lite_forms.components import FiltersBar, TextInput
 from lite_forms.generators import error_page, form_page
 from lite_forms.helpers import conditional
 from lite_forms.views import SingleFormView
 
+from caseworker.advice.services import get_advice_tab_context
 from caseworker.cases.constants import CaseType
 from caseworker.cases.forms.additional_contacts import add_additional_contact_form
 from caseworker.cases.forms.assign_users import assign_case_officer_form, assign_user_and_work_queue, users_team_queues
@@ -50,18 +55,68 @@ from caseworker.cases.services import (
     get_blocking_flags,
 )
 from caseworker.compliance.services import get_compliance_licences
+from caseworker.core.objects import Tab
 from caseworker.core.services import get_status_properties, get_permissible_statuses
 from caseworker.core.constants import Permission
 from caseworker.external_data.services import search_denials
 from caseworker.queues.services import put_queue_single_case_assignment, get_queue
 from caseworker.teams.services import get_teams
-from caseworker.users.services import get_gov_user_from_form_selection
+from caseworker.users.services import (
+    get_gov_user,
+    get_gov_user_from_form_selection,
+)
 
 
 logger = getLogger(__name__)
 
 
-class CaseDetail(CaseView):
+class CaseTabsMixin:
+    def get_tabs(self):
+        tabs = [
+            Tabs.DETAILS,
+            Tabs.ADDITIONAL_CONTACTS,
+            Tabs.ECJU_QUERIES,
+            Tabs.DOCUMENTS,
+        ]
+
+        return tabs
+
+    def get_standard_application_tabs(self):
+        tabs = self.get_tabs()
+        tabs.insert(1, Tabs.LICENCES)
+        tabs.append(self.get_notes_and_timelines_tab())
+        tabs.append(self.get_advice_tab())
+        tabs.append(self.get_assessment_tab())
+
+        return tabs
+
+    def get_advice_tab(self):
+        data, _ = get_gov_user(self.request, str(self.request.session["lite_api_user_id"]))
+        return Tab(
+            "advice",
+            "Recommendations and decision",
+            get_advice_tab_context(self.case, data["user"], str(self.kwargs["queue_pk"]))["url"],
+            has_template=False,
+        )
+
+    def get_assessment_tab(self):
+        return Tab(
+            "assessment",
+            "Product Assessment",
+            "cases:tau:home",
+            has_template=False,
+        )
+
+    def get_notes_and_timelines_tab(self):
+        return Tab(
+            "activities",
+            CasePage.Tabs.CASE_NOTES_AND_TIMELINE,
+            "cases:activities:notes-and-timeline",
+            has_template=False,
+        )
+
+
+class CaseDetail(CaseTabsMixin, CaseView):
     def get_advice_additional_context(self):
         status_props, _ = get_status_properties(self.request, self.case.data["status"]["key"])
         current_advice_level = ["user"]
@@ -155,11 +210,7 @@ class CaseDetail(CaseView):
         self.additional_context = self.get_advice_additional_context()
 
     def get_standard_application(self):
-        self.tabs = self.get_tabs()
-        self.tabs.insert(1, Tabs.LICENCES)
-        self.tabs.append(self.get_notes_and_timelines_tab())
-        self.tabs.append(self.get_advice_tab())
-        self.tabs.append(self.get_assessment_tab())
+        self.tabs = self.get_standard_application_tabs()
         self.slices = [
             Slices.GOODS,
             Slices.DESTINATIONS,

--- a/caseworker/tau/templates/tau/clear_assessments.html
+++ b/caseworker/tau/templates/tau/clear_assessments.html
@@ -3,7 +3,13 @@
 {% load static custom_tags crispy_forms_tags advice_tags tau_tags %}
 
 {% block header_tabs %}
-	{% include "includes/case-tabs.html" with case=case queue=queue selected_tab="assessment" %}
+	<div id="tab-bar" class="app-case-tab-bar">
+		<div class="govuk-width-container lite-tabs__container">
+			<div class="lite-tabs ">
+				{% include "includes/case-tabs.html" %}
+			</div>
+		</div>
+	</div>
 {% endblock %}
 
 {% block full_width %}

--- a/caseworker/tau/templates/tau/home.html
+++ b/caseworker/tau/templates/tau/home.html
@@ -3,7 +3,13 @@
 {% load static custom_tags crispy_forms_tags advice_tags tau_tags %}
 
 {% block header_tabs %}
-	{% include "includes/case-tabs.html" with case=case queue=queue selected_tab="assessment" %}
+    <div id="tab-bar" class="app-case-tab-bar">
+        <div class="govuk-width-container lite-tabs__container">
+            <div class="lite-tabs ">
+                {% include "includes/case-tabs.html" %}
+            </div>
+        </div>
+    </div>
 {% endblock %}
 
 {% block full_width %}

--- a/caseworker/tau/views.py
+++ b/caseworker/tau/views.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 
 from caseworker.advice.services import move_case_forward
 from caseworker.cases.services import get_case
+from caseworker.cases.views.main import CaseTabsMixin
 from core.auth.views import LoginRequiredMixin
 from caseworker.core.services import get_control_list_entries
 from caseworker.cases.services import post_review_good
@@ -21,7 +22,7 @@ from .utils import get_cle_suggestions_json
 TAU_ALIAS = "TAU"
 
 
-class TAUMixin:
+class TAUMixin(CaseTabsMixin):
     """Mixin containing some useful functions used in TAU views."""
 
     @cached_property
@@ -107,6 +108,18 @@ class TAUMixin:
     def caseworker(self):
         data, _ = get_gov_user(self.request, self.caseworker_id)
         return data["user"]
+
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+
+        context.update(
+            {
+                "tabs": self.get_standard_application_tabs(),
+                "current_tab": "cases:tau:home",
+            }
+        )
+
+        return context
 
 
 class TAUHome(LoginRequiredMixin, TAUMixin, FormView):

--- a/caseworker/templates/includes/case-tabs.html
+++ b/caseworker/templates/includes/case-tabs.html
@@ -1,30 +1,24 @@
-<div id="tab-bar" class="app-case-tab-bar">
-    <div class="govuk-width-container lite-tabs__container">
-        <div class="lite-tabs ">
-            <a id="tab-details" href="{% url 'cases:case' queue.id case.id 'details' %}" class="lite-tabs__tab{% if selected_tab == "details" %} lite-tabs__tab--selected{% endif %}">
-                Details
+<div class="lite-tabs {% for tab in tabs %}{% for tab in tab.children %}{% if tab.url == current_tab %}lite-tabs__container--fade{% endif %}{% endfor %}{% endfor %}">
+    {% for tab in tabs %}
+        {% if tab.url %}
+            <a id="{{ tab.id }}" href="{% if tab.has_template %}{% url 'cases:case' queue.id case.id tab.url %}{% else %}{% url tab.url queue.id case.id %}{% endif %}{{ CURRENT_PATH_ONLY_PARAMS }}" class="lite-tabs__tab {% if tab.url == current_tab %}lite-tabs__tab--selected{% endif %}">
+                {{ tab.name }}
+                {% if tab.count %}
+                    <span class="lite-tabs__tab-notification" aria-hidden="true">{{ tab.count }}</span>
+                    <strong class="govuk-visually-hidden lite-tabs__tab-notification">(Requires attention {{ tab.count }} items)</strong>
+                {% endif %}
             </a>
-            <a id="tab-licences" href="{% url 'cases:case' queue.id case.id 'licences' %}" class="lite-tabs__tab{% if selected_tab == "licenses" %} lite-tabs__tab--selected{% endif %}">
-                Licences
+        {% else %}
+            <a id="{{ tab.id }}" class="lite-tabs__tab-parent {% for tab in tab.children %}{% if tab.url == current_tab %}lite-tabs__tab-parent--selected{% endif %}{% endfor %}">
+                {{ tab.name }}
             </a>
-            <a id="tab-additional-contacts" href="{% url 'cases:case' queue.id case.id 'contacts' %}" class="lite-tabs__tab{% if selected_tab == "additional-contacts" %} lite-tabs__tab--selected{% endif %}">
-                Contacts
-            </a>
-            <a id="tab-ecju-queries" href="{% url 'cases:case' queue.id case.id 'ecju-queries' %}" class="lite-tabs__tab{% if selected_tab == "ecju-queries" %} lite-tabs__tab--selected{% endif %}">
-                Queries
-            </a>
-            <a id="tab-documents" href="{% url 'cases:case' queue.id case.id 'documents' %}" class="lite-tabs__tab{% if selected_tab == "documents" %} lite-tabs__tab--selected{% endif %}">
-                Documents
-            </a>
-            <a id="tab-activities" href="{% url 'cases:activities:notes-and-timeline' queue.id case.id %}" class="lite-tabs__tab{% if selected_tab == "activities" %} lite-tabs__tab--selected{% endif %}">
-                Notes and timeline
-            </a>
-            <a id="tab-advice" href="{% url 'cases:case' queue.id case.id 'advice' %}" class="lite-tabs__tab{% if selected_tab == "advice" %} lite-tabs__tab--selected{% endif %}">
-                Recommendations and decision
-            </a>
-            <a id="tab-assessment" href="{% url 'cases:tau:home' queue.id case.id %}" class="lite-tabs__tab{% if selected_tab == "assessment" %} lite-tabs__tab--selected{% endif %}">
-                Product Assessment
-            </a>
-        </div>
-    </div>
+            <div class="lite-tabs__tab-group {% for tab in tab.children %}{% if tab.url == current_tab %}lite-tabs__tab-group--visible{% endif %}{% endfor %}" id="{{ tab.id }}-children">
+                {% for tab in tab.children %}
+                    <a id="{{ tab.id }}" href="{% url 'cases:case' queue.id case.id tab.url %}{{ CURRENT_PATH_ONLY_PARAMS }}" class="lite-tabs__tab {% if tab.url == current_tab %}lite-tabs__tab--selected{% endif %}">
+                        {{ tab.name }}
+                    </a>
+                {% endfor %}
+            </div>
+        {% endif %}
+    {% endfor %}
 </div>

--- a/caseworker/templates/layouts/case.html
+++ b/caseworker/templates/layouts/case.html
@@ -120,29 +120,7 @@
 			<div id="tab-bar" class="app-case-tab-bar">
 				<div class="govuk-width-container lite-tabs__container">
 					<div class="lite-tabs {% for tab in tabs %}{% for tab in tab.children %}{% if tab.url == current_tab %}lite-tabs__container--fade{% endif %}{% endfor %}{% endfor %}">
-
-						{% for tab in tabs %}
-							{% if tab.url %}
-								<a id="{{ tab.id }}" href="{% if tab.has_template %}{% url 'cases:case' queue.id case.id tab.url %}{% else %}{% url tab.url queue.id case.id %}{% endif %}{{ CURRENT_PATH_ONLY_PARAMS }}" class="lite-tabs__tab {% if tab.url == current_tab %}lite-tabs__tab--selected{% endif %}">
-									{{ tab.name }} 
-									{% if tab.count %}
-										<span class="lite-tabs__tab-notification" aria-hidden="true">{{ tab.count }}</span>
-										<strong class="govuk-visually-hidden lite-tabs__tab-notification">(Requires attention {{ tab.count }} items)</strong>
-									{% endif %}
-								</a>
-							{% else %}
-								<a id="{{ tab.id }}" class="lite-tabs__tab-parent {% for tab in tab.children %}{% if tab.url == current_tab %}lite-tabs__tab-parent--selected{% endif %}{% endfor %}">
-									{{ tab.name }}
-								</a>
-								<div class="lite-tabs__tab-group {% for tab in tab.children %}{% if tab.url == current_tab %}lite-tabs__tab-group--visible{% endif %}{% endfor %}" id="{{ tab.id }}-children">
-									{% for tab in tab.children %}
-										<a id="{{ tab.id }}" href="{% url 'cases:case' queue.id case.id tab.url %}{{ CURRENT_PATH_ONLY_PARAMS }}" class="lite-tabs__tab {% if tab.url == current_tab %}lite-tabs__tab--selected{% endif %}">
-											{{ tab.name }}
-										</a>
-									{% endfor %}
-								</div>
-							{% endif %}
-						{% endfor %}
+						{% include "includes/case-tabs.html" %}
 					</div>
 					<div class="lite-tabs__controls">
 						<div class="lite-buttons-row">


### PR DESCRIPTION
This fixes the case where the incorrect URL was being used for the product assessment page depending on what case page you were currently on.

The issue was that the main case details page had additional logic to decide what URLs were used when rendering the tabs, whereas the new pages we've created (that are separate from the original case details) used much simpler logic to display the tabs.

The old tabs would change the tab URL depending on some additional logic being run whereas the tabs for the new pages assumed that the URLs were always static for any given tab.

To solve this I've reused the logic and tabs template across all of the pages that display the case tabs.