### PR TITLE
Use correct document id when displaying organisation documents intern…

### DIFF
--- a/caseworker/cases/helpers/summaries.py
+++ b/caseworker/cases/helpers/summaries.py
@@ -35,7 +35,7 @@ def _get_document_url(queue_pk, application_pk, document):
 
 def organisation_document_formatter_factory(queue_pk, application_pk):
     def organisation_document_formatter(document):
-        url = _get_document_url(queue_pk, application_pk, document)
+        url = _get_document_url(queue_pk, application_pk, document["document"])
         return document_formatter(document["document"], url)
 
     return organisation_document_formatter

--- a/caseworker/cases/views/goods.py
+++ b/caseworker/cases/views/goods.py
@@ -2,6 +2,8 @@ from collections import OrderedDict
 
 from formtools.wizard.views import SessionWizardView
 
+from core.constants import OrganisationDocumentType
+
 from caseworker.cases.forms.review_goods import review_goods_form, ExportControlCharacteristicsForm
 from caseworker.cases.helpers.advice import get_param_goods, flatten_goods_data
 from caseworker.cases.helpers.summaries import get_good_on_application_summary
@@ -235,7 +237,7 @@ class GoodDetails(LoginRequiredMixin, FormView):
 
         organisation_documents = {item["document_type"]: item for item in case.organisation["documents"]}
 
-        rfd_certificate = organisation_documents.get("rfd-certificate")
+        rfd_certificate = organisation_documents.get(OrganisationDocumentType.RFD_CERTIFICATE)
         is_user_rfd = bool(rfd_certificate) and not rfd_certificate["is_expired"]
 
         product_summary = get_good_on_application_summary(

--- a/caseworker/tau/views.py
+++ b/caseworker/tau/views.py
@@ -7,6 +7,7 @@ from django.utils.functional import cached_property
 from django.urls import reverse
 
 from core.auth.views import LoginRequiredMixin
+from core.constants import OrganisationDocumentType
 
 from caseworker.advice.services import move_case_forward
 from caseworker.cases.services import get_case
@@ -222,7 +223,7 @@ class TAUEdit(LoginRequiredMixin, TAUMixin, FormView):
         organisation_documents = {
             document["document_type"]: document for document in self.organisation_documents.values()
         }
-        rfd_certificate = organisation_documents.get("rfd-certificate")
+        rfd_certificate = organisation_documents.get(OrganisationDocumentType.RFD_CERTIFICATE)
         is_user_rfd = bool(rfd_certificate) and not rfd_certificate["is_expired"]
 
         summary = get_good_on_application_tau_summary(

--- a/core/constants.py
+++ b/core/constants.py
@@ -66,6 +66,10 @@ class CaseStatusEnum:
         return [getattr(cls, param) for param in dir(cls) if is_all_upper.match(param)]
 
 
+class OrganisationDocumentType:
+    RFD_CERTIFICATE = "rfd-certificate"
+
+
 class FirearmsActDocumentType:
     SECTION_1 = "section-one-certificate"
     SECTION_2 = "section-two-certificate"

--- a/core/summaries/formatters.py
+++ b/core/summaries/formatters.py
@@ -175,6 +175,8 @@ def to_date(val):
 
 def date_formatter(format=None):
     def _date_formatter(val):
+        # if not val:
+        #     return None
         return date_format(to_date(val), format)
 
     return _date_formatter
@@ -257,7 +259,6 @@ FIREARM_VALUE_FORMATTERS = {
         }
     ),
     "section-5-certificate-document": organisation_document_formatter,
-    "section-5-certificate-date-of-expiry": date_formatter("j F Y"),
     "section-5-certificate-missing": just("I do not have a section 5 letter of authority"),
     "firearms-act-1968-section": mapping_formatter(
         {

--- a/core/summaries/reducers.py
+++ b/core/summaries/reducers.py
@@ -140,18 +140,19 @@ def firearms_act_section5_reducer(firearm_details, organisation_documents):
                 ),
             )
         else:
+            section_5_certificate_document = organisation_documents[FirearmsActDocumentType.SECTION_5]
             summary += (
                 (
                     "section-5-certificate-document",
-                    organisation_documents[FirearmsActDocumentType.SECTION_5],
+                    section_5_certificate_document,
                 ),
                 (
                     "section-5-certificate-reference-number",
-                    firearm_details["section_certificate_number"],
+                    section_5_certificate_document["reference_code"],
                 ),
                 (
                     "section-5-certificate-date-of-expiry",
-                    firearm_details["section_certificate_date_of_expiry"],
+                    section_5_certificate_document["expiry_date"],
                 ),
             )
 

--- a/core/summaries/reducers.py
+++ b/core/summaries/reducers.py
@@ -1,10 +1,11 @@
 from decimal import Decimal
 
 from core.constants import (
+    COMPONENT_DETAILS_MAP,
     FirearmsActDocumentType,
     FirearmsActSections,
+    OrganisationDocumentType,
     SerialChoices,
-    COMPONENT_DETAILS_MAP,
 )
 from core.goods.helpers import is_product_category_made_before_1938
 
@@ -268,10 +269,10 @@ def firearm_reducer(good, is_user_rfd, organisation_documents):
 
 
 def rfd_reducer(is_user_rfd, organisation_documents):
-    if not is_user_rfd or not organisation_documents.get("rfd-certificate"):
+    if not is_user_rfd or not organisation_documents.get(OrganisationDocumentType.RFD_CERTIFICATE):
         return ()
 
-    rfd_certificate_document = organisation_documents["rfd-certificate"]
+    rfd_certificate_document = organisation_documents[OrganisationDocumentType.RFD_CERTIFICATE]
 
     summary = (
         (

--- a/exporter/applications/templatetags/additional_documents.py
+++ b/exporter/applications/templatetags/additional_documents.py
@@ -1,7 +1,9 @@
 from django import template
 
-from core.constants import FirearmsActDocumentType
-from exporter.core.constants import DocumentType
+from core.constants import (
+    FirearmsActDocumentType,
+    OrganisationDocumentType,
+)
 
 
 register = template.Library()
@@ -10,7 +12,7 @@ register = template.Library()
 @register.filter(name="is_system_document")
 def is_system_document(document):
     return document.get("document_type") in [
-        DocumentType.RFD_CERTIFICATE,
+        OrganisationDocumentType.RFD_CERTIFICATE,
         FirearmsActDocumentType.SECTION_1,
         FirearmsActDocumentType.SECTION_2,
         FirearmsActDocumentType.SECTION_5,

--- a/exporter/applications/views/goods/add_good_firearm/views/actions.py
+++ b/exporter/applications/views/goods/add_good_firearm/views/actions.py
@@ -2,7 +2,10 @@ from http import HTTPStatus
 
 from django.utils.functional import cached_property
 
-from core.constants import FirearmsActDocumentType
+from core.constants import (
+    FirearmsActDocumentType,
+    OrganisationDocumentType,
+)
 from core.decorators import expect_status
 
 from exporter.applications.services import (
@@ -13,7 +16,6 @@ from exporter.applications.services import (
     post_additional_document,
     post_application_document,
 )
-from exporter.core.constants import DocumentType
 from exporter.core.forms import CurrentFile
 from exporter.core.helpers import (
     get_document_data,
@@ -354,11 +356,11 @@ class RfdCertificateAction:
         rfd_certificate_payload = {
             **get_document_data(cert_file),
             "description": "Registered firearm dealer certificate",
-            "document_type": DocumentType.RFD_CERTIFICATE,
+            "document_type": OrganisationDocumentType.RFD_CERTIFICATE,
             "document_on_organisation": {
                 "expiry_date": expiry_date.isoformat(),
                 "reference_code": reference_code,
-                "document_type": DocumentType.RFD_CERTIFICATE,
+                "document_type": OrganisationDocumentType.RFD_CERTIFICATE,
             },
         }
         return rfd_certificate_payload
@@ -389,7 +391,7 @@ class RfdCertificateAction:
         rfd_certificate_payload = {
             "expiry_date": expiry_date.isoformat(),
             "reference_code": reference_code,
-            "document_type": DocumentType.RFD_CERTIFICATE,
+            "document_type": OrganisationDocumentType.RFD_CERTIFICATE,
         }
         return rfd_certificate_payload
 

--- a/exporter/applications/views/goods/add_good_firearm/views/add.py
+++ b/exporter/applications/views/goods/add_good_firearm/views/add.py
@@ -10,6 +10,7 @@ from core.auth.views import LoginRequiredMixin
 from core.constants import (
     FirearmsActDocumentType,
     FirearmsActSections,
+    OrganisationDocumentType,
 )
 from core.decorators import expect_status
 
@@ -17,7 +18,6 @@ from exporter.applications.services import (
     post_additional_document,
     post_firearm_good_on_application,
 )
-from exporter.core.constants import DocumentType
 from exporter.core.helpers import (
     get_document_data,
     get_rfd_certificate,
@@ -207,11 +207,11 @@ class AddGoodFirearm(
         rfd_certificate_payload = {
             **get_document_data(cert_file),
             "description": "Registered firearm dealer certificate",
-            "document_type": DocumentType.RFD_CERTIFICATE,
+            "document_type": OrganisationDocumentType.RFD_CERTIFICATE,
             "document_on_organisation": {
                 "expiry_date": expiry_date.isoformat(),
                 "reference_code": reference_code,
-                "document_type": DocumentType.RFD_CERTIFICATE,
+                "document_type": OrganisationDocumentType.RFD_CERTIFICATE,
             },
         }
         return rfd_certificate_payload
@@ -294,7 +294,7 @@ class AddGoodFirearm(
                 "s3_key": document["s3_key"],
                 "safe": document["safe"],
                 "size": document["size"],
-                "document_type": DocumentType.RFD_CERTIFICATE,
+                "document_type": OrganisationDocumentType.RFD_CERTIFICATE,
                 "description": "Registered firearm dealer certificate",
             },
         )

--- a/exporter/applications/views/goods/add_good_firearm/views/attach.py
+++ b/exporter/applications/views/goods/add_good_firearm/views/attach.py
@@ -13,6 +13,7 @@ from core.auth.views import LoginRequiredMixin
 from core.constants import (
     FirearmsActDocumentType,
     FirearmsActSections,
+    OrganisationDocumentType,
 )
 from core.decorators import expect_status
 
@@ -20,7 +21,6 @@ from exporter.applications.services import (
     post_additional_document,
     post_firearm_good_on_application,
 )
-from exporter.core.constants import DocumentType
 from exporter.core.helpers import (
     get_rfd_certificate,
     has_valid_rfd_certificate as has_valid_organisation_rfd_certificate,
@@ -252,7 +252,7 @@ class AttachFirearmToApplication(
                 "s3_key": document["s3_key"],
                 "safe": document["safe"],
                 "size": document["size"],
-                "document_type": DocumentType.RFD_CERTIFICATE,
+                "document_type": OrganisationDocumentType.RFD_CERTIFICATE,
                 "description": "Registered firearm dealer certificate",
             },
         )

--- a/exporter/applications/views/goods/add_good_firearm/views/conditionals.py
+++ b/exporter/applications/views/goods/add_good_firearm/views/conditionals.py
@@ -1,10 +1,9 @@
 from core.constants import (
     FirearmsActSections,
+    OrganisationDocumentType,
     SerialChoices,
 )
 from core.goods.helpers import is_product_category_made_before_1938 as _is_product_category_made_before_1938
-
-from exporter.core.constants import DocumentType
 from exporter.core.helpers import (
     has_organisation_firearm_act_document as _has_organisation_firearm_act_document,
     has_valid_rfd_certificate as has_valid_organisation_rfd_certificate,
@@ -28,7 +27,7 @@ def has_application_rfd_certificate(wizard):
         return False
 
     for additional_document in additional_documents:
-        if additional_document.get("document_type") == DocumentType.RFD_CERTIFICATE:
+        if additional_document.get("document_type") == OrganisationDocumentType.RFD_CERTIFICATE:
             return True
 
     return False

--- a/exporter/applications/views/goods/goods.py
+++ b/exporter/applications/views/goods/goods.py
@@ -16,6 +16,7 @@ from core.auth.views import LoginRequiredMixin
 from core.constants import (
     FirearmsActDocumentType,
     FirearmsActSections,
+    OrganisationDocumentType,
     ProductCategories,
 )
 from core.helpers import convert_dict_to_query_params
@@ -230,7 +231,7 @@ class RegisteredFirearmDealersMixin:
             "document_on_organisation": {
                 "expiry_date": format_date(self.request.POST, "expiry_date_"),
                 "reference_code": self.request.POST["reference_code"],
-                "document_type": constants.DocumentType.RFD_CERTIFICATE,
+                "document_type": OrganisationDocumentType.RFD_CERTIFICATE,
             },
         }
 
@@ -469,7 +470,7 @@ class AddGood(LoginRequiredMixin, BaseSessionWizardView):
                 "document_on_organisation": {
                     "expiry_date": format_date(all_data, "expiry_date_"),
                     "reference_code": all_data["reference_code"],
-                    "document_type": constants.DocumentType.RFD_CERTIFICATE,
+                    "document_type": OrganisationDocumentType.RFD_CERTIFICATE,
                 },
             }
 
@@ -971,7 +972,7 @@ class AddGoodToApplication(SectionDocumentMixin, LoginRequiredMixin, BaseSession
                 "document_on_organisation": {
                     "expiry_date": format_date(all_data, "expiry_date_"),
                     "reference_code": all_data["reference_code"],
-                    "document_type": constants.DocumentType.RFD_CERTIFICATE,
+                    "document_type": OrganisationDocumentType.RFD_CERTIFICATE,
                 },
             }
 

--- a/exporter/core/constants.py
+++ b/exporter/core/constants.py
@@ -225,10 +225,6 @@ class PartyDocumentType:
     END_USER_EC3_DOCUMENT = "end_user_ec3_document"
 
 
-class DocumentType:
-    RFD_CERTIFICATE = "rfd-certificate"
-
-
 class ProductSecurityFeatures:
     TITLE = "Does the product include security features to protect information?"
     SECURITY_FEATURE_DETAILS = "Provide details of the information security features"

--- a/exporter/core/helpers.py
+++ b/exporter/core/helpers.py
@@ -9,7 +9,10 @@ from django.template.defaultfilters import safe
 from django.templatetags.tz import localtime
 from django.utils.safestring import mark_safe
 
-from core.constants import ProductCategories
+from core.constants import (
+    OrganisationDocumentType,
+    ProductCategories,
+)
 
 from exporter.core import decorators
 from exporter.core import constants
@@ -250,7 +253,7 @@ def get_organisation_documents(application):
 
 def get_rfd_certificate(application):
     documents = get_organisation_documents(application)
-    return documents.get(constants.DocumentType.RFD_CERTIFICATE)
+    return documents.get(OrganisationDocumentType.RFD_CERTIFICATE)
 
 
 def is_end_user_document_available(wizard):
@@ -304,7 +307,7 @@ def get_user_organisation_documents(organisation):
 
 def get_organisation_rfd_certificate(organisation):
     documents = get_user_organisation_documents(organisation)
-    return documents.get(constants.DocumentType.RFD_CERTIFICATE)
+    return documents.get(OrganisationDocumentType.RFD_CERTIFICATE)
 
 
 def has_valid_organisation_rfd_certificate(organisation):

--- a/exporter/organisation/views.py
+++ b/exporter/organisation/views.py
@@ -3,16 +3,19 @@ from django.shortcuts import render
 from django.urls import reverse, reverse_lazy
 from django.views.generic import FormView, TemplateView, RedirectView
 
-from exporter.core.constants import DocumentType, Permissions
-from exporter.core.objects import Tab
-from exporter.core.services import get_organisation
 from lite_content.lite_exporter_frontend.organisation import Tabs
 from lite_forms.helpers import conditional
+
+from core.auth.views import LoginRequiredMixin
+from core.constants import OrganisationDocumentType
+from core.file_handler import s3_client
+
+from exporter.core.constants import Permissions
+from exporter.core.objects import Tab
+from exporter.core.services import get_organisation
 from exporter.organisation.roles.services import get_user_permissions
 from exporter.organisation import forms
 from exporter.organisation.services import post_document_on_organisation, get_document_on_organisation
-from core.auth.views import LoginRequiredMixin
-from core.file_handler import s3_client
 
 
 class OrganisationView(TemplateView):
@@ -100,7 +103,7 @@ class UploadFirearmsCertificate(AbstractOrganisationUpload):
     template_name = "core/form.html"
     form_class = forms.UploadFirearmsCertificateForm
     success_url = reverse_lazy("organisation:details")
-    document_type = DocumentType.RFD_CERTIFICATE
+    document_type = OrganisationDocumentType.RFD_CERTIFICATE
 
     def get_context_data(self, *args, **kwargs):
         return super().get_context_data(

--- a/unit_tests/caseworker/cases/helpers/test_summaries.py
+++ b/unit_tests/caseworker/cases/helpers/test_summaries.py
@@ -75,6 +75,8 @@ def test_firearm_summary_with_section_5_and_rfd_certificates(data_standard_case)
                     "name": "Section 5 document",
                     "safe": True,
                 },
+                "reference_code": "section-certificate-number",
+                "expiry_date": "9 October 2030",
             },
             OrganisationDocumentType.RFD_CERTIFICATE: {
                 "document": {

--- a/unit_tests/caseworker/cases/helpers/test_summaries.py
+++ b/unit_tests/caseworker/cases/helpers/test_summaries.py
@@ -1,5 +1,10 @@
 import uuid
 
+from core.constants import (
+    FirearmsActDocumentType,
+    FirearmsActSections,
+    OrganisationDocumentType,
+)
 from caseworker.cases.helpers.summaries import (
     firearm_summary,
     firearm_on_application_summary,
@@ -40,6 +45,96 @@ def test_firearm_summary(data_standard_case, standard_firearm_expected_product_s
                 "Upload a document that shows what your product is designed to do",
             ),
         ),
+    )
+    assert product_summary == expected_summary
+
+
+def test_firearm_summary_with_section_5_and_rfd_certificates(data_standard_case):
+    is_user_rfd = True
+    good_on_application = data_standard_case["case"]["data"]["goods"][0]
+    good = good_on_application["good"]
+    good["firearm_details"].update(
+        {
+            "firearms_act_section": FirearmsActSections.SECTION_5,
+            "section_certificate_missing": False,
+            "section_certificate_number": "section-certificate-number",
+            "section_certificate_date_of_expiry": "2030-10-09",
+        }
+    )
+    queue_pk = uuid.uuid4()
+    application_pk = good_on_application["application"]
+    product_summary = firearm_summary(
+        good,
+        queue_pk,
+        application_pk,
+        is_user_rfd,
+        {
+            FirearmsActDocumentType.SECTION_5: {
+                "document": {
+                    "id": "section-5-id",
+                    "name": "Section 5 document",
+                    "safe": True,
+                },
+            },
+            OrganisationDocumentType.RFD_CERTIFICATE: {
+                "document": {
+                    "id": "rfd-certificate-id",
+                    "name": "RFD certificate",
+                    "safe": True,
+                },
+                "reference_code": "REF123",
+                "expiry_date": "31 May 2025",
+            },
+        },
+    )
+
+    expected_summary = (
+        ("firearm-type", "Firearms", "Select the type of firearm product"),
+        ("firearm-category", "Non automatic shotgun, Non automatic rim-fired handgun", "Firearm category"),
+        ("name", "p1", "Give the product a descriptive name"),
+        ("is-good-controlled", "Yes", "Do you know the product's control list entry?"),
+        ("control-list-entries", "ML1a, ML22b", "Enter the control list entry"),
+        ("is-pv-graded", "Yes", "Does the product have a government security grading or classification?"),
+        ("pv-grading-prefix", "NATO", "Enter a prefix (optional)"),
+        ("pv-grading-grading", "Official", "What is the security grading or classification?"),
+        ("pv-grading-suffix", "SUFFIX", "Enter a suffix (optional)"),
+        ("pv-grading-issuing-authority", "Government entity", "Name and address of the issuing authority"),
+        ("pv-grading-details-reference", "GR123", "Reference"),
+        ("pv-grading-details-date-of-issue", "20 February 2020", "Date of issue"),
+        ("calibre", "0.25", "What is the calibre of the product?"),
+        ("is-replica", "No", "Is the product a replica firearm?"),
+        ("is-registered-firearms-dealer", "Yes", "Are you a registered firearms dealer?"),
+        (
+            "rfd-certificate-document",
+            f'<a class="govuk-link govuk-link--no-visited-state" href="/queues/{queue_pk}/cases/{application_pk}/documents/rfd-certificate-id/" target="_blank">RFD certificate</a>',
+            "Upload a registered firearms dealer certificate",
+        ),
+        ("rfd-certificate-reference-number", "REF123", "Certificate reference number"),
+        ("rfd-certificate-date-of-expiry", "31 May 2025", "Certificate date of expiry"),
+        (
+            "is-covered-by-firearm-act-section-five",
+            "Don't know",
+            "Is the product covered by section 5 of the Firearms Act 1968?",
+        ),
+        (
+            "section-5-certificate-document",
+            f'<a class="govuk-link govuk-link--no-visited-state" href="/queues/{queue_pk}/cases/{application_pk}/documents/section-5-id/" target="_blank">Section 5 document</a>',
+            "Upload your section 5 letter of authority",
+        ),
+        ("section-5-certificate-reference-number", "section-certificate-number", "Certificate reference number"),
+        ("section-5-certificate-date-of-expiry", "9 October 2030", "Certificate date of expiry"),
+        (
+            "has-product-document",
+            "Yes",
+            "Do you have a document that shows what your product is and what it’s " "designed to do?",
+        ),
+        ("is-document-sensitive", "No", "Is the document rated above Official-sensitive?"),
+        (
+            "product-document",
+            f'<a class="govuk-link govuk-link--no-visited-state" href="/queues/{queue_pk}/cases/{application_pk}/documents/6c48a2cc-1ed9-49a5-8ca7-df8af5fc2335/" target="_blank">data_sheet.pdf</a>',
+            "Upload a document that shows what your product is designed to do",
+        ),
+        ("product-document-description", "product data sheet", "Description (optional)"),
     )
     assert product_summary == expected_summary
 

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -3,6 +3,7 @@ import pytest
 import os
 
 from core import client
+from core.constants import OrganisationDocumentType
 
 
 @pytest.fixture(autouse=True)
@@ -1337,7 +1338,7 @@ def data_organisation():
         "documents": [
             {
                 "id": "b4a2da59-c0bc-4b6d-8ed9-4ca28ffbf65a",
-                "document_type": "rfd-certificate",
+                "document_type": OrganisationDocumentType.RFD_CERTIFICATE,
                 "expiry_date": expiry_date.strftime("%d %B %Y"),
                 "reference_code": "RFD123",
                 "is_expired": False,

--- a/unit_tests/core/summaries/test_reducers.py
+++ b/unit_tests/core/summaries/test_reducers.py
@@ -374,16 +374,23 @@ def test_is_replica_reducer(good, output):
             {
                 "firearms_act_section": "firearms_act_section5",
                 "section_certificate_missing": False,
-                "section_certificate_number": "section-certificate-number",
-                "section_certificate_date_of_expiry": "2030-10-09",
             },
             {
-                "section-five-certificate": "document",
+                "section-five-certificate": {
+                    "reference_code": "section-certificate-number",
+                    "expiry_date": "9 October 2030",
+                },
             },
             (
-                ("section-5-certificate-document", "document"),
+                (
+                    "section-5-certificate-document",
+                    {
+                        "reference_code": "section-certificate-number",
+                        "expiry_date": "9 October 2030",
+                    },
+                ),
                 ("section-5-certificate-reference-number", "section-certificate-number"),
-                ("section-5-certificate-date-of-expiry", "2030-10-09"),
+                ("section-5-certificate-date-of-expiry", "9 October 2030"),
             ),
         ),
     ),

--- a/unit_tests/core/summaries/test_reducers.py
+++ b/unit_tests/core/summaries/test_reducers.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from core.constants import (
     FirearmsActDocumentType,
     FirearmsActSections,
+    OrganisationDocumentType,
     SerialChoices,
 )
 from core.summaries.reducers import (
@@ -69,15 +70,21 @@ def test_firearm_reducer(is_user_rfd, mocker):
     organisation_documents = {}
     extra_result_values = ()
     if is_user_rfd:
-        organisation_documents["rfd-certificate"] = {
+        organisation_documents[OrganisationDocumentType.RFD_CERTIFICATE] = {
             "document": {},
             "reference_code": "12345",
             "expiry_date": "31 May 2025",
         }
         extra_result_values = (
-            ("rfd-certificate-document", organisation_documents["rfd-certificate"]),
-            ("rfd-certificate-reference-number", organisation_documents["rfd-certificate"]["reference_code"]),
-            ("rfd-certificate-date-of-expiry", organisation_documents["rfd-certificate"]["expiry_date"]),
+            ("rfd-certificate-document", organisation_documents[OrganisationDocumentType.RFD_CERTIFICATE]),
+            (
+                "rfd-certificate-reference-number",
+                organisation_documents[OrganisationDocumentType.RFD_CERTIFICATE]["reference_code"],
+            ),
+            (
+                "rfd-certificate-date-of-expiry",
+                organisation_documents[OrganisationDocumentType.RFD_CERTIFICATE]["expiry_date"],
+            ),
         )
     result = firearm_reducer(good, is_user_rfd, organisation_documents)
     assert result == (
@@ -193,7 +200,7 @@ def test_is_good_controlled_reducer(good, output):
         (
             True,
             {
-                "rfd-certificate": {
+                OrganisationDocumentType.RFD_CERTIFICATE: {
                     "document": {},
                     "reference_code": "12345",
                     "expiry_date": "31 May 2025",

--- a/unit_tests/exporter/applications/test_summaries.py
+++ b/unit_tests/exporter/applications/test_summaries.py
@@ -1,5 +1,7 @@
 import uuid
 
+from core.constants import OrganisationDocumentType
+
 from exporter.applications.summaries.firearm import (
     add_firearm_on_application_summary_edit_links,
     add_firearm_summary_edit_links,
@@ -137,7 +139,7 @@ def test_firearm_summary():
     }
     organisation_documents = {
         "section-five-certificate": section_5_document,
-        "rfd-certificate": rfd_document,
+        OrganisationDocumentType.RFD_CERTIFICATE: rfd_document,
     }
 
     assert firearm_summary(good, is_user_rfd, organisation_documents) == (

--- a/unit_tests/exporter/applications/test_summaries.py
+++ b/unit_tests/exporter/applications/test_summaries.py
@@ -126,6 +126,8 @@ def test_firearm_summary():
             "safe": True,
             "name": "section5.pdf",
         },
+        "reference_code": "section-certificate-number",
+        "expiry_date": "9 October 2020",
     }
     rfd_document = {
         "id": uuid.uuid4(),

--- a/unit_tests/exporter/applications/views/conftest.py
+++ b/unit_tests/exporter/applications/views/conftest.py
@@ -5,7 +5,10 @@ import uuid
 from django.urls import reverse
 
 from core import client
-from core.constants import SerialChoices
+from core.constants import (
+    OrganisationDocumentType,
+    SerialChoices,
+)
 
 
 @pytest.fixture
@@ -167,7 +170,7 @@ def rfd_certificate(organisation_id):
             "size": 3,
             "id": str(uuid.uuid4()),
         },
-        "document_type": "rfd-certificate",
+        "document_type": OrganisationDocumentType.RFD_CERTIFICATE,
         "is_expired": False,
         "organisation": organisation_id,
         "expiry_date": expiry_date.strftime("%d %B %Y"),
@@ -213,7 +216,7 @@ def application_with_organisation_and_application_rfd_document(data_standard_cas
     }
     case["additional_documents"] = [
         {
-            "document_type": "rfd-certificate",
+            "document_type": OrganisationDocumentType.RFD_CERTIFICATE,
         }
     ]
     matcher = requests_mock.get(url=app_url, json=case)

--- a/unit_tests/exporter/applications/views/test_add_good_firearm.py
+++ b/unit_tests/exporter/applications/views/test_add_good_firearm.py
@@ -8,6 +8,8 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 
 from core import client
+from core.constants import OrganisationDocumentType
+
 from exporter.core.constants import AddGoodFormSteps
 from exporter.core.helpers import decompose_date
 from exporter.applications.views.goods.add_good_firearm.views.constants import AddGoodFirearmSteps
@@ -501,7 +503,7 @@ def test_add_good_firearm_with_rfd_document_submission(
     application_doc_request = post_applications_document_matcher.last_request
     assert application_doc_request.json() == {
         "description": "Registered firearm dealer certificate",
-        "document_type": "rfd-certificate",
+        "document_type": OrganisationDocumentType.RFD_CERTIFICATE,
         "name": "rfd_certificate.txt",
         "s3_key": "rfd_certificate.txt.s3_key",
         "safe": True,
@@ -750,9 +752,9 @@ def test_add_good_firearm_without_rfd_document_submission_registered_firearms_de
         "document_on_organisation": {
             "expiry_date": expiry_date.isoformat(),
             "reference_code": "12345",
-            "document_type": "rfd-certificate",
+            "document_type": OrganisationDocumentType.RFD_CERTIFICATE,
         },
-        "document_type": "rfd-certificate",
+        "document_type": OrganisationDocumentType.RFD_CERTIFICATE,
         "name": file_name,
         "s3_key": file_name,
         "size": 0,
@@ -1259,7 +1261,7 @@ def test_add_good_firearm_with_rfd_document_submission_section_5(
 
     assert post_applications_document_matcher.request_history[0].json() == {
         "description": "Registered firearm dealer certificate",
-        "document_type": "rfd-certificate",
+        "document_type": OrganisationDocumentType.RFD_CERTIFICATE,
         "name": "rfd_certificate.txt",
         "s3_key": "rfd_certificate.txt.s3_key",
         "safe": True,
@@ -1382,7 +1384,7 @@ def test_add_good_firearm_with_rfd_document_submission_section_5_with_current_se
     application_doc_request = post_applications_document_matcher.last_request
     assert application_doc_request.json() == {
         "description": "Registered firearm dealer certificate",
-        "document_type": "rfd-certificate",
+        "document_type": OrganisationDocumentType.RFD_CERTIFICATE,
         "name": "rfd_certificate.txt",
         "s3_key": "rfd_certificate.txt.s3_key",
         "safe": True,

--- a/unit_tests/exporter/applications/views/test_add_good_to_application.py
+++ b/unit_tests/exporter/applications/views/test_add_good_to_application.py
@@ -2,14 +2,13 @@ import pytest
 import uuid
 
 from pytest_django.asserts import assertNotContains
-from unittest.mock import patch
 
-from django.core.files.storage import Storage
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import override_settings
 from django.urls import reverse
 
 from core import client
+from core.constants import OrganisationDocumentType
+
 from exporter.applications.views.goods import AddGoodToApplicationFormSteps
 from exporter.goods.forms import (
     AttachFirearmsDealerCertificateForm,
@@ -511,7 +510,7 @@ def test_add_good_to_application_api_submission_with_documents_preexisting(
         "document_on_organisation": {
             "expiry_date": "2030-01-01",
             "reference_code": "12345",
-            "document_type": "rfd-certificate",
+            "document_type": OrganisationDocumentType.RFD_CERTIFICATE,
         },
     }
 
@@ -654,7 +653,7 @@ def test_add_good_to_application_api_submission_with_deferred_serial_numbers_wit
         "document_on_organisation": {
             "expiry_date": "2030-01-01",
             "reference_code": "12345",
-            "document_type": "rfd-certificate",
+            "document_type": OrganisationDocumentType.RFD_CERTIFICATE,
         },
     }
 
@@ -686,7 +685,7 @@ def test_add_good_to_application_api_submission_without_documents_preexisting(
         "document_on_organisation": {
             "expiry_date": "2030-01-01",
             "reference_code": "12345",
-            "document_type": "rfd-certificate",
+            "document_type": OrganisationDocumentType.RFD_CERTIFICATE,
         },
     }
 

--- a/unit_tests/exporter/applications/views/test_attach_firearm_to_application.py
+++ b/unit_tests/exporter/applications/views/test_attach_firearm_to_application.py
@@ -7,6 +7,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 
 from core import client
+from core.constants import OrganisationDocumentType
 
 from exporter.applications.views.goods.add_good_firearm.views.constants import AttachFirearmToApplicationSteps
 from exporter.core.helpers import decompose_date
@@ -442,7 +443,7 @@ def test_attach_firearm_to_application_end_to_end_rfd_valid(
     assert post_application_document_matcher.called_once
     assert post_application_document_matcher.last_request.json() == {
         "description": "Registered firearm dealer certificate",
-        "document_type": "rfd-certificate",
+        "document_type": OrganisationDocumentType.RFD_CERTIFICATE,
         "name": "rfd_certificate.txt",
         "s3_key": "rfd_certificate.txt.s3_key",
         "safe": True,
@@ -841,7 +842,7 @@ def test_attach_firearm_to_application_end_to_end_section_5_good_with_section_5_
     assert post_application_document_matcher.called_once
     assert post_application_document_matcher.last_request.json() == {
         "description": "Registered firearm dealer certificate",
-        "document_type": "rfd-certificate",
+        "document_type": OrganisationDocumentType.RFD_CERTIFICATE,
         "name": "rfd_certificate.txt",
         "s3_key": "rfd_certificate.txt.s3_key",
         "safe": True,
@@ -1027,7 +1028,7 @@ def test_attach_firearm_to_application_end_to_end_section_5_good_without_section
     assert post_application_document_matcher.called_once
     assert post_application_document_matcher.last_request.json() == {
         "description": "Registered firearm dealer certificate",
-        "document_type": "rfd-certificate",
+        "document_type": OrganisationDocumentType.RFD_CERTIFICATE,
         "name": "rfd_certificate.txt",
         "s3_key": "rfd_certificate.txt.s3_key",
         "safe": True,
@@ -1206,7 +1207,7 @@ def test_attach_firearm_to_application_end_to_end_section_5_good_without_section
     assert post_application_document_matcher.called_once
     assert post_application_document_matcher.last_request.json() == {
         "description": "Registered firearm dealer certificate",
-        "document_type": "rfd-certificate",
+        "document_type": OrganisationDocumentType.RFD_CERTIFICATE,
         "name": "rfd_certificate.txt",
         "s3_key": "rfd_certificate.txt.s3_key",
         "safe": True,

--- a/unit_tests/exporter/applications/views/test_edit_registered_firearm_dealer.py
+++ b/unit_tests/exporter/applications/views/test_edit_registered_firearm_dealer.py
@@ -5,6 +5,8 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 
 from core import client
+from core.constants import OrganisationDocumentType
+
 from exporter.applications.views.goods.add_good_firearm.views.constants import AddGoodFirearmSteps
 from exporter.core.forms import CurrentFile
 from exporter.core.helpers import convert_api_date_string_to_date, decompose_date
@@ -114,11 +116,11 @@ def test_edit_registered_firearms_dealer_not_rfd_to_rfd(
     assert post_applications_document_matcher.request_history[0].json() == {
         "description": "Registered firearm dealer certificate",
         "document_on_organisation": {
-            "document_type": "rfd-certificate",
+            "document_type": OrganisationDocumentType.RFD_CERTIFICATE,
             "expiry_date": rfd_expiry_date.isoformat(),
             "reference_code": "12345",
         },
-        "document_type": "rfd-certificate",
+        "document_type": OrganisationDocumentType.RFD_CERTIFICATE,
         "name": "rfd_certificate.pdf",
         "s3_key": "rfd_certificate.pdf",
         "size": 0,
@@ -238,11 +240,11 @@ def test_edit_registered_firearms_dealer_rfd_to_rfd_with_updated_details_and_new
     assert application_doc_request.json() == {
         "description": "Registered firearm dealer certificate",
         "document_on_organisation": {
-            "document_type": "rfd-certificate",
+            "document_type": OrganisationDocumentType.RFD_CERTIFICATE,
             "expiry_date": rfd_expiry_date.isoformat(),
             "reference_code": "12345",
         },
-        "document_type": "rfd-certificate",
+        "document_type": OrganisationDocumentType.RFD_CERTIFICATE,
         "name": "new_rfd_certificate.pdf",
         "s3_key": "new_rfd_certificate.pdf",
         "size": 0,
@@ -332,7 +334,7 @@ def test_edit_registered_firearms_dealer_rfd_to_rfd_with_updated_details_keeping
     assert last_request.json() == {
         "expiry_date": rfd_expiry_date.isoformat(),
         "reference_code": "67890",
-        "document_type": "rfd-certificate",
+        "document_type": OrganisationDocumentType.RFD_CERTIFICATE,
     }
 
 

--- a/unit_tests/exporter/core/test_helpers.py
+++ b/unit_tests/exporter/core/test_helpers.py
@@ -1,9 +1,15 @@
+from core.constants import OrganisationDocumentType
+
 from exporter.core.helpers import has_valid_rfd_certificate
 
 
 def test_has_valid_rfd_certificate_is_expired():
     actual = has_valid_rfd_certificate(
-        {"organisation": {"documents": [{"document_type": "rfd-certificate", "is_expired": True}]}}
+        {
+            "organisation": {
+                "documents": [{"document_type": OrganisationDocumentType.RFD_CERTIFICATE, "is_expired": True}]
+            }
+        }
     )
 
     assert actual is False
@@ -11,7 +17,11 @@ def test_has_valid_rfd_certificate_is_expired():
 
 def test_has_valid_rfd_certificate_not_expired():
     actual = has_valid_rfd_certificate(
-        {"organisation": {"documents": [{"document_type": "rfd-certificate", "is_expired": False}]}}
+        {
+            "organisation": {
+                "documents": [{"document_type": OrganisationDocumentType.RFD_CERTIFICATE, "is_expired": False}]
+            }
+        }
     )
 
     assert actual is True


### PR DESCRIPTION
The incorrect document id was being passed through to the formatter that was displaying the link for the organisation documents on the internal side. This now uses the correct document id.

This also moves the key for RFD certificates into a constant and uses this across the codebase.

Additionally whilst testing the application that had this issue I found that there was a problem with displaying the section 5 certificate data as well which has also been rectified here.