### PR TITLE
[LTD-3361] Fix case officer allocation

### DIFF
--- a/core/forms/templates/forms/filter_radios.html
+++ b/core/forms/templates/forms/filter_radios.html
@@ -2,4 +2,4 @@
 
 {% include "./_filter_search_container.html" %}
 
-<script type="text/javascript" src="{% static '/javascripts/filter-radiobuttons-list.js' %}" nonce="{{ request.csp_nonce }}"></script>
+<script type="text/javascript" src="{% static 'javascripts/filter-radiobuttons-list.js' %}" nonce="{{ request.csp_nonce }}"></script>


### PR DESCRIPTION
### Aim

This change fixes up the new case officer allocation page.  The page was raising a ValueError; https://sentry.ci.uktrade.digital/organizations/dit/issues/71096/?environment=uat&project=153&query=is%3Aunresolved
This is because we have a strict staticfiles manifest and the leading "/" character was throwing this manifest off.  Locally - with `DEBUG=True` - our staticfiles lookups are more permissive.

https://uktrade.atlassian.net/browse/LTD-3361
