### PR TITLE
Use name in product summary hover

### DIFF
--- a/caseworker/templates/case/pills/goods.html
+++ b/caseworker/templates/case/pills/goods.html
@@ -5,11 +5,7 @@
 	{% for good in case.goods %}
 		<li class="govuk-!-margin-bottom-3">
 			<span data-max-length="100">
-				{% if good.description %}
-					{{ good.description }}
-				{% else %}
-					{{ good.good.description }}
-				{% endif %}
+				{{ good.good.name }}
 			</span>
 		</li>
 	{% endfor %}


### PR DESCRIPTION
Use the name of the product in the product hover over.

Description is no longer always included on a good so we need to use name instead.