### PR TITLE
[LTD-3364] Fix queue view limit case updates lines

### DIFF
--- a/caseworker/assets/styles/components/_activity_updates.scss
+++ b/caseworker/assets/styles/components/_activity_updates.scss
@@ -5,6 +5,10 @@
         padding: 0;
     }
 
+    &__item {
+        margin-bottom: govuk-spacing(2);
+    }
+
     &__department, &__activity {
         color: $govuk-secondary-text-colour;
     }

--- a/caseworker/assets/styles/components/_activity_updates.scss
+++ b/caseworker/assets/styles/components/_activity_updates.scss
@@ -8,4 +8,8 @@
     &__department, &__activity {
         color: $govuk-secondary-text-colour;
     }
+
+    &__action {
+        font-weight: bold;
+    }
 }

--- a/caseworker/queues/views.py
+++ b/caseworker/queues/views.py
@@ -140,7 +140,10 @@ class Cases(LoginRequiredMixin, TemplateView):
         return unique_destinations
 
     def _limit_lines(self, text, limit):
-        lines = text.splitlines()[:limit]
+        lines = text.splitlines()
+        if len(lines) > limit:
+            lines = lines[:limit]
+            lines[-1] += "..."
         return "\n".join(lines)
 
     def _transform_activity_updates(self, case):

--- a/caseworker/queues/views.py
+++ b/caseworker/queues/views.py
@@ -139,6 +139,26 @@ class Cases(LoginRequiredMixin, TemplateView):
         unique_destinations = [dict(t) for t in {tuple(destination["country"].items()) for destination in destinations}]
         return unique_destinations
 
+    def _limit_lines(self, text, limit):
+        lines = text.splitlines()[:limit]
+        return "\n".join(lines)
+
+    def _transform_activity_updates(self, case):
+        try:
+            activity_updates = case["activity_updates"]
+        except KeyError:
+            activity_updates = []
+
+        transformed_updates = []
+        for update in activity_updates:
+            if update["text"]:
+                update["text"] = self._limit_lines(update["text"], 2)
+            if update["additional_text"]:
+                update["additional_text"] = self._limit_lines(update["additional_text"], 2)
+            transformed_updates.append(update)
+
+        return transformed_updates
+
     def _transform_queue_assignments(self, case):
         assigned_queues = {}
         for _, assignment in case["assignments"].items():
@@ -161,6 +181,7 @@ class Cases(LoginRequiredMixin, TemplateView):
     def transform_case(self, case):
         case["unique_destinations"] = self._transform_destinations(case)
         case["queue_assignments"] = self._transform_queue_assignments(case)
+        case["activity_updates"] = self._transform_activity_updates(case)
 
     def get_context_data(self, *args, **kwargs):
 

--- a/caseworker/templates/includes/case-row.html
+++ b/caseworker/templates/includes/case-row.html
@@ -70,8 +70,6 @@
 								Previous Action
 							{% endif %}
 						</div>
-					</li>
-					<li class="app-updates__item">
 						<div class="app-updates__department">
 							{% if update.user.type == 'exporter' %}
 								Applicant
@@ -79,18 +77,14 @@
 								{{ update.user.team }}
 							{% endif %}
 						</div>
-					</li>
-					<li class="app-updates__item">
 						<div class="app-updates__activity">
 							{{ update.user.first_name }} {{ update.user.last_name }} {{ update.text|linebreaksbr }}
 						</div>
-						{% if activity.additional_text %}
+						{% if update.additional_text %}
 							<div class="app-updates__activity">
-								{{ update.additional_text }}
+								{{ update.additional_text|linebreaksbr }}
 							</div>
 						{% endif %}
-					</li>
-					<li class="app-updates__item">
 						<div class="govuk-hint govuk-!-margin-0 govuk-!-margin-bottom-2">
 							{{ update.created_at|to_datetime|date:"d F Y" }}
 						</div>

--- a/caseworker/templates/includes/case-row.html
+++ b/caseworker/templates/includes/case-row.html
@@ -65,16 +65,16 @@
 					<li class="app-updates__item">
 						<div class="app-updates__action">
 							{% if forloop.first %}
-								Latest Action
+								Latest action
 							{% else %}
-								Previous Action
+								Previous action
 							{% endif %}
 						</div>
 						<div class="app-updates__department">
 							{% if update.user.type == 'exporter' %}
-								Applicant
+								Applicant {{ update.created_at|to_datetime|date:"d F Y" }}
 							{% else %}
-								{{ update.user.team }}
+								{{ update.user.team }} {{ update.created_at|to_datetime|date:"d F Y" }}
 							{% endif %}
 						</div>
 						<div class="app-updates__activity">
@@ -85,9 +85,6 @@
 								{{ update.additional_text|linebreaksbr }}
 							</div>
 						{% endif %}
-						<div class="govuk-hint govuk-!-margin-0 govuk-!-margin-bottom-2">
-							{{ update.created_at|to_datetime|date:"d F Y" }}
-						</div>
 					</li>
 				{% endfor %}
 			{% endif %}

--- a/unit_tests/caseworker/queues/test_views.py
+++ b/unit_tests/caseworker/queues/test_views.py
@@ -618,7 +618,7 @@ def test_queue_assignments(url, authorized_client):
     assert response.context["data"]["results"]["cases"][0]["queue_assignments"] == expected_queue_assignments
 
     html = BeautifulSoup(response.content, "html.parser")
-    li_elems = [elem.get_text() for elem in html.select("li", {"class": "app-assignments__item"})]
+    li_elems = [elem.get_text() for elem in html.find_all("li", {"class": "app-assignments__item"})]
     assert "John Smith" in li_elems[0]
     assert "Initial Queue" in li_elems[0]
     assert "Joe Smith" in li_elems[1]
@@ -667,11 +667,13 @@ def test_activity_updates(url, authorized_client):
     assert response.context["data"]["results"]["cases"][0]["activity_updates"] == expected_activity_updates
 
     html = BeautifulSoup(response.content, "html.parser")
-    updates = [update.get_text() for update in html.select("li", {"class": "app-updates__item"})]
+    updates = [update.get_text() for update in html.find_all("li", {"class": "app-updates__item"})]
     assert "LITE system" in updates[0]
     assert "text line1" in updates[0]
     assert "text line2" in updates[0]
+    assert "text line3" not in updates[0]
     assert "additional line1" in updates[0]
     assert "additional line2" in updates[0]
+    assert "additional line3" not in updates[0]
     assert "Joe Bloggs" in updates[1]
     assert "applied for a licence." in updates[1]

--- a/unit_tests/caseworker/queues/test_views.py
+++ b/unit_tests/caseworker/queues/test_views.py
@@ -647,8 +647,8 @@ def test_activity_updates(url, authorized_client):
                 "type": "system",
                 "team": "",
             },
-            "text": "text line1\ntext line2",
-            "additional_text": "additional line1\nadditional line2",
+            "text": "text line1\ntext line2...",
+            "additional_text": "additional line1\nadditional line2...",
         },
         {
             "id": "77d3c3d4-9761-403a-9942-a2fcc41aa35d",
@@ -670,10 +670,10 @@ def test_activity_updates(url, authorized_client):
     updates = [update.get_text() for update in html.find_all("li", {"class": "app-updates__item"})]
     assert "LITE system" in updates[0]
     assert "text line1" in updates[0]
-    assert "text line2" in updates[0]
+    assert "text line2..." in updates[0]
     assert "text line3" not in updates[0]
     assert "additional line1" in updates[0]
-    assert "additional line2" in updates[0]
+    assert "additional line2..." in updates[0]
     assert "additional line3" not in updates[0]
     assert "Joe Bloggs" in updates[1]
     assert "applied for a licence." in updates[1]


### PR DESCRIPTION
### Aim
This change fixes the case updates column for queue view as follows;
- Boldifies the "Last Action"/"Previous Action" spans.
- Makes the HTML more semantic by using one `<li>` per update.
- Shows `additional_text` for each update if it exists.
- Limits both `additional_text`/`text` for each update to show up to two lines.
- Adds tests.

**Update;**  There's also a fair chunk of overlap with the work ongoing here with some extra content tweaks in https://uktrade.atlassian.net/browse/LTD-3365 - so I've absorbed those changes in to the final commit.

Screenshots can be found here; https://uktrade.atlassian.net/browse/LTD-3364



