### PR TITLE
Refactor out product document upload into an action

### DIFF
--- a/exporter/applications/views/goods/add_good_component/views/add.py
+++ b/exporter/applications/views/goods/add_good_component/views/add.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 from core.auth.views import LoginRequiredMixin
 from core.decorators import expect_status
 
+from exporter.applications.views.goods.common.actions import ProductDocumentAction
 from exporter.core.wizard.views import BaseSessionWizardView
 from exporter.core.helpers import get_document_data
 from exporter.goods.forms.common import (
@@ -96,9 +97,6 @@ class AddGoodComponent(
 
         return kwargs
 
-    def has_product_documentation(self):
-        return self.condition_dict[AddGoodComponentSteps.PRODUCT_DOCUMENT_UPLOAD](self)
-
     def get_product_document_payload(self):
         data = self.get_cleaned_data_for_step(AddGoodComponentSteps.PRODUCT_DOCUMENT_UPLOAD)
         document = data["product_document"]
@@ -160,8 +158,8 @@ class AddGoodComponent(
     def done(self, form_list, form_dict, **kwargs):
         good, _ = self.post_component(form_dict)
         self.good = good["good"]
-        if self.has_product_documentation():
-            self.post_product_documentation(self.good)
+
+        ProductDocumentAction(self).run()
 
         return redirect(self.get_success_url())
 

--- a/exporter/applications/views/goods/add_good_platform/views/add.py
+++ b/exporter/applications/views/goods/add_good_platform/views/add.py
@@ -8,8 +8,8 @@ from django.urls import reverse
 from core.auth.views import LoginRequiredMixin
 from core.decorators import expect_status
 
+from exporter.applications.views.goods.common.actions import ProductDocumentAction
 from exporter.core.wizard.views import BaseSessionWizardView
-from exporter.core.helpers import get_document_data
 from exporter.goods.forms.common import (
     ProductControlListEntryForm,
     ProductDescriptionForm,
@@ -28,7 +28,7 @@ from exporter.goods.forms.common import (
     ProductUsesInformationSecurityForm,
 )
 
-from exporter.goods.services import post_platform, post_good_documents
+from exporter.goods.services import post_platform
 from exporter.applications.services import post_platform_good_on_application
 from exporter.applications.views.goods.common.mixins import (
     ApplicationMixin,
@@ -92,31 +92,6 @@ class AddGoodPlatform(
 
         return kwargs
 
-    def has_product_documentation(self):
-        return self.condition_dict[AddGoodPlatformSteps.PRODUCT_DOCUMENT_UPLOAD](self)
-
-    def get_product_document_payload(self):
-        data = self.get_cleaned_data_for_step(AddGoodPlatformSteps.PRODUCT_DOCUMENT_UPLOAD)
-        document = data["product_document"]
-        payload = {
-            **get_document_data(document),
-            "description": data["description"],
-        }
-        return payload
-
-    @expect_status(
-        HTTPStatus.CREATED,
-        "Error with product document when creating platform",
-        "Unexpected error adding platform",
-    )
-    def post_product_documentation(self, good):
-        document_payload = self.get_product_document_payload()
-        return post_good_documents(
-            request=self.request,
-            pk=good["id"],
-            json=document_payload,
-        )
-
     def get_context_data(self, form, **kwargs):
         ctx = super().get_context_data(form, **kwargs)
 
@@ -156,8 +131,8 @@ class AddGoodPlatform(
     def done(self, form_list, form_dict, **kwargs):
         good, _ = self.post_platform(form_dict)
         self.good = good["good"]
-        if self.has_product_documentation():
-            self.post_product_documentation(self.good)
+
+        ProductDocumentAction(self).run()
 
         return redirect(self.get_success_url())
 

--- a/exporter/applications/views/goods/add_good_software/views/add.py
+++ b/exporter/applications/views/goods/add_good_software/views/add.py
@@ -8,8 +8,8 @@ from django.urls import reverse
 from core.auth.views import LoginRequiredMixin
 from core.decorators import expect_status
 
+from exporter.applications.views.goods.common.actions import ProductDocumentAction
 from exporter.core.wizard.views import BaseSessionWizardView
-from exporter.core.helpers import get_document_data
 from exporter.goods.forms.common import (
     ProductControlListEntryForm,
     ProductDescriptionForm,
@@ -30,7 +30,7 @@ from exporter.goods.forms.goods import (
     ProductDeclaredAtCustomsForm,
     ProductSecurityFeaturesForm,
 )
-from exporter.goods.services import post_software, post_good_documents
+from exporter.goods.services import post_software
 from exporter.applications.services import post_software_good_on_application
 from exporter.applications.views.goods.common.mixins import ApplicationMixin, GoodMixin
 from exporter.applications.views.goods.common.conditionals import (
@@ -92,32 +92,6 @@ class AddGoodSoftware(
             kwargs["request"] = self.request
         return kwargs
 
-    def has_product_documentation(self):
-        data = self.get_cleaned_data_for_step(AddGoodSoftwareSteps.PRODUCT_DOCUMENT_UPLOAD)
-        return data.get("product_document", None)
-
-    def get_product_document_payload(self):
-        data = self.get_cleaned_data_for_step(AddGoodSoftwareSteps.PRODUCT_DOCUMENT_UPLOAD)
-        document = data.get("product_document", None)
-        payload = {
-            **get_document_data(document),
-            "description": data["description"],
-        }
-        return payload
-
-    @expect_status(
-        HTTPStatus.CREATED,
-        "Error with product document when creating software",
-        "Unexpected error adding software",
-    )
-    def post_product_documentation(self, good):
-        document_payload = self.get_product_document_payload()
-        return post_good_documents(
-            request=self.request,
-            pk=good["id"],
-            json=document_payload,
-        )
-
     def get_context_data(self, form, **kwargs):
         ctx = super().get_context_data(form, **kwargs)
 
@@ -157,8 +131,8 @@ class AddGoodSoftware(
     def done(self, form_list, form_dict, **kwargs):
         good, _ = self.post_software(form_dict)
         self.good = good["good"]
-        if self.has_product_documentation():
-            self.post_product_documentation(self.good)
+
+        ProductDocumentAction(self).run()
 
         return redirect(self.get_success_url())
 

--- a/exporter/applications/views/goods/common/actions.py
+++ b/exporter/applications/views/goods/common/actions.py
@@ -1,0 +1,44 @@
+from http import HTTPStatus
+
+from core.decorators import expect_status
+
+from exporter.applications.views.goods.common.constants import PRODUCT_DOCUMENT_UPLOAD
+from exporter.core.helpers import get_document_data
+from exporter.goods.services import post_good_documents
+
+
+class ProductDocumentAction:
+    def __init__(self, wizard):
+        self.wizard = wizard
+        self.request = wizard.request
+        self.good = wizard.good
+
+    def has_product_documentation(self):
+        return self.wizard.condition_dict[PRODUCT_DOCUMENT_UPLOAD](self.wizard)
+
+    def get_product_document_payload(self):
+        data = self.wizard.get_cleaned_data_for_step(PRODUCT_DOCUMENT_UPLOAD)
+        document = data["product_document"]
+        payload = {
+            **get_document_data(document),
+            "description": data["description"],
+        }
+        return payload
+
+    @expect_status(
+        HTTPStatus.CREATED,
+        "Error adding product document",
+        "Unexpected error adding product document",
+    )
+    def post_product_documentation(self):
+        document_payload = self.get_product_document_payload()
+        return post_good_documents(
+            request=self.request,
+            pk=self.good["id"],
+            json=document_payload,
+        )
+
+    def run(self):
+        if not self.has_product_documentation():
+            return
+        self.post_product_documentation()


### PR DESCRIPTION
We have code duplicated across multiple product wizards that handles logic for uploading the product document.

Through creating the wizards we have moved away from having individual chunks of logic in each wizard and moved over to creating `Action` classes that groups together the specific logic for a certain step or steps, however the product document code was never ported over to using an `Action` object. This pull request now rectifies this.