### PR TITLE
 LTD-3099-typo 

### DIFF
--- a/caseworker/advice/forms.py
+++ b/caseworker/advice/forms.py
@@ -100,7 +100,7 @@ class GiveApprovalAdviceForm(forms.Form):
     instructions_to_exporter = forms.CharField(
         widget=forms.Textarea(attrs={"rows": "10"}),
         label="Add any instructions for the exporter (optional)",
-        help_text="These may be added to the licence cover letter, subject to review by the Licencing Unit.",
+        help_text="These may be added to the licence cover letter, subject to review by the Licensing Unit.",
         required=False,
     )
     footnote_details = PicklistCharField(


### PR DESCRIPTION
There is a tiny typo on the below screen (in the queue ‘FCDO Cases to Review’). Licensing Unit is written ‘Licencing Unit’ but should be ‘Licensing Unit’.