### PR TITLE
Fix url pattern warning

### DIFF
--- a/core/feedback/urls.py
+++ b/core/feedback/urls.py
@@ -4,5 +4,5 @@ from core.feedback.views import FeedbackView, get_thanks
 
 urlpatterns = [
     path("", FeedbackView.as_view(), name="feedback"),
-    path("/thanks/", get_thanks, name="thanks"),
+    path("thanks/", get_thanks, name="thanks"),
 ]


### PR DESCRIPTION
This fixes the warning shown below:

```lite-frontend-caseworker-1               | ?: (urls.W002) Your URL pattern '/thanks/' [name='thanks'] has a route beginning with a '/'. Remove this slash as it is unnecessary. If this pattern is targeted in an include(), ensure the include() pattern has a trailing '/'.```
