### PR TITLE
LTD-3051: shorten BEIS Nuclear team name

### DIFF
--- a/exporter/templates/includes/ecju-queries.html
+++ b/exporter/templates/includes/ecju-queries.html
@@ -7,6 +7,8 @@
 			<div class="app-ecju-query__item">
 				{% if "BEIS_CHEMICAL" == ecju_query.team.alias %}
 					<p class="app-ecju-query__heading">BEIS</p>
+				{% elif "BEIS_NUCLEAR" == ecju_query.team.alias %}
+					<p class="app-ecju-query__heading">BEIS Nuclear</p>
 				{% else %}
 					<p class="app-ecju-query__heading">{{ ecju_query.team.name }}</p>
 				{% endif %}

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -2186,5 +2186,22 @@ def data_ecju_queries():
                 "created_at": "2022-11-30T17:00:17.479098Z",
                 "responded_at": None,
             },
+            {
+                "id": "96fe0801-58ae-4a69-b2ba-f44dc79d3af4",
+                "question": "nuclear team",
+                "response": None,
+                "case": "e09a059c-1e85-47f9-b69b-edea1e91eb6d",
+                "responded_by_user": None,
+                "team": {
+                    "id": "88164d59-8724-4596-811b-40b60b5cf892",
+                    "name": "BEIS Nuclear controls",
+                    "part_of_ecju": False,
+                    "is_ogd": True,
+                    "alias": "BEIS_NUCLEAR",
+                    "department": "f4369d60-5aff-4b7f-b5d4-75e3fa0f402e",
+                },
+                "created_at": "2022-11-30T17:00:17.479098Z",
+                "responded_at": None,
+            },
         ]
     }

--- a/unit_tests/exporter/applications/views/ecju_queries/test_ecju_query_team_name.py
+++ b/unit_tests/exporter/applications/views/ecju_queries/test_ecju_query_team_name.py
@@ -34,9 +34,19 @@ def mock_ecju_queries(data_standard_case, data_ecju_queries, requests_mock):
     )
 
 
-def test_beis_chemical_team_name_shortened(authorized_client, url):
+@pytest.fixture()
+def rendered_ecju_queries(authorized_client, url):
     response = authorized_client.get(url)
-    queries = BeautifulSoup(response.content, "html.parser").find_all(id="open-ecju-query")
+    return BeautifulSoup(response.content, "html.parser").find_all(id="open-ecju-query")
 
-    assert queries[0].p.get_text() == "BEIS CWC"
-    assert queries[1].p.get_text() == "BEIS"
+
+def test_renders_team_name(rendered_ecju_queries):
+    assert rendered_ecju_queries[0].p.get_text() == "BEIS CWC"
+
+
+def test_shortens_beis_chemical_team_name(rendered_ecju_queries):
+    assert rendered_ecju_queries[1].p.get_text() == "BEIS"
+
+
+def test_shortens_beis_nuclear_team_name(rendered_ecju_queries):
+    assert rendered_ecju_queries[2].p.get_text() == "BEIS Nuclear"


### PR DESCRIPTION
GIVEN I am a user belonging the BEIS nuclear control team 

WHEN I navigate to a case

AND I click on the queries tab

THEN I am able to send a query to the exporter on the case 

AND my name is displayed as “BEIS Nuclear”

-----

*note*: I wonder if we have to do this more than twice if it would be worth having a `display_name` field or similar for team names?



![Screenshot 2022-12-13 at 14 31 28](https://user-images.githubusercontent.com/16647486/207360700-25852bc1-42b4-4b31-9a9f-7aebc9f42936.png)

