### PR TITLE
Ltd 2803 onward exporter ultimate end user

### DIFF
--- a/exporter/applications/helpers/task_lists.py
+++ b/exporter/applications/helpers/task_lists.py
@@ -139,6 +139,8 @@ def get_application_task_list(request, application, errors=None):
 
     if not application_type == OPEN:
         context["goods"] = get_application_goods(request, application["id"])
-        context["ultimate_end_users_required"] = any(good["is_good_incorporated"] for good in context["goods"])
+        context["ultimate_end_users_required"] = any(
+            good.get("is_onward_exported") or good.get("is_good_incorporated") for good in context["goods"]
+        )
 
     return render(request, "applications/task-list.html", context)

--- a/exporter/applications/helpers/task_lists.py
+++ b/exporter/applications/helpers/task_lists.py
@@ -139,6 +139,6 @@ def get_application_task_list(request, application, errors=None):
 
     if not application_type == OPEN:
         context["goods"] = get_application_goods(request, application["id"])
-        context["ultimate_end_users_required"] = True in [good["is_good_incorporated"] for good in context["goods"]]
+        context["ultimate_end_users_required"] = any(good["is_good_incorporated"] for good in context["goods"])
 
     return render(request, "applications/task-list.html", context)

--- a/unit_tests/exporter/applications/views/test_application_task_list.py
+++ b/unit_tests/exporter/applications/views/test_application_task_list.py
@@ -1,0 +1,110 @@
+import pytest
+
+from pytest_django.asserts import assertTemplateUsed
+
+from django.urls import reverse
+
+from exporter.core.objects import Application
+
+
+@pytest.fixture
+def application(data_standard_case):
+    return data_standard_case["case"]
+
+
+@pytest.fixture
+def task_list_url(application):
+    return reverse(
+        "applications:task_list",
+        kwargs={
+            "pk": application["id"],
+        },
+    )
+
+
+@pytest.fixture
+def mock_application_documents_get(application, requests_mock):
+    return requests_mock.get(
+        f"/applications/{application['id']}/documents/",
+        json={"documents": []},
+    )
+
+
+@pytest.fixture
+def mock_case_notes_get(application, requests_mock):
+    return requests_mock.get(
+        f"/cases/{application['id']}/case-notes/",
+        json={"case_notes": []},
+    )
+
+
+@pytest.fixture
+def mock_goods_get(application, requests_mock):
+    return requests_mock.get(
+        f"/applications/{application['id']}/goods/",
+        json={"goods": []},
+    )
+
+
+def test_application_task_list_status_code(
+    authorized_client,
+    task_list_url,
+    mock_application_get,
+    mock_application_documents_get,
+    mock_case_notes_get,
+    mock_goods_get,
+):
+    response = authorized_client.get(task_list_url)
+    assert response.status_code == 200
+
+
+def test_application_task_list_template_rendered(
+    authorized_client,
+    task_list_url,
+    mock_application_get,
+    mock_application_documents_get,
+    mock_case_notes_get,
+    mock_goods_get,
+):
+    response = authorized_client.get(task_list_url)
+    assertTemplateUsed(response, "applications/task-list.html")
+
+
+@pytest.mark.parametrize(
+    "goods, ultimate_end_users_required",
+    (
+        ([], False),
+        (
+            [{"is_good_incorporated": False}],
+            False,
+        ),
+        (
+            [{"is_good_incorporated": True}],
+            True,
+        ),
+        (
+            [
+                {"is_good_incorporated": True},
+                {"is_good_incorporated": False},
+            ],
+            True,
+        ),
+    ),
+)
+def test_application_task_list_ultimate_end_users_required(
+    goods,
+    ultimate_end_users_required,
+    authorized_client,
+    task_list_url,
+    application,
+    mock_application_get,
+    mock_application_documents_get,
+    mock_case_notes_get,
+    requests_mock,
+):
+    requests_mock.get(
+        f"/applications/{application['id']}/goods/",
+        json={"goods": goods},
+    )
+    response = authorized_client.get(task_list_url)
+    assert response.context["ultimate_end_users_required"] == ultimate_end_users_required

--- a/unit_tests/exporter/applications/views/test_application_task_list.py
+++ b/unit_tests/exporter/applications/views/test_application_task_list.py
@@ -89,6 +89,33 @@ def test_application_task_list_template_rendered(
             ],
             True,
         ),
+        (
+            [{"is_onward_exported": False}],
+            False,
+        ),
+        (
+            [{"is_onward_exported": True}],
+            True,
+        ),
+        (
+            [
+                {"is_onward_exported": True},
+                {"is_onward_exported": False},
+            ],
+            True,
+        ),
+        (
+            [
+                {"is_onward_exported": True, "is_good_incorporated": False},
+            ],
+            True,
+        ),
+        (
+            [
+                {"is_onward_exported": False, "is_good_incorporated": True},
+            ],
+            True,
+        ),
     ),
 )
 def test_application_task_list_ultimate_end_users_required(


### PR DESCRIPTION
The ultimate recipients task should be displayed whenever the user selects that their product will be onward exported

This is different from the original logic which used to just use the `is_good_incorporated` flag

This now checks the `is_onward_exported` flag as well but also retains the previous logic in cases where there are products that have been or are still made using just the original flag