### PR TITLE
Save screenshot artifacts on UI test failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,6 +227,8 @@ jobs:
       - run_make:
           label: Run caseworker e2e tests
           target: start-caseworker caseworker-e2e-selenium-test API_GIT_TAG="<< pipeline.parameters.api_git_tag >>"
+      - store_artifacts:
+          path: ui_tests/screenshots
 
   exporter_e2e_test:
     machine:

--- a/docker-compose.caseworker.yml
+++ b/docker-compose.caseworker.yml
@@ -34,6 +34,7 @@ services:
       - 8200:8200
     volumes:
       - ./playwright_videos:/app/playwright_videos
+      - ./ui_tests/screenshots:/app/ui_tests/screenshots
     entrypoint: ["/bin/sh","-c"]
     command:
     - |

--- a/docker-compose.exporter.yml
+++ b/docker-compose.exporter.yml
@@ -34,6 +34,7 @@ services:
       - 8300:8300
     volumes:
       - ./playwright_videos:/app/playwright_videos
+      - ./ui_tests/screenshots:/app/ui_tests/screenshots
     entrypoint: ["/bin/sh","-c"]
     command:
     - |


### PR DESCRIPTION
The tests are run within a Docker container so we need to save these out to the host system to get them uploaded