### PR TITLE
LTD-3210 Update guidance text for file uploads to include list of acceptable file types

### DIFF
--- a/exporter/applications/forms/parties.py
+++ b/exporter/applications/forms/parties.py
@@ -362,7 +362,7 @@ class PartyDocumentsForm(forms.Form):
 class PartyDocumentUploadForm(forms.Form):
     title = "Upload an end-user document"
     party_document = forms.FileField(
-        label="",
+        label="Upload a DOCX, DOC, PDF or PNG file.",
         error_messages={
             "required": "Select an end-user document",
         },
@@ -418,7 +418,7 @@ class PartyDocumentUploadForm(forms.Form):
 class PartyEnglishTranslationDocumentUploadForm(forms.Form):
     title = "Upload an English translation"
     party_eng_translation_document = forms.FileField(
-        label="",
+        label="Upload a DOCX, DOC, PDF or PNG file.",
         error_messages={
             "required": "Select an English translation",
         },
@@ -443,7 +443,7 @@ class PartyEnglishTranslationDocumentUploadForm(forms.Form):
 class PartyCompanyLetterheadDocumentUploadForm(forms.Form):
     title = "Upload a document on company letterhead"
     party_letterhead_document = forms.FileField(
-        label="",
+        label="Upload a DOCX, DOC, PDF or PNG file.",
         error_messages={
             "required": "Select a document on company letterhead",
         },

--- a/exporter/goods/forms/common.py
+++ b/exporter/goods/forms/common.py
@@ -355,7 +355,7 @@ class ProductDocumentUploadForm(BaseForm):
         TITLE = "Upload a document that shows what your product is designed to do"
 
     product_document = forms.FileField(
-        label="Upload a file",
+        label="Upload a DOCX, DOC, PDF or PNG file.",
         error_messages={
             "required": "Select a document that shows what your product is designed to do",
         },

--- a/exporter/goods/forms/firearms.py
+++ b/exporter/goods/forms/firearms.py
@@ -216,7 +216,7 @@ class FirearmAttachRFDCertificate(BaseForm):
         TITLE = "Upload a registered firearms dealer certificate"
 
     file = forms.FileField(
-        label="",
+        label="Upload a DOCX, DOC, PDF or PNG file.",
         error_messages={
             "required": "Select a registered firearms dealer certificate",
         },

--- a/exporter/goods/forms/goods.py
+++ b/exporter/goods/forms/goods.py
@@ -306,7 +306,7 @@ def format_list_item(link, name, description):
 def upload_firearms_act_certificate_form(section, filename, back_link):
     return Form(
         title=f"Attach your Firearms Act 1968 {section} certificate",
-        description="The file must be smaller than 50MB",
+        description="Upload a DOCX, DOC, PDF or PNG file.\n\nThe file must be smaller than 50MB.",
         questions=[
             HiddenField("firearms_certificate_uploaded", False),
             FileUpload(),
@@ -1139,7 +1139,7 @@ class AttachFirearmsDealerCertificateForm(forms.Form):
     title = "Attach your registered firearms dealer certificate"
 
     file = forms.FileField(
-        label="",
+        label="Upload a DOCX, DOC, PDF or PNG file.",
         help_text="The file must be smaller than 50MB",
         error_messages={
             "required": "Select certificate file to upload",

--- a/exporter/organisation/forms.py
+++ b/exporter/organisation/forms.py
@@ -52,7 +52,7 @@ class UploadSectionFiveCertificateForm(forms.Form):
 
 class UploadFirearmsCertificateForm(forms.Form):
     file = forms.FileField(
-        label="",
+        label="Upload a DOCX, DOC, PDF or PNG file.",
         help_text="The file must be smaller than 50MB",
         error_messages={"required": "Select certificate file to upload"},
     )

--- a/lite_content/lite_exporter_frontend/goods.py
+++ b/lite_content/lite_exporter_frontend/goods.py
@@ -357,7 +357,8 @@ class EditGoodForm:
 class AttachDocumentForm:
     TITLE = "Attach a document"
     DESCRIPTION = (
-        "Documentation could be specifications, datasheets, sales brochures, drawings "
+        "Upload a DOCX, DOC, PDF or PNG file."
+        "\n\nDocumentation could be specifications, datasheets, sales brochures, drawings "
         "or anything else that fully details what the product is and what it's designed to do."
         "\n\nDo not attach a document that’s above OFFICIAL-SENSITIVE. "
         "\n\nThe file must be smaller than 50MB."

--- a/lite_content/lite_exporter_frontend/strings.py
+++ b/lite_content/lite_exporter_frontend/strings.py
@@ -160,7 +160,9 @@ class UltimateEndUser:
         class AttachDocuments:
             TITLE = "Attach a document"
             DESCRIPTION = (
-                "Do not attach a document that's above OFFICIAL-SENSITIVE.\n\nThe file must be smaller than 50MB."
+                "Upload a DOCX, DOC, PDF or PNG file."
+                "\n\nDo not attach a document that's above OFFICIAL-SENSITIVE."
+                "\n\nThe file must be smaller than 50MB."
             )
             DESCRIPTION_FIELD_TITLE = "Description"
             BACK = "Back to ultimate recipients"
@@ -187,7 +189,9 @@ class Consignee:
         class AttachDocuments:
             TITLE = "Attach a document"
             DESCRIPTION = (
-                "Do not attach a document that's above OFFICIAL-SENSITIVE.\n\nThe file must be smaller than 50MB."
+                "Upload a DOCX, DOC, PDF or PNG file."
+                "\n\nDo not attach a document that's above OFFICIAL-SENSITIVE."
+                "\n\nThe file must be smaller than 50MB."
             )
             DESCRIPTION_FIELD_TITLE = "Description"
             BACK = "Back to consignee summary"
@@ -217,7 +221,9 @@ class ThirdParties:
         class AttachDocuments:
             TITLE = "Attach a document"
             DESCRIPTION = (
-                "Do not attach a document that's above OFFICIAL-SENSITIVE.\n\nThe file must be smaller than 50MB."
+                "Upload a DOCX, DOC, PDF or PNG file."
+                "\n\nDo not attach a document that's above OFFICIAL-SENSITIVE."
+                "\n\nThe file must be smaller than 50MB."
             )
             DESCRIPTION_FIELD_TITLE = "Description"
             BACK = "Back to third parties overview"
@@ -366,7 +372,9 @@ class AdditionalDocuments:
         class AttachDocuments:
             TITLE = "Attach a supporting document"
             DESCRIPTION = (
-                "Do not attach a document that's above OFFICIAL-SENSITIVE.\n\nThe file must be smaller than 50MB."
+                "Upload a DOCX, DOC, PDF or PNG file."
+                "\n\nDo not attach a document that's above OFFICIAL-SENSITIVE."
+                "\n\nThe file must be smaller than 50MB."
             )
             DESCRIPTION_FIELD_TITLE = "Description"
             BACK = "Back to supporting documents"

--- a/unit_tests/exporter/applications/views/test_add_good.py
+++ b/unit_tests/exporter/applications/views/test_add_good.py
@@ -331,10 +331,12 @@ def test_add_good_attach_firearm_dealer_certificate(url, authorized_client):
     )
 
     title = b"Attach your registered firearms dealer certificate"
+    label = b"Upload a DOCX, DOC, PDF or PNG file."
     response = authorized_client.post(
         url, data={"wizard_goto_step": AddGoodFormSteps.ATTACH_FIREARM_DEALER_CERTIFICATE}
     )
     assert title in response.content
+    assert label in response.content
     assert isinstance(response.context["form"], AttachFirearmsDealerCertificateForm)
     certificate = SimpleUploadedFile("test.pdf", b"file_content", content_type="application/pdf")
     response = authorized_client.post(


### PR DESCRIPTION
Please see parent issue for full details: LTD-3196

Wherever we have guidance text accompanying a file upload, we should make clear to the user that only certain file types are accepted.

