### PR TITLE
rename left out

### DIFF
--- a/exporter/templates/goods/goods.html
+++ b/exporter/templates/goods/goods.html
@@ -87,7 +87,7 @@
                             {% elif good.item_category.key == "group1_platform"  %}
                     		    <a class="govuk-link govuk-link--no-visited-state" href="{% url "goods:platform_detail" good.id %}">View</a>
 							{% elif good.item_category.key == "group1_components" %}
-								<a class="govuk-link govuk-link--no-visited-state" href="{% url "goods:component_detail" good.id %}">View</a>
+								<a class="govuk-link govuk-link--no-visited-state" href="{% url "goods:component_accessory_detail" good.id %}">View</a>
 							{% elif good.item_category.key == "group3_software" %}
 								<a class="govuk-link govuk-link--no-visited-state" href="{% url "goods:software_detail" good.id %}">View</a>
 							{% elif good.item_category.key == "group1_materials" %}


### PR DESCRIPTION
fixing left out rename of `component_detail` in html file, goods.html