### PR TITLE
LTD-3294: enable duplicate keys in pagination

### DIFF
--- a/lite_forms/templatetags/custom_tags.py
+++ b/lite_forms/templatetags/custom_tags.py
@@ -1,7 +1,9 @@
 import json
 from html import escape
 from json import JSONDecodeError
+import urllib.parse as urlparse
 
+from django.http import QueryDict
 from django.template.defaulttags import register
 from django.urls import reverse
 from django.utils.safestring import mark_safe
@@ -192,14 +194,10 @@ def make_list(*args):
 
 @register.filter
 def pagination_params(url, page):
-    import urllib.parse as urlparse
-    from urllib.parse import urlencode
-
-    url_parts = list(urlparse.urlparse(url))
-    query_params = dict(urlparse.parse_qsl(url_parts[4]))
-    query_params.pop("page", 1)
-    query = {"page": page, **query_params}
-    url_parts[4] = urlencode(query)
+    url_parts = urlparse.urlparse(url)
+    query_dict = QueryDict(url_parts.query, mutable=True)
+    query_dict["page"] = page
+    url_parts = url_parts._replace(query=query_dict.urlencode())
 
     return urlparse.urlunparse(url_parts)
 

--- a/unit_tests/caseworker/cases/test_views.py
+++ b/unit_tests/caseworker/cases/test_views.py
@@ -446,7 +446,7 @@ def test_search_denials(authorized_client, data_standard_case, requests_mock, qu
 
     requests_mock.get(
         client._build_absolute_uri(f"/external-data/denial-search/?search={end_user_name}&search={end_user_address}"),
-        json={"count": "1", "total_pages": "1", "results": denials_data},
+        json={"count": "26", "total_pages": "2", "results": denials_data * 26},
     )
 
     url = reverse("cases:denials", kwargs={"pk": standard_case_pk, "queue_pk": queue_pk})
@@ -455,6 +455,8 @@ def test_search_denials(authorized_client, data_standard_case, requests_mock, qu
 
     soup = BeautifulSoup(response.content, "html.parser")
     assert soup.find(id="table-denials")
+    page_2 = soup.find(id="page-2")
+    assert page_2.a["href"] == f"/queues/{queue_pk}/cases/{standard_case_pk}/denials/?end_user={end_user_id}&page=2"
 
 
 def test_search_denials_no_matches(authorized_client, requests_mock, queue_pk, standard_case_pk):

--- a/unit_tests/lite_forms/templates/test_custom_tags.py
+++ b/unit_tests/lite_forms/templates/test_custom_tags.py
@@ -15,16 +15,24 @@ def test_file_type(filename, expected):
 
 
 @pytest.mark.parametrize(
-    "url, expected",
+    "url, page, expected",
     [
         (
             "https://www.example.com/?page=1&example_param=foo&example_param=bar",
+            2,
             "https://www.example.com/?page=2&example_param=foo&example_param=bar",
         ),
-        ("https://www.example.com/?page=3&example_param=bar", "https://www.example.com/?page=2&example_param=bar"),
-        ("https://www.example.com/?example_param=bar", "https://www.example.com/?example_param=bar&page=2"),
+        (
+            "https://www.example.com/?page=3&example_param=bar",
+            5,
+            "https://www.example.com/?page=5&example_param=bar",
+        ),
+        (
+            "https://www.example.com/?example_param=bar",
+            "10",
+            "https://www.example.com/?example_param=bar&page=10",
+        ),
     ],
 )
-def test_pagination_params(url, expected):
-    page = 2
+def test_pagination_params(url, page, expected):
     assert custom_tags.pagination_params(url, page) == expected

--- a/unit_tests/lite_forms/templates/test_custom_tags.py
+++ b/unit_tests/lite_forms/templates/test_custom_tags.py
@@ -12,3 +12,19 @@ from lite_forms.templatetags import custom_tags
 )
 def test_file_type(filename, expected):
     assert expected == custom_tags.file_type(filename)
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        (
+            "https://www.example.com/?page=1&example_param=foo&example_param=bar",
+            "https://www.example.com/?page=2&example_param=foo&example_param=bar",
+        ),
+        ("https://www.example.com/?page=3&example_param=bar", "https://www.example.com/?page=2&example_param=bar"),
+        ("https://www.example.com/?example_param=bar", "https://www.example.com/?example_param=bar&page=2"),
+    ],
+)
+def test_pagination_params(url, expected):
+    page = 2
+    assert custom_tags.pagination_params(url, page) == expected


### PR DESCRIPTION
### Aim

We encountered a bug in the denials search, where duplicate keys were
being removed in the pagination as it was converting the params to a
regular dict. This commit uses a QueryDict which allows for duplicate
params.

[Link to story](https://uktrade.atlassian.net/jira/software/c/projects/LTD/boards/204?modal=detail&selectedIssue=LTD-3356)
