### PR TITLE
500 error page improvements

### DIFF
--- a/exporter/templates/500.html
+++ b/exporter/templates/500.html
@@ -14,5 +14,9 @@
 	<p class="govuk-body">
 		<strong>Request ID:</strong> {{ request.META.HTTP_X_B3_TRACEID }}
 	</p>
+    {% if request.sentry_uuid %}
+	<p class="govuk-body">
+		<strong>Error ID:</strong> {{ request.sentry_uuid }}
+	</p>
 	{% endif %}
 {% endblock %}

--- a/exporter/templates/500.html
+++ b/exporter/templates/500.html
@@ -14,6 +14,7 @@
 	<p class="govuk-body">
 		<strong>Request ID:</strong> {{ request.META.HTTP_X_B3_TRACEID }}
 	</p>
+	{% endif %}
     {% if request.sentry_uuid %}
 	<p class="govuk-body">
 		<strong>Error ID:</strong> {{ request.sentry_uuid }}

--- a/unit_tests/exporter/core/test_middleware.py
+++ b/unit_tests/exporter/core/test_middleware.py
@@ -16,6 +16,7 @@ def test_service_error_handler_non_service_error_exception(rf, mocker):
     service_error_handler = ServiceErrorHandler(get_response)
 
     request = rf.get("/")
+    request.META["HTTP_REFERER"] = "/test"
     not_service_error = Exception()
     assert service_error_handler.process_exception(request, not_service_error) is None
 
@@ -26,6 +27,7 @@ def test_service_error_handler_service_error(rf, mocker, caplog, settings):
     service_error_handler = ServiceErrorHandler(get_response)
 
     request = rf.get("/")
+    request.META["HTTP_REFERER"] = "/test"
     response = HttpResponse("OK")
     mock_error_page = mocker.patch("exporter.core.middleware.error_page")
     mock_error_page.return_value = response
@@ -50,6 +52,7 @@ def test_service_error_handler_service_error_with_debug(rf, mocker, caplog, sett
     service_error_handler = ServiceErrorHandler(get_response)
 
     request = rf.get("/")
+    request.META["HTTP_REFERER"] = "/test"
     response = HttpResponse("OK")
     mock_error_page = mocker.patch("exporter.core.middleware.error_page")
     mock_error_page.return_value = response


### PR DESCRIPTION
Added a UUID to the 500 error page and also sending to Sentry for easier debugging.

The back button has been updated to return to the referring page or if not possible the homepage