### PR TITLE
LTD-3239: Add a 'my cases' tab/filter

### DIFF
--- a/caseworker/templates/queues/cases.html
+++ b/caseworker/templates/queues/cases.html
@@ -61,29 +61,15 @@
 
 	{% include 'filters.html' %}
 
-	<div class="lite-tabs__container">
-		<div class="lite-tabs">
-			<a href="{{ open_queries_tabs.all_cases_url }}" class="lite-tabs__tab  {% if open_queries_tabs.only_open_queries == "False" %}lite-tabs__tab--selected{% endif %}" id="all-queries-tab">
-				{% if queue.is_system_queue %}
-					All cases
-				{% else %}
-					Cases to review
-				{% endif %}
-				{% if open_queries_tabs.only_open_queries == "False" %}
-					({{ data.count }})
-				{% else %}
-					({{  open_queries_tabs.unselected_tab_count }})
-				{% endif %}
-			</a>
-			<a href="{{ open_queries_tabs.open_queries_url }}" class="lite-tabs__tab {% if open_queries_tabs.only_open_queries == "True" %}lite-tabs__tab--selected{% endif %}" id="open-queries-tab">
-				Open queries {% if open_queries_tabs.only_open_queries == "True" %}({{ data.count }}){% else %}({{  open_queries_tabs.unselected_tab_count }}){% endif %}
-			</a>
-		</div>
-	</div>
+	{% include 'queues/search-tabs.html' %}
 
 	<form id="form-cases" method="get" action="{% url 'queues:case_assignments' queue.id %}">
 		{% if not data.results.cases %}
-			{% include "includes/notice.html" with text='cases.CasesListPage.NO_CASES' %}
+			{% if tab_data.my_cases.is_selected %}
+				{% include "includes/notice.html" with text='cases.CasesListPage.NO_CASES_ALLOCATED' %}
+			{% else %}
+				{% include "includes/notice.html" with text='cases.CasesListPage.NO_CASES' %}
+			{% endif %}
 		{% else %}
 		<table id="table-cases" class="govuk-table">
 			<thead class="govuk-table__head">

--- a/caseworker/templates/queues/search-tabs.html
+++ b/caseworker/templates/queues/search-tabs.html
@@ -1,18 +1,18 @@
 <div class="lite-tabs__container">
-  <div class="lite-tabs">
-    <a href="{{ tab_data.all_cases.url }}" class="lite-tabs__tab  {% if tab_data.all_cases.is_selected %}lite-tabs__tab--selected{% endif %}" id="all-cases-tab">
-      {% if queue.is_system_queue %}
+	<div class="lite-tabs">
+		<a href="{{ tab_data.all_cases.url }}" class="lite-tabs__tab  {% if tab_data.all_cases.is_selected %}lite-tabs__tab--selected{% endif %}" id="all-cases-tab">
+			{% if queue.is_system_queue %}
 					All cases
 				{% else %}
 					Cases to review
 			{% endif %}
       ({{  tab_data.all_cases.count }})
     </a>
-    <a href="{{ tab_data.my_cases.url }}" class="lite-tabs__tab {% if tab_data.my_cases.is_selected %}lite-tabs__tab--selected{% endif %}" id="my-cases-tab">
+		<a href="{{ tab_data.my_cases.url }}" class="lite-tabs__tab {% if tab_data.my_cases.is_selected %}lite-tabs__tab--selected{% endif %}" id="my-cases-tab">
 				My cases ({{ tab_data.my_cases.count }})
     </a>
-    <a href="{{ tab_data.open_queries.url }}" class="lite-tabs__tab {% if tab_data.open_queries.is_selected %}lite-tabs__tab--selected{% endif %}" id="open-queries-tab">
+		<a href="{{ tab_data.open_queries.url }}" class="lite-tabs__tab {% if tab_data.open_queries.is_selected %}lite-tabs__tab--selected{% endif %}" id="open-queries-tab">
 				Open queries ({{  tab_data.open_queries.count }})
     </a>
-  </div>
+	</div>
 </div>

--- a/caseworker/templates/queues/search-tabs.html
+++ b/caseworker/templates/queues/search-tabs.html
@@ -1,0 +1,18 @@
+<div class="lite-tabs__container">
+  <div class="lite-tabs">
+    <a href="{{ tab_data.all_cases.url }}" class="lite-tabs__tab  {% if tab_data.all_cases.is_selected %}lite-tabs__tab--selected{% endif %}" id="all-cases-tab">
+      {% if queue.is_system_queue %}
+					All cases
+				{% else %}
+					Cases to review
+			{% endif %}
+      ({{  tab_data.all_cases.count }})
+    </a>
+    <a href="{{ tab_data.my_cases.url }}" class="lite-tabs__tab {% if tab_data.my_cases.is_selected %}lite-tabs__tab--selected{% endif %}" id="my-cases-tab">
+				My cases ({{ tab_data.my_cases.count }})
+    </a>
+    <a href="{{ tab_data.open_queries.url }}" class="lite-tabs__tab {% if tab_data.open_queries.is_selected %}lite-tabs__tab--selected{% endif %}" id="open-queries-tab">
+				Open queries ({{  tab_data.open_queries.count }})
+    </a>
+  </div>
+</div>

--- a/lite_content/lite_internal_frontend/cases.py
+++ b/lite_content/lite_internal_frontend/cases.py
@@ -1,6 +1,10 @@
+from enum import Enum
+
+
 class CasesListPage:
     GO_TO_QUEUE = "Go to queue"
     NO_CASES = "There are no new cases"
+    NO_CASES_ALLOCATED = "You are not allocated to any cases"
     ACTIVE_FILTER_NO_CASES = "No cases match your filters"
     EXPORTER_AMENDMENTS_BANNER = "View cases that have changed"
     ASSIGN_USERS = "Assign users"
@@ -63,6 +67,11 @@ class CasesListPage:
         class Export:
             NO_CASES = "No matching cases found"
             GENERIC_ERROR = "An error occurred when generating XML for this queue."
+
+    class Tabs(str, Enum):
+        ALL_CASES = "all_cases"
+        MY_CASES = "my_cases"
+        OPEN_QUERIES = "open_queries"
 
 
 class CasePage:

--- a/ui_tests/caseworker/features/queues.feature
+++ b/ui_tests/caseworker/features/queues.feature
@@ -83,3 +83,4 @@ Feature: I want to view all cases ready to review
     When I go to the internal homepage
     Then I see the all cases tab
     And I see the open queries tab
+    And I see the my cases tab

--- a/ui_tests/caseworker/pages/case_list_page.py
+++ b/ui_tests/caseworker/pages/case_list_page.py
@@ -20,9 +20,12 @@ class CaseListPage(BasePage):
     # App Bar Buttons
     BUTTON_ASSIGN_USERS = "assign-users-button"  # ID
 
+    # Tabs
+    ALL_CASES_TAB = "all-cases-tab"  # ID
+    OPEN_QUERIES_TAB = "open-queries-tab"  # ID
+    MY_CASES_TAB = "my-cases-tab"  # ID
+
     # Filters
-    ALL_CASES_TAB = "all-queries-tab"
-    OPEN_CASES_TAB = "open-queries-tab"
     BUTTON_CLEAR_FILTERS = "button-clear-filters"  # ID
     LINK_ADVANCED_FILTERS = "advanced-filters-link"  # ID
     LINK_HIDE_FILTERS = "hide-filters-link"  # ID

--- a/ui_tests/caseworker/step_defs/test_queues.py
+++ b/ui_tests/caseworker/step_defs/test_queues.py
@@ -86,9 +86,14 @@ def create_countersigning_queue(context, api_test_client):  # noqa
 
 @then("I see the open queries tab")
 def i_see_the_open_queries_tab(driver):  # noqa
-    assert element_with_id_exists(driver, CaseListPage.OPEN_CASES_TAB)
+    assert element_with_id_exists(driver, CaseListPage.OPEN_QUERIES_TAB)
 
 
 @then("I see the all cases tab")
 def i_see_all_cases_tab(driver):  # noqa
     assert element_with_id_exists(driver, CaseListPage.ALL_CASES_TAB)
+
+
+@then("I see the my cases tab")
+def i_see_my_cases_tab(driver):  # noqa
+    assert element_with_id_exists(driver, CaseListPage.MY_CASES_TAB)

--- a/unit_tests/caseworker/queues/test_views.py
+++ b/unit_tests/caseworker/queues/test_views.py
@@ -12,6 +12,12 @@ from core import client
 
 queue_pk = "59ef49f4-cf0c-4085-87b1-9ac6817b4ba6"
 
+default_params = {
+    "page": ["1"],
+    "queue_id": ["00000000-0000-0000-0000-000000000001"],
+    "selected_tab": ["all_cases"],
+}
+
 
 @pytest.fixture(autouse=True)
 def setup(
@@ -165,10 +171,8 @@ def test_cases_home_page_nca_applicable_search(authorized_client, mock_cases_sea
     url = reverse("queues:cases") + "?is_nca_applicable=True"
     authorized_client.get(url)
     assert mock_cases_search.last_request.qs == {
-        "queue_id": ["00000000-0000-0000-0000-000000000001"],
-        "page": ["1"],
+        **default_params,
         "is_nca_applicable": ["true"],
-        "selected_tab": ["all_cases"],
     }
 
 
@@ -176,10 +180,8 @@ def test_cases_home_page_trigger_list_search(authorized_client, mock_cases_searc
     url = reverse("queues:cases") + "?is_trigger_list=True"
     authorized_client.get(url)
     assert mock_cases_search.last_request.qs == {
-        "queue_id": ["00000000-0000-0000-0000-000000000001"],
-        "page": ["1"],
+        **default_params,
         "is_trigger_list": ["true"],
-        "selected_tab": ["all_cases"],
     }
 
 
@@ -187,10 +189,8 @@ def test_cases_home_page_regime_entry_search(authorized_client, mock_cases_searc
     url = reverse("queues:cases") + "?regime_entry=af8043ee-6657-4d4b-83a2-f1a5cdd016ed"  # /PS-IGNORE
     authorized_client.get(url)
     assert mock_cases_search.last_request.qs == {
-        "queue_id": ["00000000-0000-0000-0000-000000000001"],
-        "page": ["1"],
+        **default_params,
         "regime_entry": ["af8043ee-6657-4d4b-83a2-f1a5cdd016ed"],  # /PS-IGNORE
-        "selected_tab": ["all_cases"],
     }
 
 
@@ -257,11 +257,7 @@ def test_with_all_cases_default(authorized_client, mock_cases_search, mock_cases
     assert "lite-tabs__tab--selected" in all_queries_tab.attrs["class"]
 
     head_request_history = [x.qs for x in mock_cases_search_head.request_history]
-    assert {
-        "selected_tab": ["all_cases"],
-        "page": ["1"],
-        "queue_id": ["00000000-0000-0000-0000-000000000001"],
-    } in head_request_history
+    assert default_params in head_request_history
 
     tabs_with_hidden_param = ("my_cases", "open_queries")
     for tab in tabs_with_hidden_param:
@@ -279,11 +275,7 @@ def test_tabs_with_all_cases_param(authorized_client, mock_cases_search):
     all_queries_button = html.find(id="all-cases-tab")
     assert "?selected_tab=all_cases" in all_queries_button.attrs["href"]
     assert "lite-tabs__tab--selected" in all_queries_button.attrs["class"]
-    assert mock_cases_search.last_request.qs == {
-        "queue_id": ["00000000-0000-0000-0000-000000000001"],
-        "page": ["1"],
-        "selected_tab": ["all_cases"],
-    }
+    assert mock_cases_search.last_request.qs == default_params
 
 
 @pytest.mark.parametrize(
@@ -332,6 +324,6 @@ def test_tabs_on_team_queue(authorized_client, mock_team_cases, mock_team_queue,
     assert mock_team_cases.last_request.qs == {
         "queue_id": [queue_pk],
         "page": ["1"],
-        "selected_tab": [f"{tab_name}"],
+        "selected_tab": [tab_name],
         "hidden": ["true"],
     }


### PR DESCRIPTION
### aim

[LTD-3239](https://uktrade.atlassian.net/jira/software/c/projects/LTD/boards/204?modal=detail&selectedIssue=LTD-3239)

The frontend for the cases/queues view is going to have several tabs that aim to filter out cases. We have already introduced the 'all cases' and 'open queries' tabs, but now that one more is being added ('my cases') we need to change the way the logic for filtering is handled (it's not either/or anymore).

[Together with this backend PR](https://github.com/uktrade/lite-api/pull/1260) I'm proposing:
 
_on the frontend_
1. instead of a param for each tab (e.g. `only_open_queries`) we have a param whose value is the selected tab e.g. `selected_tab=open_queries`
2. in the view, to get a count for each tab, we the tab names and make a HEAD request to get the count like we do currently, and save that in a dict for each tab, as well as its URL and whether it is selected.

_on the backend_
1. the view takes a look at the `selected_tab` value and passes the manager `True` for the name of the selected tab. e.g. `open_queries=True`
2. the manager can then apply the right filter. 

Would be great to get feedback on the structure/naming of this approach.



[LTD-3239]: https://uktrade.atlassian.net/browse/LTD-3239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ