### PR TITLE
[LTD-3234] Add case adviser removal functionality to case detail page

### DIFF
--- a/caseworker/assets/styles/components/_cases.scss
+++ b/caseworker/assets/styles/components/_cases.scss
@@ -25,6 +25,23 @@
 
     span {
       @include govuk-font($size: 19);
+
+      &.govuk-label {
+        font-weight: bold;
+      }
+
+    }
+
+    &__actions {
+      margin-top: govuk-spacing(3);
+    }
+
+    &__fullwidth {
+      display: flex;
+
+      & > :first-child {
+        margin-right: auto;
+      }
     }
   }
   @media screen and (min-width: 900px) {

--- a/caseworker/cases/forms/case_assignment.py
+++ b/caseworker/cases/forms/case_assignment.py
@@ -1,0 +1,5 @@
+from django import forms
+
+
+class CaseAssignmentRemove(forms.Form):
+    assignment_id = forms.CharField(widget=forms.HiddenInput)

--- a/caseworker/cases/services.py
+++ b/caseworker/cases/services.py
@@ -42,6 +42,11 @@ def put_unassign_queues(request, pk, json):
     return data.json(), data.status_code
 
 
+def delete_case_assignment(request, case_id, assignment_id):
+    response = client.delete(request, f"/cases/{case_id}/case-assignments/{assignment_id}")
+    return response
+
+
 # Applications
 def put_application_status(request, pk, json):
     data = client.put(request, f"/applications/{pk}/status/", json)

--- a/caseworker/cases/urls.py
+++ b/caseworker/cases/urls.py
@@ -1,6 +1,16 @@
 from django.urls import path, include
 
-from caseworker.cases.views import main, advice, generate_document, ecju, goods_query, goods, compliance, external_data
+from caseworker.cases.views import (
+    main,
+    advice,
+    generate_document,
+    ecju,
+    goods_query,
+    goods,
+    compliance,
+    external_data,
+    case_assignments,
+)
 from caseworker.flags.views import AssignFlags
 
 app_name = "cases"
@@ -27,6 +37,11 @@ urlpatterns = [
         "remove-matching-sanction/",
         external_data.SanctionRevokeView.as_view(),
         name="remove-matching-sanctions",
+    ),
+    path(
+        "remove-assignment/",
+        case_assignments.CaseAssignmentRemove.as_view(),
+        name="remove-case-assignment",
     ),
     path(
         "matching-denials/<str:category>/",

--- a/caseworker/cases/views/case_assignments.py
+++ b/caseworker/cases/views/case_assignments.py
@@ -1,0 +1,66 @@
+import itertools
+
+from django.contrib import messages
+from django.http import Http404
+from django.urls import reverse
+from django.views.generic.edit import FormView
+
+from core.auth.views import LoginRequiredMixin
+from caseworker.cases.forms import case_assignment as forms
+
+from caseworker.cases.services import delete_case_assignment
+from caseworker.cases.services import get_case
+
+
+class CaseAssignmentRemove(LoginRequiredMixin, FormView):
+    template_name = "case/remove-case-assignment.html"
+    form_class = forms.CaseAssignmentRemove
+
+    def _get_adviser(self, case, assignment_id):
+        all_assigned_users = itertools.chain.from_iterable(
+            [queue_users for queue_users in case["assigned_users"].values()]
+        )
+        assigned_users_by_assignment_id = {user["assignment_id"]: user for user in all_assigned_users}
+        try:
+            return assigned_users_by_assignment_id[assignment_id]
+        except KeyError:
+            raise Http404
+
+    def _get_adviser_identifier(self, case, assignment_id):
+        adviser = self._get_adviser(case, assignment_id)
+        adviser_identifier = adviser["email"]
+        if adviser["first_name"] and adviser["last_name"]:
+            adviser_identifier = f"{adviser['first_name']} {adviser['last_name']}"
+        return adviser_identifier
+
+    def get_case(self):
+        return get_case(self.request, self.kwargs["pk"])
+
+    def get_context_data(self, **kwargs):
+        case = self.get_case()
+        return super().get_context_data(
+            case=case,
+            queue_id=self.kwargs["queue_pk"],
+            case_id=self.kwargs["pk"],
+            adviser_identifier=self._get_adviser_identifier(case, self.request.GET.get("assignment_id")),
+            **kwargs,
+        )
+
+    def get_success_url(self):
+        return reverse("cases:case", kwargs={"queue_pk": self.kwargs["queue_pk"], "pk": self.kwargs["pk"]})
+
+    def get_initial(self):
+        return {"assignment_id": self.request.GET.get("assignment_id")}
+
+    def form_valid(self, form):
+        adviser_identifier = self._get_adviser_identifier(self.get_case(), form.cleaned_data["assignment_id"])
+        response = delete_case_assignment(self.request, self.kwargs["pk"], form.cleaned_data["assignment_id"])
+        if response.ok:
+            messages.success(self.request, f"{adviser_identifier} was successfully removed as case adviser")
+        else:
+            messages.error(
+                self.request,
+                f"An error occurred when removing {adviser_identifier} as case adviser. Please try again later",
+            )
+
+        return super().form_valid(form)

--- a/caseworker/templates/case/remove-case-assignment.html
+++ b/caseworker/templates/case/remove-case-assignment.html
@@ -1,0 +1,19 @@
+{% extends 'layouts/case.html' %}
+
+{% block details %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <a class="lite-back-link-button" id="back-link" href="{% url 'cases:case' queue_pk=queue.id pk=case.id %}">Back</a>
+            <div>
+                <h2 class="govuk-heading-xl govuk-!-margin-bottom-3">Are you sure you want to remove {{adviser_identifier}} as case adviser?</h2>
+                <form method="post">{% csrf_token %}
+                    {{ form.as_p }}
+                    <input type="submit" class="govuk-button" value="Confirm and remove">
+                    <a href="{% url 'cases:case' queue_pk=queue.id pk=case.id %}" class="govuk-button govuk-button--secondary govuk-button--secondary-white">
+                        Cancel
+                    </a>
+                </form>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/caseworker/templates/case/slices/summary.html
+++ b/caseworker/templates/case/slices/summary.html
@@ -179,8 +179,10 @@
 				<ol class="govuk-list govuk-!-margin-0">
 					{% for user in users %}
 						<li>
-							<a href="{% url 'users:user' user.id %}?return_to={{ CURRENT_PATH }}&return_to_text={{ case.reference_code }}" class="govuk-link govuk-link--no-visited-state">{{ user|username }}</a>
-                            <a href="{% url 'cases:remove-case-assignment' queue.id case.id %}?assignment_id={{user.assignment_id}}" class="govuk-link govuk-link--no-visited-state app-case__summary-list__value__item-action">Remove</a>
+                            <div class="app-case__summary-list__value__fullwidth">
+							    <a href="{% url 'users:user' user.id %}?return_to={{ CURRENT_PATH }}&return_to_text={{ case.reference_code }}" class="govuk-link govuk-link--no-visited-state">{{ user|username }}</a>
+                                <a href="{% url 'cases:remove-case-assignment' queue.id case.id %}?assignment_id={{user.assignment_id}}" class="govuk-link govuk-link--no-visited-state app-case__summary-list__value__item-action">Remove</a>
+                            </div>
 						</li>
 					{% endfor %}
 				</ol>

--- a/caseworker/templates/case/slices/summary.html
+++ b/caseworker/templates/case/slices/summary.html
@@ -180,6 +180,7 @@
 					{% for user in users %}
 						<li>
 							<a href="{% url 'users:user' user.id %}?return_to={{ CURRENT_PATH }}&return_to_text={{ case.reference_code }}" class="govuk-link govuk-link--no-visited-state">{{ user|username }}</a>
+                            <a href="{% url 'cases:remove-case-assignment' queue.id case.id %}?assignment_id={{user.assignment_id}}" class="govuk-link govuk-link--no-visited-state app-case__summary-list__value__item-action">Remove</a>
 						</li>
 					{% endfor %}
 				</ol>
@@ -188,11 +189,11 @@
 					{% lcs 'cases.CasePage.DetailsTab.NO_USERS_ASSIGNED' %}
 				</span>
 			{% endfor %}
-		</dd>
-		<dd class="app-case__summary-list__actions">
-			<a id="link-change-assigned-users" class="govuk-link govuk-link--no-visited-state" href="{% url 'cases:assign_user' queue.id case.id %}">
-				{% lcs 'generic.CHANGE' %}
-			</a>
+            <div class="app-case__summary-list__value__actions">
+			    <a id="link-change-assigned-users" class="govuk-link govuk-link--no-visited-state" href="{% url 'cases:assign_user' queue.id case.id %}">
+			    	{% lcs 'cases.CasePage.DetailsTab.ADD_ASSIGNED_USER' %}
+			    </a>
+            </div>
 		</dd>
 	</div>
 	<div class="app-case__summary-list__row">

--- a/lite_content/lite_internal_frontend/cases.py
+++ b/lite_content/lite_internal_frontend/cases.py
@@ -92,7 +92,7 @@ class CasePage:
         class CaseOfficer:
             CASE_OFFICER = "Case officer"
             INSPECTOR = "Inspector"
-            ASSIGNED_USERS = "Assigned users"
+            ASSIGNED_USERS = "Case advisers"
             NO_CASE_OFFICER = "No case officer assigned"
             NO_INSPECTOR = "No inspector assigned"
             NO_USERS_ASSIGNED = "No users assigned"
@@ -133,7 +133,8 @@ class CasePage:
         TYPE = "Type"
         LAST_UPDATED = "Last updated"
         CASE_OFFICER = "Case officer"
-        ASSIGNED_USERS = "Assigned users"
+        ASSIGNED_USERS = "Case advisers"
+        ADD_ASSIGNED_USER = "Add case adviser"
         COPY_OF = "Copy of"
         RAISED_BY = "Raised by"
         EXPORT_TYPE = "Export type"

--- a/unit_tests/caseworker/cases/views/test_case_assignments.py
+++ b/unit_tests/caseworker/cases/views/test_case_assignments.py
@@ -1,0 +1,155 @@
+import pytest
+from uuid import uuid4
+
+from django.urls import reverse
+from pytest_django.asserts import assertTemplateUsed
+from bs4 import BeautifulSoup
+
+from core import client
+
+
+@pytest.fixture
+def data_assignment(data_standard_case, data_queue):
+    assignment_id = "4ccc09d8-04e1-426d-a69d-eda2d3854788"
+    user_id = "9ac96323-d519-4781-8424-84b9c7cc3186"
+    return {
+        "case": data_standard_case["case"]["id"],
+        "id": assignment_id,
+        "queue": data_queue["id"],
+        "user": {
+            "email": "example@example.net",
+            "first_name": "some",
+            "id": user_id,
+            "last_name": "user",
+            "team": "The A Team",
+        },
+    }
+
+
+@pytest.fixture
+def mock_standard_case_with_assignments(requests_mock, data_standard_case, data_assignment, data_queue):
+    url = client._build_absolute_uri(f"/cases/{data_standard_case['case']['id']}/")
+    data_standard_case["case"]["assigned_users"] = {
+        data_queue["name"]: [
+            {
+                "id": data_assignment["user"]["id"],
+                "first_name": data_assignment["user"]["first_name"],
+                "last_name": data_assignment["user"]["last_name"],
+                "email": data_assignment["user"]["email"],
+                "assignment_id": data_assignment["id"],
+            }
+        ]
+    }
+    return requests_mock.get(url=url, json=data_standard_case)
+
+
+@pytest.fixture
+def mock_remove_assignment(requests_mock, data_standard_case, data_assignment):
+    url = client._build_absolute_uri(
+        f"/cases/{data_standard_case['case']['id']}/case-assignments/{data_assignment['id']}"
+    )
+    return requests_mock.delete(url=url, json=data_assignment)
+
+
+@pytest.fixture
+def mock_remove_assignment_error(requests_mock, data_standard_case, data_assignment):
+    url = client._build_absolute_uri(
+        f"/cases/{data_standard_case['case']['id']}/case-assignments/{data_assignment['id']}"
+    )
+    return requests_mock.delete(url=url, json={}, status_code=500)
+
+
+def test_case_assignments_GET_remove_user(
+    authorized_client, data_queue, data_standard_case, data_assignment, mock_standard_case_with_assignments, mock_queue
+):
+
+    case = data_standard_case
+    url_params = f"?assignment_id={data_assignment['id']}"
+    url = (
+        reverse("cases:remove-case-assignment", kwargs={"queue_pk": data_queue["id"], "pk": case["case"]["id"]})
+        + url_params
+    )
+    response = authorized_client.get(url)
+    assert response.status_code == 200
+    assertTemplateUsed(response, "layouts/case.html")
+    context = response.context
+    assert context["adviser_identifier"] == "some user"
+
+    html = BeautifulSoup(response.content, "html.parser")
+    assert "Are you sure you want to remove some user as case adviser?" in html.find("h2").get_text()
+
+
+def test_case_assignments_GET_remove_user_404(authorized_client, data_queue, data_standard_case, mock_queue, mock_case):
+
+    url = reverse(
+        "cases:remove-case-assignment", kwargs={"queue_pk": data_queue["id"], "pk": data_standard_case["case"]["id"]}
+    )
+    response = authorized_client.get(url)
+    assert response.status_code == 404
+
+
+def test_case_assignments_POST_remove_user_success(
+    authorized_client,
+    data_queue,
+    data_standard_case,
+    data_assignment,
+    mock_standard_case_with_assignments,
+    mock_standard_case_ecju_queries,
+    mock_standard_case_assigned_queues,
+    mock_standard_case_documents,
+    mock_standard_case_additional_contacts,
+    mock_standard_case_activity_filters,
+    mock_remove_assignment,
+    mock_queue,
+):
+
+    case = data_standard_case
+    url = reverse("cases:remove-case-assignment", kwargs={"queue_pk": data_queue["id"], "pk": case["case"]["id"]})
+    response = authorized_client.post(url, data={"assignment_id": str(data_assignment["id"])}, follow=True)
+    assert response.status_code == 200
+    assert response.redirect_chain[-1][0] == f"/queues/{data_queue['id']}/cases/{data_standard_case['case']['id']}/"
+    messages = [str(msg) for msg in response.context["messages"]]
+    expected_message = "some user was successfully removed as case adviser"
+    assert messages == [expected_message]
+    assert mock_remove_assignment.called
+    assert (
+        mock_remove_assignment.last_request.path
+        == f"/cases/{data_standard_case['case']['id']}/case-assignments/{data_assignment['id']}/"
+    )
+    assert mock_remove_assignment.last_request.json() == {}
+
+    html = BeautifulSoup(response.content, "html.parser")
+    assert expected_message in html.select("div.app-snackbar__content")[0].get_text()
+
+
+def test_case_assignments_POST_remove_user_error(
+    authorized_client,
+    data_queue,
+    data_standard_case,
+    data_assignment,
+    mock_standard_case_with_assignments,
+    mock_standard_case_ecju_queries,
+    mock_standard_case_assigned_queues,
+    mock_standard_case_documents,
+    mock_standard_case_additional_contacts,
+    mock_standard_case_activity_filters,
+    mock_remove_assignment_error,
+    mock_queue,
+):
+
+    case = data_standard_case
+    url = reverse("cases:remove-case-assignment", kwargs={"queue_pk": data_queue["id"], "pk": case["case"]["id"]})
+    response = authorized_client.post(url, data={"assignment_id": str(data_assignment["id"])}, follow=True)
+    assert response.status_code == 200
+    assert response.redirect_chain[-1][0] == f"/queues/{data_queue['id']}/cases/{data_standard_case['case']['id']}/"
+    messages = [str(msg) for msg in response.context["messages"]]
+    expected_message = "An error occurred when removing some user as case adviser. Please try again later"
+    assert messages == [expected_message]
+    assert mock_remove_assignment_error.called
+    assert (
+        mock_remove_assignment_error.last_request.path
+        == f"/cases/{data_standard_case['case']['id']}/case-assignments/{data_assignment['id']}/"
+    )
+
+    html = BeautifulSoup(response.content, "html.parser")
+    assert expected_message in html.select("div.app-snackbar__content")[0].get_text()


### PR DESCRIPTION
This change adds the ability for case adviser assignments to be removed from a case.  It depends on the lite-api PR: https://github.com/uktrade/lite-api/pull/1276

Screenshots can be found in a comment on the Jira ticket: https://uktrade.atlassian.net/browse/LTD-3234