### PR TITLE
Fix LU countersign feature test

### DIFF
--- a/ui_tests/caseworker/features/give_advice.feature
+++ b/ui_tests/caseworker/features/give_advice.feature
@@ -328,7 +328,7 @@ Feature: I want to record my user advice and any comments and conditions relatin
     And I create standard application or standard application has been previously created
     And I prepare the application for final review
     When I go to my profile page
-    And I change my team to "Licensing Unit" and default queue to "Team Leader to Countersign"
+    And I change my team to "Licensing Unit" and default queue to "Licensing manager countersigning"
     And I go to my case list
     And I click the application previously created
     Then I see the application destinations
@@ -341,7 +341,7 @@ Feature: I want to record my user advice and any comments and conditions relatin
     And I go to application previously created
     Then I see the case status is now "Under final review"
     When I go to my profile page
-    And I change my team to "Licensing Unit" and default queue to "Head of Licensing Unit countersigning"
+    And I change my team to "Licensing Unit" and default queue to "Senior licensing manager countersigning"
     And I go to my case list
     And I click the application previously created
     Then I click on Notes and timeline


### PR DESCRIPTION
### Aim

This fixes the caseworker e2e tests that are currently failing on CircleCI. The reason this is a problem is because the lite-routing sha was recently updated and the queue names have now changed. However this was not updated in the frontend, this change corrects that.