### PR TITLE
[LTD-3294] add pagination to denials search

### DIFF
--- a/caseworker/cases/views/main.py
+++ b/caseworker/cases/views/main.py
@@ -642,10 +642,12 @@ class Denials(LoginRequiredMixin, TemplateView):
             search.append(party["address"])
             filter["country"].add(party["country"]["name"])
 
-        if search:
-            response = search_denials(request=self.request, search=search, filter=filter)
-            results = [item["_source"] for item in response.json()["hits"]["hits"]]
-        else:
-            results = []
+        total_pages = 0
+        results = []
 
-        return super().get_context_data(case=case, results=results, **kwargs)
+        if search:
+            response = search_denials(request=self.request, search=search, filter=filter).json()
+            results = response["results"]
+            total_pages = response["total_pages"]
+
+        return super().get_context_data(case=case, results=results, total_pages=total_pages, **kwargs)

--- a/caseworker/external_data/services.py
+++ b/caseworker/external_data/services.py
@@ -12,7 +12,8 @@ def upload_denials(request, data):
 
 
 def search_denials(request, search, filter):
-    data = {"search": search, **filter}
+    page = request.GET.get("page", 1)
+    data = {"search": search, "page": page, **filter}
     querystring = urlencode(data, doseq=True)
     return client.get(request=request, appended_address=f"/external-data/denial-search/?{querystring}")
 

--- a/caseworker/templates/case/denial-for-case.html
+++ b/caseworker/templates/case/denial-for-case.html
@@ -83,6 +83,7 @@
 
             {% if not hide_controls %}
             </form>
+            {% pagination %}
             {% endif %}
         </div>
     </div>

--- a/unit_tests/caseworker/conftest.py
+++ b/unit_tests/caseworker/conftest.py
@@ -330,7 +330,7 @@ def mock_post_refusal_advice(requests_mock, standard_case_pk):
 @pytest.fixture
 def mock_party_denial_search_results(requests_mock):
     url = client._build_absolute_uri(f"/external-data/denial-search/")
-    yield requests_mock.get(url=url, json={"hits": {"hits": []}})
+    yield requests_mock.get(url=url, json={"count": "0", "total_pages": "1", "results": []})
 
 
 @pytest.fixture


### PR DESCRIPTION
## aim

[Ticket](https://uktrade.atlassian.net/jira/software/c/projects/LTD/boards/204?modal=detail&selectedIssue=LTD-3294) 

The Denials search was only returning the first 10 results, this adds pagination to the view. 
Relies on this API change for the e2es to pass: https://github.com/uktrade/lite-api/pull/1291 
