### PR TITLE
LTD-3186-Summary-Template

### DIFF
--- a/exporter/templates/applications/summary.html
+++ b/exporter/templates/applications/summary.html
@@ -1,9 +1,18 @@
 {% if not type %}
 	{% for key, value in answers.items %}
-		<h2 class="govuk-heading-m">{{ key }}</h2>
+		{% if value %}
+					<h2 class="govuk-heading-m">{{ key }}</h2>
+			{% else %}
+					{% if key != "Third parties" and key != "Consignee" %}
+						<h2 class="govuk-heading-m">{{ key }}</h2>
+			{% endif %}
+		{% endif %}
+
 		<div>
 			{% if not value %}
-				<p class="govuk-caption-m">{% lcs "applications.ApplicationPage.NO_INFORMATION_PROVIDED" %}</p>
+				{% if key != "Third parties" and key != "Consignee" %}
+					<p class="govuk-caption-m">{% lcs "applications.ApplicationPage.NO_INFORMATION_PROVIDED" %}</p>
+				{% endif %}
 			{% elif value|classname == 'str' %}
 				<dl class="govuk-summary-list">
 					<div class="govuk-summary-list__row">


### PR DESCRIPTION
Ideally, if they haven’t filled in the consignee/third party section we shouldn’t show it at all in this final check your answers summary.

SS shows third parties section is not filled so it is not showing up:
<img width="1414" alt="Screenshot 2023-01-05 at 23 30 57" src="https://user-images.githubusercontent.com/24960282/210899766-d53ad403-ef9f-4417-869b-584ced2ae1ad.png">

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/LTD-3186
- [x] Jira ticket has the correct status.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [x] Includes screenshot(s) - ideally before and after, but at least after

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [ ] Frontend assets have been re-compiled.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)