### PR TITLE
Stop regimes being a required field on TAU form if feature flag is off

### DIFF
--- a/caseworker/tau/forms.py
+++ b/caseworker/tau/forms.py
@@ -89,6 +89,9 @@ class TAUEditForm(forms.Form):
         self.fields["control_list_entries"].choices = control_list_entries_choices
         self.fields["wassenaar_entries"].choices = wassenaar_entries
         self.fields["mtcr_entries"].choices = mtcr_entries
+        if not settings.FEATURE_FLAG_REGIMES:
+            self.fields["regimes"].required = False
+
         self.helper = FormHelper()
 
         fields = [


### PR DESCRIPTION
The new regimes UI is behind a feature switch, however the TAU forms validation wasn't taking this into account and so when the new regimes field was missing it was still expecting a value to be posted and was causing a hidden error to occur.

This now changes the TAU forms to take this feature switch into account and correctly ignore the regimes field if it isn't meant to be present.