### PR TITLE
Enable Make recommendation button for BEIS teams

### DIFF
--- a/caseworker/advice/services.py
+++ b/caseworker/advice/services.py
@@ -5,6 +5,9 @@ from requests.exceptions import HTTPError
 from core import client
 
 # Queues
+BEIS_CHEMICAL_CASES_TO_REVIEW = "BEIS_CHEMICAL_CASES_TO_REVIEW"
+BEIS_NUCLEAR_CASES_TO_REVIEW = "BEIS_NUCLEAR_CASES_TO_REVIEW"
+BEIS_NUCLEAR_COUNTERSIGNING = "BEIS_NUCLEAR_COUNTERSIGNING"
 FCDO_CASES_TO_REVIEW_QUEUE = "FCDO_CASES_TO_REVIEW"
 FCDO_CPACC_CASES_TO_REVIEW_QUEUE = "FCDO_CPACC_CASES_TO_REVIEW"
 FCDO_COUNTERSIGNING_QUEUE = "FCDO_COUNTER_SIGNING"
@@ -23,6 +26,10 @@ MOD_CONSOLIDATE_QUEUES = [
 LU_POST_CIRC_FINALISE_QUEUE = "LU_POST_CIRC_FINALISE"
 
 # Teams
+BEIS_TEAMS = [
+    "BEIS_CHEMICAL",
+    "BEIS_NUCLEAR",
+]
 FCDO_TEAM = "FCO"
 LICENSING_UNIT_TEAM = "LICENSING_UNIT"
 MOD_ECJU_TEAM = "MOD_ECJU"
@@ -320,8 +327,14 @@ def get_advice_tab_context(case, caseworker, queue_id):
         },
     }
 
-    if team_alias in (FCDO_TEAM, *MOD_CONSOLIDATE_TEAMS):
-        if queue_alias in (FCDO_CASES_TO_REVIEW_QUEUE, FCDO_CPACC_CASES_TO_REVIEW_QUEUE, *MOD_CONSOLIDATE_QUEUES):
+    if team_alias in (FCDO_TEAM, *MOD_CONSOLIDATE_TEAMS, *BEIS_TEAMS):
+        if queue_alias in (
+            FCDO_CASES_TO_REVIEW_QUEUE,
+            FCDO_CPACC_CASES_TO_REVIEW_QUEUE,
+            *MOD_CONSOLIDATE_QUEUES,
+            BEIS_CHEMICAL_CASES_TO_REVIEW,
+            BEIS_NUCLEAR_CASES_TO_REVIEW,
+        ):
             existing_advice = get_my_advice(case.advice, caseworker["id"])
 
             if not existing_advice:
@@ -334,7 +347,7 @@ def get_advice_tab_context(case, caseworker, queue_id):
                 context["buttons"]["clear_recommendation"] = True
                 context["buttons"]["move_case_forward"] = True
 
-        elif queue_alias == FCDO_COUNTERSIGNING_QUEUE:
+        elif queue_alias == FCDO_COUNTERSIGNING_QUEUE or queue_alias == BEIS_NUCLEAR_COUNTERSIGNING:
             advice_to_countersign = get_advice_to_countersign(case.advice, caseworker)
             countersigned_by = get_countersigners(advice_to_countersign)
 

--- a/unit_tests/caseworker/advice/test_services.py
+++ b/unit_tests/caseworker/advice/test_services.py
@@ -1,9 +1,13 @@
 import pytest
 
 from caseworker.advice.services import (
+    BEIS_CHEMICAL_CASES_TO_REVIEW,
+    BEIS_NUCLEAR_CASES_TO_REVIEW,
+    BEIS_NUCLEAR_COUNTERSIGNING,
     FCDO_CASES_TO_REVIEW_QUEUE,
     FCDO_CPACC_CASES_TO_REVIEW_QUEUE,
     FCDO_COUNTERSIGNING_QUEUE,
+    BEIS_TEAMS,
     FCDO_TEAM,
     LICENSING_UNIT_TEAM,
     LU_POST_CIRC_FINALISE_QUEUE,
@@ -51,6 +55,8 @@ def advice(current_user):
 advice_tab_test_data = [
     # Fields: Has Advice, Advice Level, Countersigned, User Team, Current Queue, Expected Tab URL, Expected Buttons Enabled (dict)
     # An individual giving advice on a case for the first time
+    (False, "user", False, BEIS_TEAMS[0], BEIS_CHEMICAL_CASES_TO_REVIEW, "cases:advice_view", {"make_recommendation": True},),
+    (False, "user", False, BEIS_TEAMS[1], BEIS_NUCLEAR_CASES_TO_REVIEW, "cases:advice_view", {"make_recommendation": True},),
     (False, "user", False, FCDO_TEAM, FCDO_CASES_TO_REVIEW_QUEUE, "cases:advice_view", {"make_recommendation": True},),
     (False, "user", False, FCDO_TEAM, FCDO_CPACC_CASES_TO_REVIEW_QUEUE, "cases:advice_view", {"make_recommendation": True},),
     (False, "user", False, MOD_CONSOLIDATE_TEAMS[0], MOD_CONSOLIDATE_QUEUES[0], "cases:advice_view", {"make_recommendation": True},),
@@ -59,6 +65,8 @@ advice_tab_test_data = [
     (False, "user", False, MOD_CONSOLIDATE_TEAMS[2], MOD_CONSOLIDATE_QUEUES[3], "cases:advice_view", {"make_recommendation": True},),
     (False, "user", False, MOD_CONSOLIDATE_TEAMS[3], MOD_CONSOLIDATE_QUEUES[4], "cases:advice_view", {"make_recommendation": True},),
     # An individual accessing the cases again after having given advice
+    (True, "user", False, BEIS_TEAMS[0], BEIS_CHEMICAL_CASES_TO_REVIEW, "cases:view_my_advice", {"edit_recommendation": True, "clear_recommendation": True, "move_case_forward": True},),
+    (True, "user", False, BEIS_TEAMS[1], BEIS_NUCLEAR_CASES_TO_REVIEW, "cases:view_my_advice", {"edit_recommendation": True, "clear_recommendation": True, "move_case_forward": True},),
     (True, "user", False, FCDO_TEAM, FCDO_CASES_TO_REVIEW_QUEUE, "cases:view_my_advice", {"edit_recommendation": True, "clear_recommendation": True, "move_case_forward": True},),
     (True, "user", False, FCDO_TEAM, FCDO_CPACC_CASES_TO_REVIEW_QUEUE, "cases:view_my_advice", {"edit_recommendation": True, "clear_recommendation": True, "move_case_forward": True},),
     (True, "user", False, MOD_CONSOLIDATE_TEAMS[0], MOD_CONSOLIDATE_QUEUES[0], "cases:view_my_advice", {"edit_recommendation": True, "clear_recommendation": True, "move_case_forward": True},),
@@ -68,7 +76,9 @@ advice_tab_test_data = [
     (True, "user", False, MOD_CONSOLIDATE_TEAMS[3], MOD_CONSOLIDATE_QUEUES[4], "cases:view_my_advice", {"edit_recommendation": True, "clear_recommendation": True, "move_case_forward": True},),
     # An individual countersigning advice on a case for the first time
     (True, "user", False, FCDO_TEAM, FCDO_COUNTERSIGNING_QUEUE, "cases:countersign_advice_view", {"review_and_countersign": True},),
+    (True, "user", False, BEIS_TEAMS[1], BEIS_NUCLEAR_COUNTERSIGNING, "cases:countersign_advice_view", {"review_and_countersign": True},),
     # An individual accessing the case after giving countersigned advice
+    (True, "user", True, BEIS_TEAMS[1], BEIS_NUCLEAR_COUNTERSIGNING, "cases:countersign_view", {"edit_recommendation": True, "move_case_forward": True},),
     (True, "user", True, FCDO_TEAM, FCDO_COUNTERSIGNING_QUEUE, "cases:countersign_view", {"edit_recommendation": True, "move_case_forward": True},),
     # An individual consolidating advice on a case for the first time
     (True, "user", True, MOD_ECJU_TEAM, MOD_CASES_TO_REVIEW_QUEUES[0], "cases:consolidate_advice_view", {"review_and_combine": True},),


### PR DESCRIPTION
## Change description

Users from BEIS teams can give recommendation for the cases in their queues.