### PR TITLE
[LTD-3354] show correct tab count for 'all_cases' tab

### DIFF
--- a/caseworker/queues/views.py
+++ b/caseworker/queues/views.py
@@ -98,9 +98,14 @@ class Cases(LoginRequiredMixin, TemplateView):
         return f"?{params.urlencode()}"
 
     def _get_tab_count(self, tab_name):
+        is_hidden_by_user = self.request.GET.get("hidden", None)
         params = self.get_params()
         params["selected_tab"] = tab_name
-        if tab_name != CasesListPage.Tabs.ALL_CASES:
+        # TODO refactor this to share func
+        is_system_queue = self.queue.get("is_system_queue", False)
+        if tab_name == CasesListPage.Tabs.ALL_CASES and not is_system_queue and not is_hidden_by_user:
+            params["hidden"] = "False"
+        elif tab_name == CasesListPage.Tabs.MY_CASES or tab_name == CasesListPage.Tabs.OPEN_QUERIES:
             params["hidden"] = "True"
 
         return head_cases_search_count(self.request, self.queue_pk, params)

--- a/unit_tests/caseworker/queues/test_views.py
+++ b/unit_tests/caseworker/queues/test_views.py
@@ -17,6 +17,7 @@ default_params = {
     "page": ["1"],
     "queue_id": ["00000000-0000-0000-0000-000000000001"],
     "selected_tab": ["all_cases"],
+    "hidden": ["true"],
 }
 
 


### PR DESCRIPTION
### Aim

![Screenshot 2023-02-13 at 12 34 49](https://user-images.githubusercontent.com/16647486/218993281-00d22fa7-7f80-4c05-95c8-5da677c652d5.png)


There is some logic on both the front [and backend](https://github.com/uktrade/lite-api/blob/dev/api/cases/views/search/views.py#L114) around whether cases with open queries should be `hidden` on a queue view. With the introduction of different tabs adding different rules this logic is getting a bit confusing.

This PR is to put in a quick a fix for the issue where the `cases to review/all cases` tab count was including cases that should be hidden when the user is on a different tab, and hopefully clarifies the rules around when we should be 'hiding' open queries. 

There's logic in two places on the API around the `include_hidden` param - maybe the API should handle it more, and the frontend only pass 'true' for hidden if it's on the form? 

I would suggest as this maybe isn't a priority the next time we touch this we make time to refactor a bit, or we create a ticket to refactor. At the least the param could be renamed, `hidden` or `include_hidden` is a bit confusing and might be better if the boolean was the other way round, could be e.g. `exclude_open_queries`. 

[Link to story](https://uktrade.atlassian.net/jira/software/c/projects/LTD/boards/204?modal=detail&selectedIssue=LTD-3354)
