### PR TITLE
add PR template

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,12 @@
+### Aim
+
+<!--
+Enter a description of the changes in the PR here.
+
+Include any context that will help reviewers understand the reason for these changes.
+
+* Are there any dependencies on the API reviewers should be aware of?
+* Have you included any relevant screenshots in the JIRA ticket?
+-->
+
+[Link to story](insert Jira link here)


### PR DESCRIPTION
## Aim 

add a suggested template to prompt more detail in a PR.

Should be auto available once merged into master. Documentation: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository 