### PR TITLE
Wait for notes button to be enabled before progressing with tests

### DIFF
--- a/ui_tests/caseworker/pages/application_page.py
+++ b/ui_tests/caseworker/pages/application_page.py
@@ -95,7 +95,9 @@ class ApplicationPage(BasePage):
 
     def click_post_note_btn(self):
         WebDriverWait(self.driver, 30).until(
-            expected_conditions.presence_of_element_located((By.ID, self.BUTTON_POST_NOTE_ID))
+            expected_conditions.presence_of_element_located(
+                (By.CSS_SELECTOR, f"#{self.BUTTON_POST_NOTE_ID}:not([disabled])")
+            )
         )
 
         self.driver.find_element(by=By.ID, value=self.BUTTON_POST_NOTE_ID).click()


### PR DESCRIPTION
This is to hopefully solve an intermittent UI test.

In the case notes UI there is a button that is not enabled until text is input. My guess is that this isn't being enabled quickly enough for the tests so I've changed the wait to explicitly wait for the button to be enabled before it's clicked.