### PR TITLE
Hide the 'Not allocated' message for unassigned case advisers on LU Post/Pre-circ

### DIFF
--- a/caseworker/cases/helpers/case.py
+++ b/caseworker/cases/helpers/case.py
@@ -28,6 +28,7 @@ from caseworker.users.services import get_gov_user
 TAU_ALIAS = "TAU"
 LU_ALIAS = "LICENSING_UNIT"
 LU_POST_CIRC_FINALISE_QUEUE_ALIAS = "LU_POST_CIRC_FINALISE"
+LU_PRE_CIRC_REVIEW_QUEUE_ALIAS = "LU_PRE_CIRC_REVIEW"
 
 
 class Tabs:

--- a/caseworker/queues/views.py
+++ b/caseworker/queues/views.py
@@ -20,6 +20,7 @@ from core.decorators import expect_status
 
 from caseworker.cases.forms.assign_users import assign_users_form
 from caseworker.cases.helpers.filters import case_filters_bar
+from caseworker.cases.helpers.case import LU_POST_CIRC_FINALISE_QUEUE_ALIAS, LU_PRE_CIRC_REVIEW_QUEUE_ALIAS
 from caseworker.core.constants import (
     ALL_CASES_QUEUE_ID,
     Permission,
@@ -175,7 +176,10 @@ class Cases(LoginRequiredMixin, TemplateView):
                         "assignees": [{k: v for k, v in assignment.items() if k != "queues"}],
                     }
 
-        all_queues = {queue["id"]: {"queue_name": queue["name"], "assignees": []} for queue in case["queues"]}
+        queues_that_hide_assignments = (LU_PRE_CIRC_REVIEW_QUEUE_ALIAS, LU_POST_CIRC_FINALISE_QUEUE_ALIAS)
+        all_queues = {}
+        if self.queue["alias"] not in queues_that_hide_assignments:
+            all_queues = {queue["id"]: {"queue_name": queue["name"], "assignees": []} for queue in case["queues"]}
 
         all_assignments = {**all_queues, **assigned_queues}
 

--- a/caseworker/templates/includes/case-row.html
+++ b/caseworker/templates/includes/case-row.html
@@ -110,7 +110,7 @@
                    {% if not assignment.assignees %}
 				   <li class="app-assignments__item expander__expand-list__item">
 					   <div class="app-assignments__user">
-                                Not Allocated
+                                Not allocated
 					   </div>
 					   <div class="app-assignments__team">
 						   {{ assignment.queue_name }}

--- a/unit_tests/caseworker/conftest.py
+++ b/unit_tests/caseworker/conftest.py
@@ -128,6 +128,7 @@ def mock_all_standard_case_data(
 def data_queue():
     return {
         "id": "00000000-0000-0000-0000-000000000001",
+        "alias": None,
         "name": "All cases",
         "is_system_queue": True,
         "countersigning_queue": None,

--- a/unit_tests/caseworker/queues/test_views.py
+++ b/unit_tests/caseworker/queues/test_views.py
@@ -635,7 +635,7 @@ def test_queue_assignments(url, authorized_client):
     assert "Initial Queue" in li_elems[0]
     assert "Joe Smith" in li_elems[1]
     assert "Initial Queue" in li_elems[1]
-    assert "Not Allocated" in li_elems[2]
+    assert "Not allocated" in li_elems[2]
     assert "Another Queue" in li_elems[2]
 
 


### PR DESCRIPTION
### Aim

When I am on the Licensing Unit pre-circulation OR Licensing Unit post-circulation queues
And I’m looking at the list of cases
And a case has an assigned case officer
And no assigned case advisers 
Then I only see the information for the assigned case officer
And NOT the information for case advisers 

When I am on any other queue
Then I see the information for BOTH the case advisers and case officer

[Link to story](https://uktrade.atlassian.net/jira/software/c/projects/LTD/boards/204)
