### PR TITLE
LTD-3209: Filter NLR products when re-issuing a licence

### DIFF
--- a/caseworker/templates/components/goods-licence-list.html
+++ b/caseworker/templates/components/goods-licence-list.html
@@ -5,7 +5,7 @@
 	<thead class="govuk-table__head">
 		<tr class="govuk-table__row">
 			<th class="govuk-table__header" scope="col">{% lcs 'advice.FinaliseLicenceForm.GoodsTable.CLC_COLUMN' %}</th>
-			<th class="govuk-table__header" scope="col">{% lcs 'advice.FinaliseLicenceForm.GoodsTable.DESCRIPTION_COLUMN' %}</th>
+			<th class="govuk-table__header" scope="col">Name</th>
 			<th class="govuk-table__header" scope="col">{% lcs 'advice.FinaliseLicenceForm.GoodsTable.DECISION_COLUMN' %}</th>
 			<th class="govuk-table__header" scope="col">{% lcs 'advice.FinaliseLicenceForm.GoodsTable.LICENCED_QTY_COLUMN' %}</th>
 			<th class="govuk-table__header" scope="col">{% lcs 'advice.FinaliseLicenceForm.GoodsTable.LICENCED_VALUE_COLUMN' %}</th>
@@ -25,7 +25,10 @@
 						{% endif %}
 					</td>
 					<td class="govuk-table__cell">
-						{{ good.good.name }}{% if good.good.name %}<br>{% endif %}
+						<p class="govuk-body govuk-!-font-weight-bold">
+							{{ good.good.name }}
+						</p>
+						{% if good.good.name %}<br>{% endif %}
 						{{ good.good.description }}
 					</td>
 					<td class="govuk-table__cell">
@@ -86,7 +89,7 @@
 	<caption class="govuk-table__caption govuk-table__caption--m">No licence required</caption>
 	<thead class="govuk-table__head">
 		<tr class="govuk-table__row">
-			<th class="govuk-table__header" scope="col">{% lcs 'advice.FinaliseLicenceForm.GoodsTable.DESCRIPTION_COLUMN' %}</th>
+			<th class="govuk-table__header" scope="col">Name</th>
 			<th></th>
 		</tr>
 	</thead>

--- a/caseworker/templates/components/goods-licence-reissue-list.html
+++ b/caseworker/templates/components/goods-licence-reissue-list.html
@@ -6,7 +6,7 @@
 	<thead class="govuk-table__head">
 		<tr class="govuk-table__row">
 			<th class="govuk-table__header" scope="col">{% lcs 'advice.FinaliseLicenceForm.GoodsTable.CLC_COLUMN' %}</th>
-			<th class="govuk-table__header" scope="col">{% lcs 'advice.FinaliseLicenceForm.GoodsTable.DESCRIPTION_COLUMN' %}</th>
+			<th class="govuk-table__header" scope="col">Name</th>
 			<th class="govuk-table__header" scope="col">{% lcs 'advice.FinaliseLicenceForm.GoodsTable.DECISION_COLUMN' %}</th>
 			<th class="govuk-table__header" scope="col">{% lcs 'advice.FinaliseLicenceForm.GoodsTable.LICENCED_QTY_COLUMN' %}</th>
 			<th class="govuk-table__header" scope="col">{% lcs 'advice.FinaliseLicenceForm.GoodsTable.LICENCED_VALUE_COLUMN' %}</th>
@@ -14,63 +14,97 @@
 	</thead>
 	<tbody class="govuk-table__body">
 		{% for good in data %}
-			<tr class="govuk-table__row">
-				<td class="govuk-table__cell">
-					{% include 'includes/control-list-entries.html' with control_list_entries=good.control_list_entries %}
-				</td>
-				<td class="govuk-table__cell">
-					{{ good.description }}
-				</td>
-				<td class="govuk-table__cell">
-					<p class="govuk-body govuk-!-font-weight-bold">
-						{% if good.advice.type.key == 'proviso' %}
-							Approve with proviso
+			{% if good.advice.type.key == 'approve' and has_proviso %}
+				{# "approve with proviso" takes priority over "approve" #}
+			{% elif good.advice.type.key != 'no_licence_required' %}
+				<tr class="govuk-table__row">
+					<td class="govuk-table__cell">
+						{% if good.is_good_controlled is not None %}
+							{% include 'includes/control-list-entries.html' with control_list_entries=good.control_list_entries %}
 						{% else %}
-							{{ good.advice.type.value }}
+							{% include 'includes/control-list-entries.html' with control_list_entries=good.good.control_list_entries %}
 						{% endif %}
-					</p>
-					<p>{{ good.advice.text }}<br></p>
-					{% if good.advice.proviso %}
-						<p>{% lcs 'advice.FinaliseLicenceForm.GoodsTable.PROVISO_TEXT' %}</p>
-						{{ good.advice.proviso }}
-					{% endif %}
-				</td>
-				<td class="govuk-table__cell">
-					<span id="quantity-applied-for-{{ good.good_on_application_id }}" class="govuk-hint govuk-!-margin-0">{% lcs 'advice.FinaliseLicenceForm.GoodsTable.APPLIED_FOR_TEXT' %} {{ good.applied_for_quantity|intcomma }} {{ good.units.value }}</span>
-					<span id="quantity-usage-licenced-{{ good.good_on_application_id }}" class="govuk-hint govuk-!-margin-0">{% lcs 'advice.FinaliseLicenceForm.GoodsTable.PREVIOUSLY_LICENCED' %} {{ good.licenced_quantity|intcomma }} {{ good.units.value }}</span>
-					<span id="quantity-usage-{{ good.good_on_application_id }}" class="govuk-hint govuk-!-margin-0">{% lcs 'advice.FinaliseLicenceForm.GoodsTable.USAGE' %} {{ good.usage|intcomma }} {{ good.units.value }}</span>
-					<input
-						class="govuk-input js-update-total-value"
-						id="quantity-{{ good.good_on_application_id }}"
-						type="text"
-						name="quantity-{{ good.good_on_application_id }}"
-						value="{{ good.licenced_quantity|subtract:good.usage }}"
-						data-applied-for-quantity="{{ good.licenced_quantity|subtract:good.usage }}"
-						data-applied-for-value="{{ good.licenced_value_per_item|multiply:good.usage }}"
-						data-output-element-id="value-{{ good.good_on_application_id }}"
-					/>
-					<br>
-				</td>
-				<td class="govuk-table__cell">
-					<span id="value-applied-for-{{ good.good_on_application_id }}" class="govuk-hint govuk-!-margin-0">{% lcs 'advice.FinaliseLicenceForm.GoodsTable.APPLIED_FOR_TEXT' %} £{{ good.applied_for_value|multiply:good.applied_for_quantity|floatformat:2 }}</span>
-					<span id="value-usage-licenced-{{ good.good_on_application_id }}" class="govuk-hint govuk-!-margin-0">{% lcs 'advice.FinaliseLicenceForm.GoodsTable.PREVIOUSLY_LICENCED' %} £{{ good.licenced_value|floatformat:2 }}</span>
-					<span id="value-usage-{{ good.good_on_application_id }}" class="govuk-hint govuk-!-margin-0">{% lcs 'advice.FinaliseLicenceForm.GoodsTable.USAGE' %} £{{ good.licenced_value_per_item|multiply:good.usage|floatformat:2 }}</span>
-					<div class="lite-currency-input">
-						<div class="lite-currency-input__symbol {% if error %}lite-currency--error{% endif %}" aria-hidden="true">£</div>
-						{% with good.licenced_quantity|subtract:good.usage as quantity %}
-							<input
-								class="govuk-input"
-								id="value-{{ good.good_on_application_id }}"
-								type="text"
-								name="value-{{ good.good_on_application_id }}"
-								value="{{ good.licenced_value_per_item|multiply:quantity|floatformat:2 }}"/>
-						{% endwith %}
-					</div>
-				</td>
-			</tr>
+					</td>
+					<td class="govuk-table__cell">
+						<p class="govuk-body govuk-!-font-weight-bold">
+							{{ good.name }}
+						</p>
+						{% if good.name %}<br>{% endif %}
+						{{ good.description }}
+					</td>
+					<td class="govuk-table__cell">
+						<p class="govuk-body govuk-!-font-weight-bold">
+							{% if good.advice.type.key == 'proviso' %}
+								Approve with proviso
+							{% else %}
+								{{ good.advice.type.value }}
+							{% endif %}
+						</p>
+						<p>{{ good.advice.text }}<br></p>
+						{% if good.advice.proviso %}
+							<p>{% lcs 'advice.FinaliseLicenceForm.GoodsTable.PROVISO_TEXT' %}</p>
+							{{ good.advice.proviso }}
+						{% endif %}
+					</td>
+					<td class="govuk-table__cell">
+						<span id="quantity-applied-for-{{ good.good_on_application_id }}" class="govuk-hint govuk-!-margin-0">{% lcs 'advice.FinaliseLicenceForm.GoodsTable.APPLIED_FOR_TEXT' %} {{ good.applied_for_quantity|intcomma }} {{ good.units.value }}</span>
+						<span id="quantity-usage-licenced-{{ good.good_on_application_id }}" class="govuk-hint govuk-!-margin-0">{% lcs 'advice.FinaliseLicenceForm.GoodsTable.PREVIOUSLY_LICENCED' %} {{ good.licenced_quantity|intcomma }} {{ good.units.value }}</span>
+						<span id="quantity-usage-{{ good.good_on_application_id }}" class="govuk-hint govuk-!-margin-0">{% lcs 'advice.FinaliseLicenceForm.GoodsTable.USAGE' %} {{ good.usage|intcomma }} {{ good.units.value }}</span>
+						<input
+							class="govuk-input js-update-total-value"
+							id="quantity-{{ good.good_on_application_id }}"
+							type="text"
+							name="quantity-{{ good.good_on_application_id }}"
+							value="{{ good.licenced_quantity|subtract:good.usage }}"
+							data-applied-for-quantity="{{ good.licenced_quantity|subtract:good.usage }}"
+							data-applied-for-value="{{ good.licenced_value_per_item|multiply:good.usage }}"
+							data-output-element-id="value-{{ good.good_on_application_id }}"
+						/>
+						<br>
+					</td>
+					<td class="govuk-table__cell">
+						<span id="value-applied-for-{{ good.good_on_application_id }}" class="govuk-hint govuk-!-margin-0">{% lcs 'advice.FinaliseLicenceForm.GoodsTable.APPLIED_FOR_TEXT' %} £{{ good.applied_for_value|multiply:good.applied_for_quantity|floatformat:2 }}</span>
+						<span id="value-usage-licenced-{{ good.good_on_application_id }}" class="govuk-hint govuk-!-margin-0">{% lcs 'advice.FinaliseLicenceForm.GoodsTable.PREVIOUSLY_LICENCED' %} £{{ good.licenced_value|floatformat:2 }}</span>
+						<span id="value-usage-{{ good.good_on_application_id }}" class="govuk-hint govuk-!-margin-0">{% lcs 'advice.FinaliseLicenceForm.GoodsTable.USAGE' %} £{{ good.licenced_value_per_item|multiply:good.usage|floatformat:2 }}</span>
+						<div class="lite-currency-input">
+							<div class="lite-currency-input__symbol {% if error %}lite-currency--error{% endif %}" aria-hidden="true">£</div>
+							{% with good.licenced_quantity|subtract:good.usage as quantity %}
+								<input
+									class="govuk-input"
+									id="value-{{ good.good_on_application_id }}"
+									type="text"
+									name="value-{{ good.good_on_application_id }}"
+									value="{{ good.licenced_value_per_item|multiply:quantity|floatformat:2 }}"/>
+							{% endwith %}
+						</div>
+					</td>
+				</tr>
+			{% endif %}
 		{% endfor %}
 	</tbody>
 </table>
+
+{% if any_nlr %}
+<table class="govuk-table">
+	<caption class="govuk-table__caption govuk-table__caption--m">No licence required</caption>
+	<thead class="govuk-table__head">
+		<tr class="govuk-table__row">
+			<th class="govuk-table__header" scope="col">Name</th>
+			<th></th>
+		</tr>
+	</thead>
+	<tbody>
+		{% for good in data %}
+			{% if good.advice.type.key == 'no_licence_required' %}
+				<td class="govuk-table__cell">
+					<p>{{ good.name }}</p>{% if good.name %}<br>{% endif %}
+					{{ good.description }}
+				</td>
+			{% endif %}
+		{% endfor %}
+	</tbody>
+</table>
+{% endif %}
 
 {% block javascript %}
     <script src="{% static 'javascripts/update-total-value.js' %}"></script>


### PR DESCRIPTION
## Change description

In case of re-issuing a licence, LU needs to finalise the application again. We use a different form when re-issuing as opposed to initial licence issue and this form currently is not filtering NLR products. It is not aware of NLR products and showing them in this case.

When the form is submitted we attach those NLR products also to the licence. They in turn get included in the licence pdf and also in the details sent to HMRC which is not correct.

Update the form to account for NLR products and exclude them from including on the licence.