### PR TITLE
Ltd 3024 software summary page

### DIFF
--- a/core/summaries/summaries.py
+++ b/core/summaries/summaries.py
@@ -477,7 +477,7 @@ def get_summary_type_for_good(good):
     summary_map = {
         ProductCategories.PRODUCT_CATEGORY_COMPLETE_ITEM: SummaryTypes.COMPLETE_ITEM,
         ProductCategories.PRODUCT_CATEGORY_MATERIAL: SummaryTypes.MATERIAL,
-        ProductCategories.PRODUCT_CATEGORY_TECHNOLOGY: SummaryTypes.TECHNOLOGY,
+        ProductCategories.PRODUCT_CATEGORY_SOFTWARE: SummaryTypes.TECHNOLOGY,
         ProductCategories.PRODUCT_CATEGORY_COMPONENT_ACCESSORY: SummaryTypes.COMPONENT_ACCESSORY,
     }
 
@@ -507,7 +507,7 @@ def get_summary_type_for_good_on_application(good_on_application):
     summary_map = {
         ProductCategories.PRODUCT_CATEGORY_COMPLETE_ITEM: SummaryTypes.COMPLETE_ITEM,
         ProductCategories.PRODUCT_CATEGORY_MATERIAL: SummaryTypes.MATERIAL,
-        ProductCategories.PRODUCT_CATEGORY_TECHNOLOGY: SummaryTypes.TECHNOLOGY,
+        ProductCategories.PRODUCT_CATEGORY_SOFTWARE: SummaryTypes.TECHNOLOGY,
         ProductCategories.PRODUCT_CATEGORY_COMPONENT_ACCESSORY: SummaryTypes.COMPONENT_ACCESSORY,
     }
 

--- a/core/summaries/summaries.py
+++ b/core/summaries/summaries.py
@@ -492,15 +492,15 @@ def get_summary_type_for_good_on_application(good_on_application):
         return SummaryTypes.FIREARM
 
     if good_on_application.get("firearm_details"):
-        raise NoSummaryForType
+        raise NoSummaryForType("Missing `firearm_details`")
 
     good = good_on_application.get("good")
     if not good:
-        raise NoSummaryForType
+        raise NoSummaryForType("Missing `good`")
 
     item_category = good.get("item_category")
     if not item_category:
-        raise NoSummaryForType
+        raise NoSummaryForType("Missing `item_category`")
 
     item_category = item_category["key"]
 
@@ -514,4 +514,4 @@ def get_summary_type_for_good_on_application(good_on_application):
     try:
         return summary_map[item_category]
     except KeyError:
-        raise NoSummaryForType
+        raise NoSummaryForType(f"Did not find summary for product category {item_category}") from e

--- a/core/summaries/summaries.py
+++ b/core/summaries/summaries.py
@@ -484,7 +484,7 @@ def get_summary_type_for_good(good):
     try:
         return summary_map[item_category]
     except KeyError as e:
-        raise NoSummaryForType from e
+        raise NoSummaryForType(f"Did not find summary for product category {item_category}") from e
 
 
 def get_summary_type_for_good_on_application(good_on_application):

--- a/core/summaries/summaries.py
+++ b/core/summaries/summaries.py
@@ -461,6 +461,20 @@ class SummaryTypes:
     COMPONENT_ACCESSORY = "COMPONENT_ACCESSORY"
 
 
+def get_summary_type_from_item_category(item_category):
+    summary_map = {
+        ProductCategories.PRODUCT_CATEGORY_COMPLETE_ITEM: SummaryTypes.COMPLETE_ITEM,
+        ProductCategories.PRODUCT_CATEGORY_MATERIAL: SummaryTypes.MATERIAL,
+        ProductCategories.PRODUCT_CATEGORY_SOFTWARE: SummaryTypes.TECHNOLOGY,
+        ProductCategories.PRODUCT_CATEGORY_COMPONENT_ACCESSORY: SummaryTypes.COMPONENT_ACCESSORY,
+    }
+
+    try:
+        return summary_map[item_category]
+    except KeyError as e:
+        raise NoSummaryForType(f"Did not find summary for product category {item_category}") from e
+
+
 def get_summary_type_for_good(good):
     firearm_details = good.get("firearm_details")
     if firearm_details:
@@ -474,17 +488,7 @@ def get_summary_type_for_good(good):
 
     item_category = item_category["key"]
 
-    summary_map = {
-        ProductCategories.PRODUCT_CATEGORY_COMPLETE_ITEM: SummaryTypes.COMPLETE_ITEM,
-        ProductCategories.PRODUCT_CATEGORY_MATERIAL: SummaryTypes.MATERIAL,
-        ProductCategories.PRODUCT_CATEGORY_SOFTWARE: SummaryTypes.TECHNOLOGY,
-        ProductCategories.PRODUCT_CATEGORY_COMPONENT_ACCESSORY: SummaryTypes.COMPONENT_ACCESSORY,
-    }
-
-    try:
-        return summary_map[item_category]
-    except KeyError as e:
-        raise NoSummaryForType(f"Did not find summary for product category {item_category}") from e
+    return get_summary_type_from_item_category(item_category)
 
 
 def get_summary_type_for_good_on_application(good_on_application):
@@ -504,14 +508,4 @@ def get_summary_type_for_good_on_application(good_on_application):
 
     item_category = item_category["key"]
 
-    summary_map = {
-        ProductCategories.PRODUCT_CATEGORY_COMPLETE_ITEM: SummaryTypes.COMPLETE_ITEM,
-        ProductCategories.PRODUCT_CATEGORY_MATERIAL: SummaryTypes.MATERIAL,
-        ProductCategories.PRODUCT_CATEGORY_SOFTWARE: SummaryTypes.TECHNOLOGY,
-        ProductCategories.PRODUCT_CATEGORY_COMPONENT_ACCESSORY: SummaryTypes.COMPONENT_ACCESSORY,
-    }
-
-    try:
-        return summary_map[item_category]
-    except KeyError:
-        raise NoSummaryForType(f"Did not find summary for product category {item_category}") from e
+    return get_summary_type_from_item_category(item_category)

--- a/unit_tests/caseworker/tau/test_forms.py
+++ b/unit_tests/caseworker/tau/test_forms.py
@@ -495,7 +495,7 @@ def test_tau_assessment_form_without_feature_flag(data, valid, errors, rf, setti
                     "good": {
                         "id": "12345",
                         "item_category": {
-                            "key": ProductCategories.PRODUCT_CATEGORY_TECHNOLOGY,
+                            "key": ProductCategories.PRODUCT_CATEGORY_SOFTWARE,
                         },
                     },
                 },
@@ -507,7 +507,7 @@ def test_tau_assessment_form_without_feature_flag(data, valid, errors, rf, setti
                         "good_on_application": {
                             "good": {
                                 "id": "12345",
-                                "item_category": {"key": ProductCategories.PRODUCT_CATEGORY_TECHNOLOGY},
+                                "item_category": {"key": ProductCategories.PRODUCT_CATEGORY_SOFTWARE},
                             }
                         },
                         "summary": (

--- a/unit_tests/core/summaries/test_summaries.py
+++ b/unit_tests/core/summaries/test_summaries.py
@@ -43,7 +43,7 @@ def test_firearm_on_application_summary(data_standard_case, standard_firearm_exp
             SummaryTypes.MATERIAL,
         ),
         (
-            {"item_category": {"key": ProductCategories.PRODUCT_CATEGORY_TECHNOLOGY}},
+            {"item_category": {"key": ProductCategories.PRODUCT_CATEGORY_SOFTWARE}},
             SummaryTypes.TECHNOLOGY,
         ),
         (
@@ -88,7 +88,7 @@ def test_get_summary_type_for_good_no_summary_type(good):
             SummaryTypes.MATERIAL,
         ),
         (
-            {"good": {"item_category": {"key": ProductCategories.PRODUCT_CATEGORY_TECHNOLOGY}}},
+            {"good": {"item_category": {"key": ProductCategories.PRODUCT_CATEGORY_SOFTWARE}}},
             SummaryTypes.TECHNOLOGY,
         ),
         (

--- a/unit_tests/exporter/applications/views/goods/test_good_detail_summary_check_your_answers.py
+++ b/unit_tests/exporter/applications/views/goods/test_good_detail_summary_check_your_answers.py
@@ -126,7 +126,7 @@ def test_good_detail_summary_check_your_answers_view_template_used(
                 "good": {
                     "id": str(uuid.uuid4()),
                     "item_category": {
-                        "key": ProductCategories.PRODUCT_CATEGORY_TECHNOLOGY,
+                        "key": ProductCategories.PRODUCT_CATEGORY_SOFTWARE,
                     },
                 },
             },

--- a/unit_tests/exporter/goods/views/test_software_product_details.py
+++ b/unit_tests/exporter/goods/views/test_software_product_details.py
@@ -26,7 +26,7 @@ def mock_good_get(requests_mock, data_standard_case):
             "is_pv_graded": {"key": "yes", "value": "Yes"},
             "is_covered_by_firearm_act_section_one_two_or_five": "Yes",
             "item_category": {
-                "key": ProductCategories.PRODUCT_CATEGORY_TECHNOLOGY,
+                "key": ProductCategories.PRODUCT_CATEGORY_SOFTWARE,
             },
         }
     )


### PR DESCRIPTION
Use old key for software product category.

We have updated the name from "software" to "technology" except for how the Good.item_category is stored and so this still needs to use the old key.