### PR TITLE
LTD-3324 Update serial number message in case detail template

### DIFF
--- a/caseworker/advice/templates/advice/case_detail.html
+++ b/caseworker/advice/templates/advice/case_detail.html
@@ -83,18 +83,7 @@
                   <tr class="govuk-table__row">
                     <td class="govuk-table__cell govuk-!-font-weight-bold">Serial numbers</td>
                     <td class="govuk-table__cell">
-                      {% if good.good.firearm_details.serial_numbers_available == "LATER" and not good.good.firearm_details.serial_numbers %}
-                        Not added yet
-                      {% else %}
-                        <details class="govuk-details" data-module="govuk-details">
-                          <summary class="govuk-details__summary">
-                            <span class="govuk-details__summary-text">View serial numbers</span>
-                          </summary>
-                          <div class="govuk-details__text">
-                            {{ good.good.firearm_details.serial_numbers|format_serial_numbers:good.quantity|join:"<br>" }}
-                          </div>
-                        </details>
-                      {% endif %}
+                      {% include "goods/includes/serial_numbers.html" with firearm_details=good.good.firearm_details %}
                     </td>
                   </tr>
                 {% endif %}


### PR DESCRIPTION
This change updates the display of serial numbers in the advice side panel to only show the list of numbers if there is at least one serial number present, otherwise it shows `Not added yet`.

The way this is done is by reusing the serial numbers template tag that is used elsewhere in the advice app.

Therefore the new if statement logic for this template satisfies the criteria for display given in the ticket, namely:
```
We’re currently showing serial numbers for all sub-firearm category products (so things like accessories where we don’t capture serial numbers on the application form') but it should just be:

firearms

ammunition

components for ammunition

components for firearms
```