### PR TITLE
LTD-2941: Enable MOD-DI Direct and FCDO CPACC users to give their recommendation

### DIFF
--- a/caseworker/advice/services.py
+++ b/caseworker/advice/services.py
@@ -6,6 +6,7 @@ from core import client
 
 # Queues
 FCDO_CASES_TO_REVIEW_QUEUE = "FCDO_CASES_TO_REVIEW"
+FCDO_CPACC_CASES_TO_REVIEW_QUEUE = "FCDO_CPACC_CASES_TO_REVIEW"
 FCDO_COUNTERSIGNING_QUEUE = "FCDO_COUNTER_SIGNING"
 MOD_CASES_TO_REVIEW_QUEUES = [
     "MOD_CASES_TO_REVIEW",
@@ -13,9 +14,9 @@ MOD_CASES_TO_REVIEW_QUEUES = [
 ]
 MOD_CONSOLIDATE_QUEUES = [
     "MOD_DI_CASES_TO_REVIEW",
+    "MOD_DI_DIRECT_CASES_TO_REVIEW",
     "MOD_DSR_CASES_TO_REVIEW",
     "MOD_DSTL_CASES_TO_REVIEW",
-    "MOD_WECA_CASES_TO_REVIEW",  # TODO: Remove this after https://uktrade.atlassian.net/browse/LTD-2730 released
     "MOD_CAPPROT_CASES_TO_REVIEW",
     "MOD_ECJU_REVIEW_AND_COMBINE",
 ]
@@ -29,7 +30,6 @@ MOD_CONSOLIDATE_TEAMS = [
     "MOD_DI",
     "MOD_DSR",
     "MOD_DSTL",
-    "MOD_WECA",  # TODO: Remove this after https://uktrade.atlassian.net/browse/LTD-2730 released
     "MOD_CAPPROT",
 ]
 LU_CONSOLIDATE_TEAMS = [FCDO_TEAM, MOD_ECJU_TEAM]
@@ -321,7 +321,7 @@ def get_advice_tab_context(case, caseworker, queue_id):
     }
 
     if team_alias in (FCDO_TEAM, *MOD_CONSOLIDATE_TEAMS):
-        if queue_alias in (FCDO_CASES_TO_REVIEW_QUEUE, *MOD_CONSOLIDATE_QUEUES):
+        if queue_alias in (FCDO_CASES_TO_REVIEW_QUEUE, FCDO_CPACC_CASES_TO_REVIEW_QUEUE, *MOD_CONSOLIDATE_QUEUES):
             existing_advice = get_my_advice(case.advice, caseworker["id"])
 
             if not existing_advice:

--- a/unit_tests/caseworker/advice/test_services.py
+++ b/unit_tests/caseworker/advice/test_services.py
@@ -2,6 +2,7 @@ import pytest
 
 from caseworker.advice.services import (
     FCDO_CASES_TO_REVIEW_QUEUE,
+    FCDO_CPACC_CASES_TO_REVIEW_QUEUE,
     FCDO_COUNTERSIGNING_QUEUE,
     FCDO_TEAM,
     LICENSING_UNIT_TEAM,
@@ -51,18 +52,20 @@ advice_tab_test_data = [
     # Fields: Has Advice, Advice Level, Countersigned, User Team, Current Queue, Expected Tab URL, Expected Buttons Enabled (dict)
     # An individual giving advice on a case for the first time
     (False, "user", False, FCDO_TEAM, FCDO_CASES_TO_REVIEW_QUEUE, "cases:advice_view", {"make_recommendation": True},),
+    (False, "user", False, FCDO_TEAM, FCDO_CPACC_CASES_TO_REVIEW_QUEUE, "cases:advice_view", {"make_recommendation": True},),
     (False, "user", False, MOD_CONSOLIDATE_TEAMS[0], MOD_CONSOLIDATE_QUEUES[0], "cases:advice_view", {"make_recommendation": True},),
-    (False, "user", False, MOD_CONSOLIDATE_TEAMS[1], MOD_CONSOLIDATE_QUEUES[1], "cases:advice_view", {"make_recommendation": True},),
-    (False, "user", False, MOD_CONSOLIDATE_TEAMS[2], MOD_CONSOLIDATE_QUEUES[2], "cases:advice_view", {"make_recommendation": True},),
-    (False, "user", False, MOD_CONSOLIDATE_TEAMS[3], MOD_CONSOLIDATE_QUEUES[3], "cases:advice_view", {"make_recommendation": True},),
-    (False, "user", False, MOD_CONSOLIDATE_TEAMS[4], MOD_CONSOLIDATE_QUEUES[4], "cases:advice_view", {"make_recommendation": True},),
+    (False, "user", False, MOD_CONSOLIDATE_TEAMS[0], MOD_CONSOLIDATE_QUEUES[1], "cases:advice_view", {"make_recommendation": True},),
+    (False, "user", False, MOD_CONSOLIDATE_TEAMS[1], MOD_CONSOLIDATE_QUEUES[2], "cases:advice_view", {"make_recommendation": True},),
+    (False, "user", False, MOD_CONSOLIDATE_TEAMS[2], MOD_CONSOLIDATE_QUEUES[3], "cases:advice_view", {"make_recommendation": True},),
+    (False, "user", False, MOD_CONSOLIDATE_TEAMS[3], MOD_CONSOLIDATE_QUEUES[4], "cases:advice_view", {"make_recommendation": True},),
     # An individual accessing the cases again after having given advice
     (True, "user", False, FCDO_TEAM, FCDO_CASES_TO_REVIEW_QUEUE, "cases:view_my_advice", {"edit_recommendation": True, "clear_recommendation": True, "move_case_forward": True},),
+    (True, "user", False, FCDO_TEAM, FCDO_CPACC_CASES_TO_REVIEW_QUEUE, "cases:view_my_advice", {"edit_recommendation": True, "clear_recommendation": True, "move_case_forward": True},),
     (True, "user", False, MOD_CONSOLIDATE_TEAMS[0], MOD_CONSOLIDATE_QUEUES[0], "cases:view_my_advice", {"edit_recommendation": True, "clear_recommendation": True, "move_case_forward": True},),
-    (True, "user", False, MOD_CONSOLIDATE_TEAMS[1], MOD_CONSOLIDATE_QUEUES[1], "cases:view_my_advice", {"edit_recommendation": True, "clear_recommendation": True, "move_case_forward": True},),
-    (True, "user", False, MOD_CONSOLIDATE_TEAMS[2], MOD_CONSOLIDATE_QUEUES[2], "cases:view_my_advice", {"edit_recommendation": True, "clear_recommendation": True, "move_case_forward": True},),
-    (True, "user", False, MOD_CONSOLIDATE_TEAMS[3], MOD_CONSOLIDATE_QUEUES[3], "cases:view_my_advice", {"edit_recommendation": True, "clear_recommendation": True, "move_case_forward": True},),
-    (True, "user", False, MOD_CONSOLIDATE_TEAMS[4], MOD_CONSOLIDATE_QUEUES[4], "cases:view_my_advice", {"edit_recommendation": True, "clear_recommendation": True, "move_case_forward": True},),
+    (True, "user", False, MOD_CONSOLIDATE_TEAMS[0], MOD_CONSOLIDATE_QUEUES[1], "cases:view_my_advice", {"edit_recommendation": True, "clear_recommendation": True, "move_case_forward": True},),
+    (True, "user", False, MOD_CONSOLIDATE_TEAMS[1], MOD_CONSOLIDATE_QUEUES[2], "cases:view_my_advice", {"edit_recommendation": True, "clear_recommendation": True, "move_case_forward": True},),
+    (True, "user", False, MOD_CONSOLIDATE_TEAMS[2], MOD_CONSOLIDATE_QUEUES[3], "cases:view_my_advice", {"edit_recommendation": True, "clear_recommendation": True, "move_case_forward": True},),
+    (True, "user", False, MOD_CONSOLIDATE_TEAMS[3], MOD_CONSOLIDATE_QUEUES[4], "cases:view_my_advice", {"edit_recommendation": True, "clear_recommendation": True, "move_case_forward": True},),
     # An individual countersigning advice on a case for the first time
     (True, "user", False, FCDO_TEAM, FCDO_COUNTERSIGNING_QUEUE, "cases:countersign_advice_view", {"review_and_countersign": True},),
     # An individual accessing the case after giving countersigned advice


### PR DESCRIPTION
## Change description

The option to give recommendation is only available if the user's current queue matches with the queue the case is currently on. We match this based on queue alias.

As part of routing changes we added new queues so include their aliases in this check so that users processing a case on these queues can give their recommendation.

Also removed MOD-WECA alias which we no longer need.