### PR TITLE
Edit view refactoring

### DIFF
--- a/exporter/applications/views/goods/common/edit.py
+++ b/exporter/applications/views/goods/common/edit.py
@@ -18,7 +18,6 @@ from exporter.goods.forms.common import (
     ProductDocumentAvailabilityForm,
     ProductDocumentSensitivityForm,
     ProductDocumentUploadForm,
-    ProductNameForm,
     ProductPartNumberForm,
 )
 from exporter.goods.services import (
@@ -33,10 +32,7 @@ from .conditionals import (
 )
 from . import constants
 from .helpers import get_product_document
-from .initial import (
-    get_control_list_entry_initial_data,
-    get_name_initial_data,
-)
+from .initial import get_control_list_entry_initial_data
 from .mixins import (
     ApplicationMixin,
     GoodMixin,
@@ -82,13 +78,6 @@ class BaseProductEditView(
         ctx["title"] = self.form_class.Layout.TITLE
 
         return ctx
-
-
-class BaseEditName:
-    form_class = ProductNameForm
-
-    def get_initial(self):
-        return get_name_initial_data(self.good)
 
 
 class BaseEditControlListEntry:

--- a/exporter/applications/views/goods/common/edit.py
+++ b/exporter/applications/views/goods/common/edit.py
@@ -13,7 +13,6 @@ from exporter.core.helpers import get_document_data
 from exporter.core.wizard.conditionals import C
 from exporter.core.wizard.views import BaseSessionWizardView
 from exporter.goods.forms.common import (
-    ProductControlListEntryForm,
     ProductDescriptionForm,
     ProductDocumentAvailabilityForm,
     ProductDocumentSensitivityForm,
@@ -32,7 +31,6 @@ from .conditionals import (
 )
 from . import constants
 from .helpers import get_product_document
-from .initial import get_control_list_entry_initial_data
 from .mixins import (
     ApplicationMixin,
     GoodMixin,
@@ -78,17 +76,6 @@ class BaseProductEditView(
         ctx["title"] = self.form_class.Layout.TITLE
 
         return ctx
-
-
-class BaseEditControlListEntry:
-    form_class = ProductControlListEntryForm
-
-    def get_form_kwargs(self):
-        kwargs = super().get_form_kwargs()
-        return {**kwargs, "request": self.request}
-
-    def get_initial(self):
-        return get_control_list_entry_initial_data(self.good)
 
 
 class BaseEditPartNumber:

--- a/exporter/applications/views/goods/common/edit.py
+++ b/exporter/applications/views/goods/common/edit.py
@@ -17,7 +17,6 @@ from exporter.goods.forms.common import (
     ProductDocumentAvailabilityForm,
     ProductDocumentSensitivityForm,
     ProductDocumentUploadForm,
-    ProductPartNumberForm,
 )
 from exporter.goods.services import (
     delete_good_document,
@@ -36,7 +35,6 @@ from .mixins import (
     GoodMixin,
 )
 from .payloads import (
-    get_part_number_payload,
     ProductEditProductDocumentAvailabilityPayloadBuilder,
     ProductEditProductDocumentSensitivityPayloadBuilder,
 )
@@ -76,24 +74,6 @@ class BaseProductEditView(
         ctx["title"] = self.form_class.Layout.TITLE
 
         return ctx
-
-
-class BaseEditPartNumber:
-    form_class = ProductPartNumberForm
-
-    def get_edit_payload(self, form):
-        return get_part_number_payload(form)
-
-    def get_initial(self):
-        no_part_number_comments = self.good.get("no_part_number_comments")
-        if no_part_number_comments:
-            return {
-                "part_number_missing": True,
-                "no_part_number_comments": no_part_number_comments,
-            }
-        return {
-            "part_number": self.good["part_number"],
-        }
 
 
 class BaseEditProductDescription:

--- a/exporter/applications/views/goods/common/steps.py
+++ b/exporter/applications/views/goods/common/steps.py
@@ -1,4 +1,4 @@
-from exporter.applications.views.goods.common.edit import get_name_initial_data
+from exporter.applications.views.goods.common.initial import get_name_initial_data
 from exporter.core.wizard.steps import Step
 from exporter.goods.forms.common import ProductNameForm
 

--- a/exporter/applications/views/goods/common/steps.py
+++ b/exporter/applications/views/goods/common/steps.py
@@ -1,12 +1,15 @@
-from exporter.applications.views.goods.common.initial import (
-    get_control_list_entry_initial_data,
-    get_name_initial_data,
-)
 from exporter.core.wizard.steps import Step
 from exporter.goods.forms.common import (
     ProductControlListEntryForm,
     ProductNameForm,
+    ProductPartNumberForm,
 )
+
+from .initial import (
+    get_control_list_entry_initial_data,
+    get_name_initial_data,
+)
+from .payloads import get_part_number_payload
 
 
 class ProductNameStep(Step):
@@ -24,3 +27,21 @@ class ProductControlListEntryStep(Step):
 
     def get_form_kwargs(self, view):
         return {"request": view.request}
+
+
+class ProductPartNumberStep(Step):
+    form_class = ProductPartNumberForm
+
+    def get_initial(self, view):
+        no_part_number_comments = view.good.get("no_part_number_comments")
+        if no_part_number_comments:
+            return {
+                "part_number_missing": True,
+                "no_part_number_comments": no_part_number_comments,
+            }
+        return {
+            "part_number": view.good["part_number"],
+        }
+
+    def get_step_data(self, form):
+        return get_part_number_payload(form)

--- a/exporter/applications/views/goods/common/steps.py
+++ b/exporter/applications/views/goods/common/steps.py
@@ -1,6 +1,12 @@
-from exporter.applications.views.goods.common.initial import get_name_initial_data
+from exporter.applications.views.goods.common.initial import (
+    get_control_list_entry_initial_data,
+    get_name_initial_data,
+)
 from exporter.core.wizard.steps import Step
-from exporter.goods.forms.common import ProductNameForm
+from exporter.goods.forms.common import (
+    ProductControlListEntryForm,
+    ProductNameForm,
+)
 
 
 class ProductNameStep(Step):
@@ -8,3 +14,13 @@ class ProductNameStep(Step):
 
     def get_initial(self, view):
         return get_name_initial_data(view.good)
+
+
+class ProductControlListEntryStep(Step):
+    form_class = ProductControlListEntryForm
+
+    def get_initial(self, view):
+        return get_control_list_entry_initial_data(view.good)
+
+    def get_form_kwargs(self, view):
+        return {"request": view.request}

--- a/exporter/applications/views/goods/common/steps.py
+++ b/exporter/applications/views/goods/common/steps.py
@@ -1,0 +1,10 @@
+from exporter.applications.views.goods.common.edit import get_name_initial_data
+from exporter.core.wizard.steps import Step
+from exporter.goods.forms.common import ProductNameForm
+
+
+class ProductNameStep(Step):
+    form_class = ProductNameForm
+
+    def get_initial(self, view):
+        return get_name_initial_data(view.good)

--- a/exporter/applications/views/goods/component/views/edit.py
+++ b/exporter/applications/views/goods/component/views/edit.py
@@ -18,9 +18,9 @@ from exporter.applications.views.goods.common.conditionals import (
 from exporter.applications.views.goods.common.steps import (
     ProductControlListEntryStep,
     ProductNameStep,
+    ProductPartNumberStep,
 )
 from exporter.applications.views.goods.common.edit import (
-    BaseEditPartNumber,
     BaseEditProductDescription,
     BaseEditProductDocumentAvailability,
     BaseEditProductDocumentSensitivity,
@@ -106,15 +106,14 @@ class EditComponentAccessory:
         "Error editing component/accessory",
         "Unexpected error editing component/accessory",
     )
-    def edit_component_accessory(self, request, good_id, form):
-        payload = get_cleaned_data(form)
+    def edit_component_accessory(self, request, good_id, payload):
         return edit_component_accessory(request, good_id, payload)
 
     def run(self, view, form):
         self.edit_component_accessory(
             view.request,
             view.good["id"],
-            form,
+            view.get_step_data(form),
         )
 
 
@@ -141,10 +140,14 @@ class ComponentAccessoryEditControlListEntry(
 
 
 class ComponentAccessoryEditPartNumberView(
-    BaseEditPartNumber,
-    BaseComponentAccessoryEditView,
+    LoginRequiredMixin,
+    ApplicationMixin,
+    GoodMixin,
+    ComponentAccessorySummaryMixin,
+    StepEditView,
 ):
-    pass
+    actions = (EditComponentAccessory(),)
+    step = ProductPartNumberStep()
 
 
 class BaseComponentAccessoryEditWizardView(

--- a/exporter/applications/views/goods/component/views/edit.py
+++ b/exporter/applications/views/goods/component/views/edit.py
@@ -15,9 +15,11 @@ from exporter.applications.views.goods.common.conditionals import (
     is_pv_graded,
     is_onward_exported,
 )
-from exporter.applications.views.goods.common.steps import ProductNameStep
+from exporter.applications.views.goods.common.steps import (
+    ProductControlListEntryStep,
+    ProductNameStep,
+)
 from exporter.applications.views.goods.common.edit import (
-    BaseEditControlListEntry,
     BaseEditPartNumber,
     BaseEditProductDescription,
     BaseEditProductDocumentAvailability,
@@ -127,8 +129,15 @@ class ComponentAccessoryEditName(
     step = ProductNameStep()
 
 
-class ComponentAccessoryEditControlListEntry(BaseEditControlListEntry, BaseComponentAccessoryEditView):
-    pass
+class ComponentAccessoryEditControlListEntry(
+    LoginRequiredMixin,
+    ApplicationMixin,
+    GoodMixin,
+    ComponentAccessorySummaryMixin,
+    StepEditView,
+):
+    actions = (EditComponentAccessory(),)
+    step = ProductControlListEntryStep()
 
 
 class ComponentAccessoryEditPartNumberView(

--- a/exporter/applications/views/goods/firearm/views/edit.py
+++ b/exporter/applications/views/goods/firearm/views/edit.py
@@ -24,7 +24,6 @@ from exporter.applications.views.goods.common.conditionals import (
     is_onward_exported,
 )
 from exporter.applications.views.goods.common.edit import (
-    BaseEditControlListEntry,
     BaseEditProductDocumentAvailability,
     BaseEditProductDescription,
     BaseEditProductDocumentSensitivity,
@@ -50,7 +49,10 @@ from exporter.applications.views.goods.common.payloads import (
     get_pv_grading_details_payload,
     ProductEditPVGradingPayloadBuilder,
 )
-from exporter.applications.views.goods.common.steps import ProductNameStep
+from exporter.applications.views.goods.common.steps import (
+    ProductControlListEntryStep,
+    ProductNameStep,
+)
 from exporter.core.forms import CurrentFile
 from exporter.core.helpers import (
     convert_api_date_string_to_date,
@@ -204,8 +206,15 @@ class FirearmEditCalibre(BaseFirearmEditView):
         return {"calibre": self.good["firearm_details"]["calibre"]}
 
 
-class FirearmEditControlListEntry(BaseEditControlListEntry, BaseGoodEditView):
-    pass
+class FirearmEditControlListEntry(
+    LoginRequiredMixin,
+    ApplicationMixin,
+    GoodMixin,
+    FirearmSummaryMixin,
+    StepEditView,
+):
+    actions = (EditFirearm(),)
+    step = ProductControlListEntryStep()
 
 
 class FirearmEditReplica(BaseFirearmEditView):

--- a/exporter/applications/views/goods/material/views/edit.py
+++ b/exporter/applications/views/goods/material/views/edit.py
@@ -16,7 +16,6 @@ from exporter.applications.views.goods.common.conditionals import (
     is_onward_exported,
 )
 from exporter.applications.views.goods.common.edit import (
-    BaseEditControlListEntry,
     BaseEditPartNumber,
     BaseEditProductDescription,
     BaseEditProductDocumentAvailability,
@@ -45,7 +44,10 @@ from exporter.applications.views.goods.common.payloads import (
     get_unit_quantity_and_value_payload,
     ProductEditPVGradingPayloadBuilder,
 )
-from exporter.applications.views.goods.common.steps import ProductNameStep
+from exporter.applications.views.goods.common.steps import (
+    ProductControlListEntryStep,
+    ProductNameStep,
+)
 from exporter.core.wizard.views import (
     BaseSessionWizardView,
     StepEditView,
@@ -120,8 +122,15 @@ class MaterialEditName(
     step = ProductNameStep()
 
 
-class MaterialEditControlListEntry(BaseEditControlListEntry, BaseMaterialEditView):
-    pass
+class MaterialEditControlListEntry(
+    LoginRequiredMixin,
+    ApplicationMixin,
+    GoodMixin,
+    MaterialSummaryMixin,
+    StepEditView,
+):
+    actions = (EditMaterial(),)
+    step = ProductControlListEntryStep()
 
 
 class MaterialEditPartNumberView(

--- a/exporter/applications/views/goods/material/views/edit.py
+++ b/exporter/applications/views/goods/material/views/edit.py
@@ -17,7 +17,6 @@ from exporter.applications.views.goods.common.conditionals import (
 )
 from exporter.applications.views.goods.common.edit import (
     BaseEditControlListEntry,
-    BaseEditName,
     BaseEditPartNumber,
     BaseEditProductDescription,
     BaseEditProductDocumentAvailability,
@@ -37,6 +36,7 @@ from exporter.applications.views.goods.common.initial import (
 )
 from exporter.applications.views.goods.common.mixins import (
     ApplicationMixin,
+    GoodMixin,
     GoodOnApplicationMixin,
 )
 from exporter.applications.views.goods.common.payloads import (
@@ -45,7 +45,11 @@ from exporter.applications.views.goods.common.payloads import (
     get_unit_quantity_and_value_payload,
     ProductEditPVGradingPayloadBuilder,
 )
-from exporter.core.wizard.views import BaseSessionWizardView
+from exporter.applications.views.goods.common.steps import ProductNameStep
+from exporter.core.wizard.views import (
+    BaseSessionWizardView,
+    StepEditView,
+)
 from exporter.goods.forms.common import (
     ProductOnwardAlteredProcessedForm,
     ProductOnwardExportedForm,
@@ -82,8 +86,38 @@ class BaseMaterialEditView(BaseEditView):
         return get_cleaned_data(form)
 
 
-class MaterialEditName(BaseEditName, BaseMaterialEditView):
-    pass
+class EditMaterial:
+    @expect_status(
+        HTTPStatus.OK,
+        "Error editing material",
+        "Unexpected error editing material",
+    )
+    def edit_material(self, request, good_id, form):
+        payload = get_cleaned_data(form)
+        return edit_material(request, good_id, payload)
+
+    def run(self, view, form):
+        self.edit_material(
+            view.request,
+            view.good["id"],
+            form,
+        )
+
+
+class MaterialSummaryMixin:
+    def get_success_url(self):
+        return reverse("applications:material_product_summary", kwargs=self.kwargs)
+
+
+class MaterialEditName(
+    LoginRequiredMixin,
+    ApplicationMixin,
+    GoodMixin,
+    MaterialSummaryMixin,
+    StepEditView,
+):
+    actions = (EditMaterial(),)
+    step = ProductNameStep()
 
 
 class MaterialEditControlListEntry(BaseEditControlListEntry, BaseMaterialEditView):

--- a/exporter/applications/views/goods/material/views/edit.py
+++ b/exporter/applications/views/goods/material/views/edit.py
@@ -16,7 +16,6 @@ from exporter.applications.views.goods.common.conditionals import (
     is_onward_exported,
 )
 from exporter.applications.views.goods.common.edit import (
-    BaseEditPartNumber,
     BaseEditProductDescription,
     BaseEditProductDocumentAvailability,
     BaseEditProductDocumentSensitivity,
@@ -47,6 +46,7 @@ from exporter.applications.views.goods.common.payloads import (
 from exporter.applications.views.goods.common.steps import (
     ProductControlListEntryStep,
     ProductNameStep,
+    ProductPartNumberStep,
 )
 from exporter.core.wizard.views import (
     BaseSessionWizardView,
@@ -94,15 +94,14 @@ class EditMaterial:
         "Error editing material",
         "Unexpected error editing material",
     )
-    def edit_material(self, request, good_id, form):
-        payload = get_cleaned_data(form)
+    def edit_material(self, request, good_id, payload):
         return edit_material(request, good_id, payload)
 
     def run(self, view, form):
         self.edit_material(
             view.request,
             view.good["id"],
-            form,
+            view.get_step_data(form),
         )
 
 
@@ -134,10 +133,14 @@ class MaterialEditControlListEntry(
 
 
 class MaterialEditPartNumberView(
-    BaseEditPartNumber,
-    BaseMaterialEditView,
+    LoginRequiredMixin,
+    ApplicationMixin,
+    GoodMixin,
+    MaterialSummaryMixin,
+    StepEditView,
 ):
-    pass
+    actions = (EditMaterial(),)
+    step = ProductPartNumberStep()
 
 
 class BaseMaterialEditWizardView(

--- a/exporter/applications/views/goods/platform/views/edit.py
+++ b/exporter/applications/views/goods/platform/views/edit.py
@@ -16,7 +16,6 @@ from exporter.applications.views.goods.common.conditionals import (
     is_onward_exported,
 )
 from exporter.applications.views.goods.common.edit import (
-    BaseEditPartNumber,
     BaseEditProductDescription,
     BaseEditProductDocumentAvailability,
     BaseEditProductDocumentSensitivity,
@@ -47,6 +46,7 @@ from exporter.applications.views.goods.common.payloads import (
 from exporter.applications.views.goods.common.steps import (
     ProductControlListEntryStep,
     ProductNameStep,
+    ProductPartNumberStep,
 )
 from exporter.core.wizard.views import (
     BaseSessionWizardView,
@@ -99,15 +99,14 @@ class EditCompleteItem:
         "Error editing complete item",
         "Unexpected error editing complete item",
     )
-    def edit_complete_item(self, request, good_id, form):
-        payload = get_cleaned_data(form)
+    def edit_complete_item(self, request, good_id, payload):
         return edit_complete_item(request, good_id, payload)
 
     def run(self, view, form):
         self.edit_complete_item(
             view.request,
             view.good["id"],
-            form,
+            view.get_step_data(form),
         )
 
 
@@ -134,10 +133,14 @@ class CompleteItemEditControlListEntry(
 
 
 class CompleteItemEditPartNumberView(
-    BaseEditPartNumber,
-    BaseCompleteItemEditView,
+    LoginRequiredMixin,
+    ApplicationMixin,
+    GoodMixin,
+    CompleteItemSummaryMixin,
+    StepEditView,
 ):
-    pass
+    actions = (EditCompleteItem(),)
+    step = ProductPartNumberStep()
 
 
 class BaseCompleteItemEditWizardView(

--- a/exporter/applications/views/goods/platform/views/edit.py
+++ b/exporter/applications/views/goods/platform/views/edit.py
@@ -16,7 +16,6 @@ from exporter.applications.views.goods.common.conditionals import (
     is_onward_exported,
 )
 from exporter.applications.views.goods.common.edit import (
-    BaseEditControlListEntry,
     BaseEditPartNumber,
     BaseEditProductDescription,
     BaseEditProductDocumentAvailability,
@@ -45,7 +44,10 @@ from exporter.applications.views.goods.common.payloads import (
     get_quantity_and_value_payload,
     ProductEditPVGradingPayloadBuilder,
 )
-from exporter.applications.views.goods.common.steps import ProductNameStep
+from exporter.applications.views.goods.common.steps import (
+    ProductControlListEntryStep,
+    ProductNameStep,
+)
 from exporter.core.wizard.views import (
     BaseSessionWizardView,
     StepEditView,
@@ -120,8 +122,15 @@ class CompleteItemEditName(
     step = ProductNameStep()
 
 
-class CompleteItemEditControlListEntry(BaseEditControlListEntry, BaseCompleteItemEditView):
-    pass
+class CompleteItemEditControlListEntry(
+    LoginRequiredMixin,
+    ApplicationMixin,
+    GoodMixin,
+    CompleteItemSummaryMixin,
+    StepEditView,
+):
+    actions = (EditCompleteItem(),)
+    step = ProductControlListEntryStep()
 
 
 class CompleteItemEditPartNumberView(

--- a/exporter/applications/views/goods/platform/views/edit.py
+++ b/exporter/applications/views/goods/platform/views/edit.py
@@ -17,7 +17,6 @@ from exporter.applications.views.goods.common.conditionals import (
 )
 from exporter.applications.views.goods.common.edit import (
     BaseEditControlListEntry,
-    BaseEditName,
     BaseEditPartNumber,
     BaseEditProductDescription,
     BaseEditProductDocumentAvailability,
@@ -37,6 +36,7 @@ from exporter.applications.views.goods.common.initial import (
 )
 from exporter.applications.views.goods.common.mixins import (
     ApplicationMixin,
+    GoodMixin,
     GoodOnApplicationMixin,
 )
 from exporter.applications.views.goods.common.payloads import (
@@ -45,7 +45,11 @@ from exporter.applications.views.goods.common.payloads import (
     get_quantity_and_value_payload,
     ProductEditPVGradingPayloadBuilder,
 )
-from exporter.core.wizard.views import BaseSessionWizardView
+from exporter.applications.views.goods.common.steps import ProductNameStep
+from exporter.core.wizard.views import (
+    BaseSessionWizardView,
+    StepEditView,
+)
 from exporter.goods.forms.common import (
     ProductMilitaryUseForm,
     ProductOnwardAlteredProcessedForm,
@@ -82,8 +86,38 @@ class BaseCompleteItemEditView(BaseEditView):
         return get_cleaned_data(form)
 
 
-class CompleteItemEditName(BaseEditName, BaseCompleteItemEditView):
-    pass
+class CompleteItemSummaryMixin:
+    def get_success_url(self):
+        return reverse("applications:complete_item_product_summary", kwargs=self.kwargs)
+
+
+class EditCompleteItem:
+    @expect_status(
+        HTTPStatus.OK,
+        "Error editing complete item",
+        "Unexpected error editing complete item",
+    )
+    def edit_complete_item(self, request, good_id, form):
+        payload = get_cleaned_data(form)
+        return edit_complete_item(request, good_id, payload)
+
+    def run(self, view, form):
+        self.edit_complete_item(
+            view.request,
+            view.good["id"],
+            form,
+        )
+
+
+class CompleteItemEditName(
+    LoginRequiredMixin,
+    ApplicationMixin,
+    GoodMixin,
+    CompleteItemSummaryMixin,
+    StepEditView,
+):
+    actions = (EditCompleteItem(),)
+    step = ProductNameStep()
 
 
 class CompleteItemEditControlListEntry(BaseEditControlListEntry, BaseCompleteItemEditView):

--- a/exporter/applications/views/goods/software/views/edit.py
+++ b/exporter/applications/views/goods/software/views/edit.py
@@ -16,7 +16,6 @@ from exporter.applications.views.goods.common.conditionals import (
     is_onward_exported,
 )
 from exporter.applications.views.goods.common.edit import (
-    BaseEditControlListEntry,
     BaseEditPartNumber,
     BaseEditProductDescription,
     BaseEditProductDocumentAvailability,
@@ -45,7 +44,10 @@ from exporter.applications.views.goods.common.payloads import (
     get_quantity_and_value_payload,
     ProductEditPVGradingPayloadBuilder,
 )
-from exporter.applications.views.goods.common.steps import ProductNameStep
+from exporter.applications.views.goods.common.steps import (
+    ProductControlListEntryStep,
+    ProductNameStep,
+)
 from exporter.core.wizard.views import (
     BaseSessionWizardView,
     StepEditView,
@@ -126,8 +128,15 @@ class TechnologyEditName(
     step = ProductNameStep()
 
 
-class TechnologyEditControlListEntry(BaseEditControlListEntry, BaseTechnologyEditView):
-    pass
+class TechnologyEditControlListEntry(
+    LoginRequiredMixin,
+    ApplicationMixin,
+    GoodMixin,
+    TechnologySummaryMixin,
+    StepEditView,
+):
+    actions = (EditTechnology(),)
+    step = ProductControlListEntryStep()
 
 
 class TechnologyEditPartNumberView(

--- a/exporter/applications/views/goods/software/views/edit.py
+++ b/exporter/applications/views/goods/software/views/edit.py
@@ -17,7 +17,6 @@ from exporter.applications.views.goods.common.conditionals import (
 )
 from exporter.applications.views.goods.common.edit import (
     BaseEditControlListEntry,
-    BaseEditName,
     BaseEditPartNumber,
     BaseEditProductDescription,
     BaseEditProductDocumentAvailability,
@@ -37,6 +36,7 @@ from exporter.applications.views.goods.common.initial import (
 )
 from exporter.applications.views.goods.common.mixins import (
     ApplicationMixin,
+    GoodMixin,
     GoodOnApplicationMixin,
 )
 from exporter.applications.views.goods.common.payloads import (
@@ -45,7 +45,11 @@ from exporter.applications.views.goods.common.payloads import (
     get_quantity_and_value_payload,
     ProductEditPVGradingPayloadBuilder,
 )
-from exporter.core.wizard.views import BaseSessionWizardView
+from exporter.applications.views.goods.common.steps import ProductNameStep
+from exporter.core.wizard.views import (
+    BaseSessionWizardView,
+    StepEditView,
+)
 from exporter.goods.forms.common import (
     ProductMilitaryUseForm,
     ProductOnwardAlteredProcessedForm,
@@ -59,7 +63,7 @@ from exporter.goods.forms import (
     ProductSecurityFeaturesForm,
     ProductDeclaredAtCustomsForm,
 )
-from exporter.goods.services import edit_technolgy
+from exporter.goods.services import edit_technology
 
 from .constants import (
     AddGoodTechnologyToApplicationSteps,
@@ -80,7 +84,7 @@ class BaseEditView(
         return reverse("applications:technology_product_summary", kwargs=self.kwargs)
 
     def edit_object(self, request, good_id, payload):
-        edit_technolgy(request, good_id, payload)
+        edit_technology(request, good_id, payload)
 
 
 class BaseTechnologyEditView(BaseEditView):
@@ -88,8 +92,38 @@ class BaseTechnologyEditView(BaseEditView):
         return get_cleaned_data(form)
 
 
-class TechnologyEditName(BaseEditName, BaseTechnologyEditView):
-    pass
+class TechnologySummaryMixin:
+    def get_success_url(self):
+        return reverse("applications:technology_product_summary", kwargs=self.kwargs)
+
+
+class EditTechnology:
+    @expect_status(
+        HTTPStatus.OK,
+        "Error editing technology",
+        "Unexpected error editing technology",
+    )
+    def edit_technology(self, request, good_id, form):
+        payload = get_cleaned_data(form)
+        return edit_technology(request, good_id, payload)
+
+    def run(self, view, form):
+        self.edit_technology(
+            view.request,
+            view.good["id"],
+            form,
+        )
+
+
+class TechnologyEditName(
+    LoginRequiredMixin,
+    ApplicationMixin,
+    GoodMixin,
+    TechnologySummaryMixin,
+    StepEditView,
+):
+    actions = (EditTechnology(),)
+    step = ProductNameStep()
 
 
 class TechnologyEditControlListEntry(BaseEditControlListEntry, BaseTechnologyEditView):
@@ -110,7 +144,7 @@ class BaseTechnologyEditWizardView(
         return reverse("applications:technology_product_summary", kwargs=self.kwargs)
 
     def edit_object(self, request, good_pk, payload):
-        return edit_technolgy(self.request, good_pk, payload)
+        return edit_technology(self.request, good_pk, payload)
 
 
 class TechnologyEditPVGrading(BaseTechnologyEditWizardView):

--- a/exporter/applications/views/goods/software/views/edit.py
+++ b/exporter/applications/views/goods/software/views/edit.py
@@ -16,7 +16,6 @@ from exporter.applications.views.goods.common.conditionals import (
     is_onward_exported,
 )
 from exporter.applications.views.goods.common.edit import (
-    BaseEditPartNumber,
     BaseEditProductDescription,
     BaseEditProductDocumentAvailability,
     BaseEditProductDocumentSensitivity,
@@ -47,6 +46,7 @@ from exporter.applications.views.goods.common.payloads import (
 from exporter.applications.views.goods.common.steps import (
     ProductControlListEntryStep,
     ProductNameStep,
+    ProductPartNumberStep,
 )
 from exporter.core.wizard.views import (
     BaseSessionWizardView,
@@ -105,15 +105,14 @@ class EditTechnology:
         "Error editing technology",
         "Unexpected error editing technology",
     )
-    def edit_technology(self, request, good_id, form):
-        payload = get_cleaned_data(form)
+    def edit_technology(self, request, good_id, payload):
         return edit_technology(request, good_id, payload)
 
     def run(self, view, form):
         self.edit_technology(
             view.request,
             view.good["id"],
-            form,
+            view.get_step_data(form),
         )
 
 
@@ -140,10 +139,14 @@ class TechnologyEditControlListEntry(
 
 
 class TechnologyEditPartNumberView(
-    BaseEditPartNumber,
-    BaseTechnologyEditView,
+    LoginRequiredMixin,
+    ApplicationMixin,
+    GoodMixin,
+    TechnologySummaryMixin,
+    StepEditView,
 ):
-    pass
+    actions = (EditTechnology(),)
+    step = ProductPartNumberStep()
 
 
 class BaseTechnologyEditWizardView(

--- a/exporter/core/wizard/steps.py
+++ b/exporter/core/wizard/steps.py
@@ -1,0 +1,7 @@
+class Step:
+    @property
+    def form_class(self):
+        raise NotImplementedError(f"`form_class` is a required attribute on {self.__class__.__name__}")
+
+    def get_initial(self, view):
+        raise NotImplementedError(f"Implement `get_initial` on {self.__class__.__name__}")

--- a/exporter/core/wizard/steps.py
+++ b/exporter/core/wizard/steps.py
@@ -5,3 +5,6 @@ class Step:
 
     def get_initial(self, view):
         raise NotImplementedError(f"Implement `get_initial` on {self.__class__.__name__}")
+
+    def get_form_kwargs(self, view):
+        return {}

--- a/exporter/core/wizard/steps.py
+++ b/exporter/core/wizard/steps.py
@@ -8,3 +8,6 @@ class Step:
 
     def get_form_kwargs(self, view):
         return {}
+
+    def get_step_data(self, form):
+        return form.cleaned_data

--- a/exporter/core/wizard/views.py
+++ b/exporter/core/wizard/views.py
@@ -37,3 +37,6 @@ class StepEditView(FormView):
             **form_kwargs,
             **step_form_kwargs,
         }
+
+    def get_step_data(self, form):
+        return self.step.get_step_data(form)

--- a/exporter/core/wizard/views.py
+++ b/exporter/core/wizard/views.py
@@ -1,3 +1,5 @@
+from django.views.generic import FormView
+
 from formtools.wizard.views import SessionWizardView
 
 from .storage import NoSaveStorage
@@ -12,3 +14,18 @@ class BaseSessionWizardView(SessionWizardView):
         if cleaned_data is None:
             return {}
         return cleaned_data
+
+
+class StepEditView(FormView):
+    template_name = "core/form.html"
+
+    def get_form_class(self):
+        return self.step.form_class
+
+    def get_initial(self):
+        return self.step.get_initial(self)
+
+    def form_valid(self, form):
+        for action in self.actions:
+            action.run(self, form)
+        return super().form_valid(form)

--- a/exporter/core/wizard/views.py
+++ b/exporter/core/wizard/views.py
@@ -29,3 +29,11 @@ class StepEditView(FormView):
         for action in self.actions:
             action.run(self, form)
         return super().form_valid(form)
+
+    def get_form_kwargs(self):
+        form_kwargs = super().get_form_kwargs()
+        step_form_kwargs = self.step.get_form_kwargs(self)
+        return {
+            **form_kwargs,
+            **step_form_kwargs,
+        }

--- a/exporter/goods/services.py
+++ b/exporter/goods/services.py
@@ -342,6 +342,6 @@ def post_technology(request, json):
     return data.json(), data.status_code
 
 
-def edit_technolgy(request, pk, json):
+def edit_technology(request, pk, json):
     response = client.put(request, f"/goods/{pk}", json)
     return response.json(), response.status_code


### PR DESCRIPTION
This is the first part of probably a few PRs to refactor out how we handle wizards with a focus on consolidating functionality that's commonly reused into a new concept of a `Step`.

This first PR transitions three such forms over across all of the product types.

These three forms were picked as they are simple enough but also require `initial_data` changes, custom payload changes and `form_kwargs` changes which are the key things that we are trying to consolidate for reuse.