### PR TITLE
Update logic for displaying pluralise quantity

### DIFF
--- a/unit_tests/caseworker/cases/test_templates.py
+++ b/unit_tests/caseworker/cases/test_templates.py
@@ -359,21 +359,20 @@ def test_good_on_application_detail_verified_product(
 
 
 @pytest.mark.parametrize(
-    "quantity,unit",
+    "quantity, unit, expected_value",
     [
-        (256, {"key": "NAR", "value": "items"}),
-        (1, {"key": "NAR", "value": "item"}),
-        (123.45, {"key": "GRM", "value": "Gram"}),
-        (128.64, {"key": "KGM", "value": "Kilogram"}),
-        (1150.32, {"key": "MTK", "value": "Square metre"}),
-        (100.00, {"key": "MTR", "value": "Metre"}),
-        (2500.25, {"key": "LTR", "value": "Litre"}),
-        (123.45, {"key": "MTQ", "value": "Cubic metre"}),
+        (256, {"key": "NAR", "value": "Items"}, "256 items"),
+        (1, {"key": "NAR", "value": "Items"}, "1 item"),
+        (123.45, {"key": "GRM", "value": "Grams"}, "123.45 grams"),
+        (128.64, {"key": "KGM", "value": "Kilograms"}, "128.64 kilograms"),
+        (1150.32, {"key": "MTK", "value": "Square metres"}, "1150.32 square metres"),
+        (100.00, {"key": "MTR", "value": "Metres"}, "100.0 metres"),
+        (2500.25, {"key": "LTR", "value": "Litres"}, "2500.25 litres"),
+        (123.45, {"key": "MTQ", "value": "Cubic metres"}, "123.45 cubic metres"),
     ],
 )
-def test_good_on_application_display_quantity(data_good_on_application, quantity, unit):
+def test_good_on_application_display_quantity(data_good_on_application, quantity, unit, expected_value):
     good_on_application = {**data_good_on_application}
-    good_on_application["good"]["item_category"] = {"key": "group2_firearms", "value": "Firearms"}
     good_on_application["quantity"] = quantity
     good_on_application["unit"] = unit
 
@@ -383,12 +382,10 @@ def test_good_on_application_display_quantity(data_good_on_application, quantity
         "goods": [good_on_application],
     }
 
-    expected_quantity = f"{quantity} {unit['value']}"
-
     html = render_to_string("case/slices/goods.html", context)
     soup = BeautifulSoup(html, "html.parser")
     actual_quantity = soup.find(id="quantity-value").text
-    assert expected_quantity == actual_quantity
+    assert expected_value == actual_quantity
 
 
 @pytest.mark.parametrize(

--- a/unit_tests/core/builtins/test_custom_tags.py
+++ b/unit_tests/core/builtins/test_custom_tags.py
@@ -110,45 +110,22 @@ def test_get_end_use_details_status(application, expected):
 @pytest.mark.parametrize(
     "good_on_app,quantity_display",
     [
-        ({"quantity": 0, "unit": {"key": "NAR"}}, "0 items"),
-        ({"quantity": 1, "unit": {"key": "NAR"}}, "1 item"),
-        ({"quantity": 0, "unit": {"key": "MTG"}}, "0 MTG"),
-        ({"quantity": 1, "unit": {"key": "MTG"}}, "1 MTG"),
-        ({"firearm_details": {"type": {"key": "firearms"}}, "quantity": None}, "0 items"),
-        ({"firearm_details": {"type": {"key": "firearms"}}, "quantity": 0}, "0 items"),
-        ({"firearm_details": {"type": {"key": "firearms"}}, "quantity": 1}, "1 item"),
-        ({"firearm_details": {"type": {"key": "firearms"}}, "quantity": 5}, "5 items"),
-        ({"firearm_details": {"type": {"key": "ammunition"}}, "quantity": 1}, "1 item"),
-        ({"firearm_details": {"type": {"key": "components_for_firearms"}}, "quantity": 5}, "5 items"),
-        (
-            {
-                "firearm_details": {"type": {"key": "software_related_to_firearms"}},
-                "quantity": 1,
-                "unit": {"key": "NAR", "value": "Number of articles"},
-            },
-            "1 item",
-        ),
-        (
-            {
-                "firearm_details": {"type": {"key": "software_related_to_firearms"}},
-                "quantity": 9,
-                "unit": {"key": "NAR", "value": "Number of articles"},
-            },
-            "9 items",
-        ),
-        (
-            {
-                "firearm_details": {"type": {"key": "firearms_accessory"}},
-                "quantity": 9.0,
-                "unit": {"key": "KGM", "value": "Kilogram(s)"},
-            },
-            "9.0 Kilogram(s)",
-        ),
+        ({"quantity": 0, "unit": {"key": "NAR", "value": "Items"}}, "0 items"),
+        ({"quantity": 1, "unit": {"key": "NAR", "value": "Items"}}, "1 item"),
+        ({"quantity": 2, "unit": {"key": "NAR", "value": "Items"}}, "2 items"),
+        ({"quantity": 0.0, "unit": {"key": "NAR", "value": "Items"}}, "0 items"),
+        ({"quantity": 1.0, "unit": {"key": "NAR", "value": "Items"}}, "1 item"),
+        ({"quantity": 2.0, "unit": {"key": "NAR", "value": "Items"}}, "2 items"),
+        ({"quantity": 0, "unit": {"key": "TON", "value": "Tonnes"}}, "0 tonnes"),
+        ({"quantity": 1, "unit": {"key": "TON", "value": "Tonnes"}}, "1 tonne"),
+        ({"quantity": 2, "unit": {"key": "TON", "value": "Tonnes"}}, "2 tonnes"),
+        ({"quantity": 0.0, "unit": {"key": "TON", "value": "Tonnes"}}, "0.0 tonnes"),
+        ({"quantity": 1.0, "unit": {"key": "TON", "value": "Tonnes"}}, "1.0 tonne"),
+        ({"quantity": 1.5, "unit": {"key": "TON", "value": "Tonnes"}}, "1.5 tonnes"),
+        ({"quantity": 2.0, "unit": {"key": "TON", "value": "Tonnes"}}, "2.0 tonnes"),
     ],
 )
 def test_pluralise_quantity(good_on_app, quantity_display):
-    if "firearm_details" in good_on_app:
-        good_on_app["good"] = {"item_category": {"key": "group2_firearms"}}
     actual = custom_tags.pluralise_quantity(good_on_app)
     assert actual == quantity_display
 


### PR DESCRIPTION
The original function was catering for some eventualitites that we've now removed:

  - the quantity and unit are always on the good_on_application model
  - these values are never null
  - all units can have their ending `s` removed to make the singular