### PR TITLE
LTD-3189 open queries count

### DIFF
--- a/caseworker/queues/services.py
+++ b/caseworker/queues/services.py
@@ -63,6 +63,12 @@ def get_cases_search_data(request, queue_pk, params):
     return data.json()
 
 
+def head_cases_search_count(request, queue_pk, params):
+    querystring = convert_parameters_to_query_params({"queue_id": queue_pk, **params})
+    response = client.head(request, f"/cases/{querystring}")
+    return response.headers["Resource-Count"]
+
+
 def put_queue(request, pk, json):
     data = client.put(request, f"/queues/{pk}/", json)
     return data.json(), data.status_code

--- a/caseworker/templates/queues/cases.html
+++ b/caseworker/templates/queues/cases.html
@@ -71,10 +71,12 @@
 				{% endif %}
 				{% if open_queries_tabs.only_open_queries == "False" %}
 					({{ data.count }})
+				{% else %}
+					({{  open_queries_tabs.unselected_tab_count }})
 				{% endif %}
 			</a>
 			<a href="{{ open_queries_tabs.open_queries_url }}" class="lite-tabs__tab {% if open_queries_tabs.only_open_queries == "True" %}lite-tabs__tab--selected{% endif %}" id="view-open-queries-tab">
-				Open queries {% if open_queries_tabs.only_open_queries == "True" %}({{ data.count }}){% endif %}
+				Open queries {% if open_queries_tabs.only_open_queries == "True" %}({{ data.count }}){% else %}({{  open_queries_tabs.unselected_tab_count }}){% endif %}
 			</a>
 		</div>
 	</div>

--- a/caseworker/templates/queues/cases.html
+++ b/caseworker/templates/queues/cases.html
@@ -63,7 +63,7 @@
 
 	<div class="lite-tabs__container">
 		<div class="lite-tabs">
-			<a href="{{ open_queries_tabs.all_cases_url }}" class="lite-tabs__tab  {% if open_queries_tabs.only_open_queries == "False" %}lite-tabs__tab--selected{% endif %}" id="view-all-queries-tab">
+			<a href="{{ open_queries_tabs.all_cases_url }}" class="lite-tabs__tab  {% if open_queries_tabs.only_open_queries == "False" %}lite-tabs__tab--selected{% endif %}" id="all-queries-tab">
 				{% if queue.is_system_queue %}
 					All cases
 				{% else %}
@@ -75,7 +75,7 @@
 					({{  open_queries_tabs.unselected_tab_count }})
 				{% endif %}
 			</a>
-			<a href="{{ open_queries_tabs.open_queries_url }}" class="lite-tabs__tab {% if open_queries_tabs.only_open_queries == "True" %}lite-tabs__tab--selected{% endif %}" id="view-open-queries-tab">
+			<a href="{{ open_queries_tabs.open_queries_url }}" class="lite-tabs__tab {% if open_queries_tabs.only_open_queries == "True" %}lite-tabs__tab--selected{% endif %}" id="open-queries-tab">
 				Open queries {% if open_queries_tabs.only_open_queries == "True" %}({{ data.count }}){% else %}({{  open_queries_tabs.unselected_tab_count }}){% endif %}
 			</a>
 		</div>

--- a/core/client.py
+++ b/core/client.py
@@ -99,6 +99,7 @@ def perform_request(method, request, appended_address, data=None):
 
 
 get = partial(perform_request, "GET")
+head = partial(perform_request, "HEAD")
 patch = partial(perform_request, "PATCH")
 put = partial(perform_request, "PUT")
 post = partial(perform_request, "POST")

--- a/ui_tests/caseworker/features/queues.feature
+++ b/ui_tests/caseworker/features/queues.feature
@@ -71,3 +71,15 @@ Feature: I want to define new work queues and the teams they belong to
     Then my case is not in the queue
     When I go to the countersigning queue
     Then I should see my case in the cases list
+
+@all @internal @queues
+Feature: I want to view all cases ready to review
+  As a logged in government user
+  I want to see how many open cases there are
+  So that I can quickly make an assessement
+
+  Scenario: Go to work queue
+    Given I sign in to SSO or am signed into SSO
+    When I go to the internal homepage
+    Then I see the all cases tab
+    And I see the open queries tab

--- a/ui_tests/caseworker/pages/case_list_page.py
+++ b/ui_tests/caseworker/pages/case_list_page.py
@@ -21,6 +21,8 @@ class CaseListPage(BasePage):
     BUTTON_ASSIGN_USERS = "assign-users-button"  # ID
 
     # Filters
+    ALL_CASES_TAB = "all-queries-tab"
+    OPEN_CASES_TAB = "open-queries-tab"
     BUTTON_CLEAR_FILTERS = "button-clear-filters"  # ID
     LINK_ADVANCED_FILTERS = "advanced-filters-link"  # ID
     LINK_HIDE_FILTERS = "hide-filters-link"  # ID

--- a/ui_tests/caseworker/step_defs/test_queues.py
+++ b/ui_tests/caseworker/step_defs/test_queues.py
@@ -4,6 +4,7 @@ from ui_tests.caseworker.pages.shared import Shared
 from ui_tests.caseworker.pages.application_page import ApplicationPage
 from ui_tests.caseworker.pages.case_list_page import CaseListPage
 from ui_tests.caseworker.pages.queues_pages import QueuesPages
+from tests_common.functions import element_with_id_exists
 import tests_common.tools.helpers as utils
 
 
@@ -81,3 +82,13 @@ def create_countersigning_queue(context, api_test_client):  # noqa
     api_test_client.queues.add_queue(f"countersigningqueue {utils.get_formatted_date_time_y_m_d_h_s()}")
     context.countersigning_queue_name = api_test_client.context["queue_name"]
     context.countersigning_queue_id = api_test_client.context["queue_id"]
+
+
+@then("I see the open queries tab")
+def i_see_the_open_queries_tab(driver):  # noqa
+    assert element_with_id_exists(driver, CaseListPage.OPEN_CASES_TAB)
+
+
+@then("I see the all cases tab")
+def i_see_all_cases_tab(driver):  # noqa
+    assert element_with_id_exists(driver, CaseListPage.ALL_CASES_TAB)

--- a/unit_tests/caseworker/queues/test_views.py
+++ b/unit_tests/caseworker/queues/test_views.py
@@ -246,8 +246,8 @@ def test_case_assignment_case_office(authorized_client, requests_mock, mock_gov_
 def test_with_all_cases_default(authorized_client, mock_cases_search, mock_cases_search_head):
     response = authorized_client.get(reverse("core:index"))
     html = BeautifulSoup(response.content, "html.parser")
-    all_queries_tab = html.find(id="view-all-queries-tab")
-    open_queries_tab = html.find(id="view-open-queries-tab")
+    all_queries_tab = html.find(id="all-queries-tab")
+    open_queries_tab = html.find(id="open-queries-tab")
 
     assert "All cases" in all_queries_tab.get_text()
     assert "(2)" in all_queries_tab.get_text()
@@ -267,7 +267,7 @@ def test_with_all_cases_default(authorized_client, mock_cases_search, mock_cases
 def test_with_all_cases_param(authorized_client, mock_cases_search):
     response = authorized_client.get(reverse("core:index") + "/?only_open_queries=False")
     html = BeautifulSoup(response.content, "html.parser")
-    all_queries_button = html.find(id="view-all-queries-tab")
+    all_queries_button = html.find(id="all-queries-tab")
     assert "/?only_open_queries=False" in all_queries_button.attrs["href"]
     assert "lite-tabs__tab--selected" in all_queries_button.attrs["class"]
     assert mock_cases_search.last_request.qs == {
@@ -280,7 +280,7 @@ def test_with_all_cases_param(authorized_client, mock_cases_search):
 def test_with_open_queries(authorized_client, mock_cases_search):
     response = authorized_client.get(reverse("core:index") + "/?only_open_queries=True")
     html = BeautifulSoup(response.content, "html.parser")
-    open_queries_tab = html.find(id="view-open-queries-tab")
+    open_queries_tab = html.find(id="open-queries-tab")
 
     assert "/?only_open_queries=True" in open_queries_tab.attrs["href"]
     assert "lite-tabs__tab--selected" in open_queries_tab.attrs["class"]
@@ -296,8 +296,8 @@ def test_with_open_queries_team_queue(authorized_client, mock_team_cases, mock_t
     url = client._build_absolute_uri(f"/queues/{queue_pk}/?only_open_queries=True")
     response = authorized_client.get(url)
     html = BeautifulSoup(response.content, "html.parser")
-    open_queries_tab = html.find(id="view-open-queries-tab")
-    all_queries_tab = html.find(id="view-all-queries-tab")
+    open_queries_tab = html.find(id="open-queries-tab")
+    all_queries_tab = html.find(id="all-queries-tab")
 
     assert "Cases to review" in all_queries_tab.get_text()
     assert "/?only_open_queries=True" in open_queries_tab.attrs["href"]


### PR DESCRIPTION
waiting on https://github.com/uktrade/lite-frontend/pull/1049  on the frontend and this API PR to merge so that the e2e tests can pass https://github.com/uktrade/lite-api/pull/1249#pullrequestreview-1253367975 

This PR adds the `count` of cases for the unselected tab on the queues view.

![Screenshot 2023-01-19 at 10 35 20](https://user-images.githubusercontent.com/16647486/213420328-9f00ca88-7349-4e73-89d2-d260079d29a0.png)

