### PR TITLE
add case activity to cases page

### DIFF
--- a/caseworker/assets/styles/components/_activity_updates.scss
+++ b/caseworker/assets/styles/components/_activity_updates.scss
@@ -1,0 +1,11 @@
+.app-updates {
+    &__list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    &__department, &__activity {
+        color: $govuk-secondary-text-colour;
+    }
+}

--- a/caseworker/assets/styles/components/_all.scss
+++ b/caseworker/assets/styles/components/_all.scss
@@ -1,4 +1,5 @@
 @import "activity";
+@import "activity_updates";
 @import "advice";
 @import "assignments";
 @import "cases";

--- a/caseworker/templates/includes/case-row.html
+++ b/caseworker/templates/includes/case-row.html
@@ -57,6 +57,49 @@
 		<p class="govuk-tag govuk-tag--grey govuk-!-margin-0 govuk-!-margin-top-2">{{ case.status.value }}</p>
 	</td>
 
+    {# case updates #}
+	<td class="govuk-table__cell lite-mobile-hide">
+		<ul class="app-updates__list">
+			{% if case.activity_updates %}
+				{% for update in case.activity_updates %}
+					<li class="app-updates__item">
+						<div class="app-updates__action">
+							{% if forloop.first %}
+								Latest Action
+							{% else %}
+								Previous Action
+							{% endif %}
+						</div>
+					</li>
+					<li class="app-updates__item">
+						<div class="app-updates__department">
+							{% if update.user.type == 'exporter' %}
+								Applicant
+							{% else %}
+								{{ update.user.team }}
+							{% endif %}
+						</div>
+					</li>
+					<li class="app-updates__item">
+						<div class="app-updates__activity">
+							{{ update.user.first_name }} {{ update.user.last_name }} {{ update.text|linebreaksbr }}
+						</div>
+						{% if activity.additional_text %}
+							<div class="app-updates__activity">
+								{{ update.additional_text }}
+							</div>
+						{% endif %}
+					</li>
+					<li class="app-updates__item">
+						<div class="govuk-hint govuk-!-margin-0 govuk-!-margin-bottom-2">
+							{{ update.created_at|to_datetime|date:"d F Y" }}
+						</div>
+					</li>
+				{% endfor %}
+			{% endif %}
+		</ul>
+	</td>
+
 	{# 	Case allocation #}
 	<td class="govuk-table__cell lite-mobile-hide expander" data-expander-visible-elems="3">
 		<ul class="app-assignments__list expander__expand-list">

--- a/caseworker/templates/queues/cases.html
+++ b/caseworker/templates/queues/cases.html
@@ -82,6 +82,7 @@
 					<th class="govuk-table__header govuk-table__cell--tight" scope="col"><span class="govuk-visually-hidden">{% lcs 'cases.CasesListPage.Table.SLA' %}</span></th>
 					<th class="govuk-table__header app-table__header--skeleton" scope="col">{% lcs 'cases.CasesListPage.Table.CASE' %}</th>
 					<th class="govuk-table__header app-table__header--skeleton" scope="col">{% lcs 'cases.CasesListPage.Table.ASSIGNEES' %}</th>
+					<th class="govuk-table__header app-table__header--skeleton" scope="col">{% lcs 'cases.CasesListPage.Table.UPDATES' %}</th>
 					<th class="govuk-table__header app-table__header--skeleton lite-tablet-hide" width="15%" scope="col">{% lcs 'cases.CasesListPage.Table.DESTINATIONS' %}</th>
 					<th class="govuk-table__header app-table__header--skeleton lite-tablet-hide" width="15%" scope="col">{% lcs 'cases.CasesListPage.Table.FLAGS' %}</th>
 				</tr>

--- a/lite_content/lite_internal_frontend/cases.py
+++ b/lite_content/lite_internal_frontend/cases.py
@@ -20,6 +20,7 @@ class CasesListPage:
         SLA = "SLA"
         INFORMATION = "Information"
         CASE = "Case"
+        UPDATES = "Case updates"
         ASSIGNEES = "Case allocation"
         DESTINATIONS = "Destinations"
         FLAGS = "Flags"


### PR DESCRIPTION
add recent activity column to cases page
-enhanced cases templates to include extra data from the api

compared getting data via api using several queries and this appeared to be the quickest when run on local environment.
We needed last 2 audit activities per case but the case_id could be an action object or target object. Alternatives tried:

using union to get correct results from the fb
using filter to get last 2 activities per action and target (total 4) and filtering down to 2
a few different methods of massaging the data after retrieving results