### PR TITLE
View cases with open queries tab

### DIFF
--- a/caseworker/queues/views.py
+++ b/caseworker/queues/views.py
@@ -60,8 +60,6 @@ class Cases(LoginRequiredMixin, TemplateView):
 
     @cached_property
     def data(self):
-        hidden = self.request.GET.get("hidden")
-
         params = {"page": int(self.request.GET.get("page", 1))}
         for key, value in self.request.GET.items():
             if key != "flags[]":
@@ -69,8 +67,11 @@ class Cases(LoginRequiredMixin, TemplateView):
 
         params["flags"] = self.request.GET.getlist("flags[]", [])
 
-        if hidden:
-            params["hidden"] = hidden
+        # if the hidden param is not true
+        # then cases with open queries are filtered out on team queue views
+        only_open_queries = self.request.GET.get("only_open_queries")
+        if only_open_queries == "True":
+            params["hidden"] = "True"
 
         data = get_cases_search_data(self.request, self.queue_pk, params)
         return data
@@ -78,6 +79,25 @@ class Cases(LoginRequiredMixin, TemplateView):
     @property
     def filters(self):
         return self.data["results"]["filters"]
+
+    def open_queries_tabs(self):
+        only_open_queries = self.request.GET.get("only_open_queries") or "False"
+
+        params_with_queries = self.request.GET.copy()
+        params_with_queries["only_open_queries"] = "True"
+        params_all_cases = self.request.GET.copy()
+        params_all_cases["only_open_queries"] = "False"
+
+        open_queries_url = "{}?{}".format(self.request.path, params_with_queries.urlencode())
+        all_cases_url = "{}?{}".format(self.request.path, params_all_cases.urlencode())
+
+        open_queries_tabs = {
+            "only_open_queries": only_open_queries,
+            "open_queries_url": open_queries_url,
+            "all_cases_url": all_cases_url,
+        }
+
+        return open_queries_tabs
 
     def get_context_data(self, *args, **kwargs):
 
@@ -112,6 +132,7 @@ class Cases(LoginRequiredMixin, TemplateView):
             "enforcement_check": Permission.ENFORCEMENT_CHECK.value in get_user_permissions(self.request),
             "updated_cases_banner_queue_id": UPDATED_CASES_QUEUE_ID,
             "show_updated_cases_banner": show_updated_cases_banner,
+            "open_queries_tabs": self.open_queries_tabs,
         }
 
         return super().get_context_data(*args, **context, **kwargs)

--- a/caseworker/templates/queues/cases.html
+++ b/caseworker/templates/queues/cases.html
@@ -61,6 +61,24 @@
 
 	{% include 'filters.html' %}
 
+	<div class="lite-tabs__container">
+		<div class="lite-tabs">
+			<a href="{{ open_queries_tabs.all_cases_url }}" class="lite-tabs__tab  {% if open_queries_tabs.only_open_queries == "False" %}lite-tabs__tab--selected{% endif %}" id="view-all-queries-tab">
+				{% if queue.is_system_queue %}
+					All cases
+				{% else %}
+					Cases to review
+				{% endif %}
+				{% if open_queries_tabs.only_open_queries == "False" %}
+					({{ data.count }})
+				{% endif %}
+			</a>
+			<a href="{{ open_queries_tabs.open_queries_url }}" class="lite-tabs__tab {% if open_queries_tabs.only_open_queries == "True" %}lite-tabs__tab--selected{% endif %}" id="view-open-queries-tab">
+				Open queries {% if open_queries_tabs.only_open_queries == "True" %}({{ data.count }}){% endif %}
+			</a>
+		</div>
+	</div>
+
 	<form id="form-cases" method="get" action="{% url 'queues:case_assignments' queue.id %}">
 		{% if not data.results.cases %}
 			{% include "includes/notice.html" with text='cases.CasesListPage.NO_CASES' %}


### PR DESCRIPTION
### aim

Add tabs beneath the filters on the cases views (both all cases and for specific queues), one tab shows all cases (with whatever filters have been applied) the other tab shows cases that have an ECJU Query that has NOT been responded to by the user.

***NOTE: this PR is just for the tabs, and a PR to add the `count` to the deselected tab will be upcoming. (as well as potentially no longer 'hiding' cases with open queries on the queue search)***

corresponding API PR to apply the query param= https://github.com/uktrade/lite-api/pull/1247 

all cases view:

<img width="1442" alt="Screenshot 2023-01-13 at 10 10 53" src="https://user-images.githubusercontent.com/16647486/212294559-bb029cb1-8346-48ae-b32f-b03ec82f0887.png">

team queue view:

<img width="1484" alt="Screenshot 2023-01-13 at 11 55 48" src="https://user-images.githubusercontent.com/16647486/212314932-347cae71-9542-4148-9c1f-6196cf4ca5d9.png">

