### PR TITLE
Added prefix into the MOD approve advice journey

### DIFF
--- a/tests_common/functions.py
+++ b/tests_common/functions.py
@@ -99,6 +99,19 @@ def select_report_summary_subject_and_fill(driver, subject):
     driver.find_element(by=By.XPATH, value="//body").click()
 
 
+def select_report_summary_prefix_and_fill(driver, prefix):
+    suggestion_input_autocomplete = driver.find_element(by=By.ID, value="_report_summary_prefix")
+    suggestion_input_autocomplete.send_keys(prefix)
+    WebDriverWait(driver, 30).until(
+        expected_conditions.text_to_be_present_in_element(
+            (By.CSS_SELECTOR, ".lite-autocomplete__menu--visible #_report_summary_prefix__option--0"),
+            prefix,
+        )
+    )
+    suggestion_input_autocomplete.send_keys(Keys.ARROW_DOWN)
+    driver.find_element(by=By.XPATH, value="//body").click()
+
+
 def click_regime_none(driver: WebDriver):
     driver.find_element(
         By.XPATH,

--- a/ui_tests/caseworker/conftest.py
+++ b/ui_tests/caseworker/conftest.py
@@ -851,8 +851,11 @@ def click_on_product_assessment(driver):  # noqa
     ApplicationPage(driver).select_a_good()
 
 
-@then(parsers.parse('I select "{subject}" as report summary subject and regime to none and submit'))
-def fill_report_summary_select_regime_none_and_submit(driver, subject):  # noqa
+@then(
+    parsers.parse('I select "{prefix}" / "{subject}" as report summary prefix / subject and regime to none and submit')
+)
+def fill_report_summary_select_regime_none_and_submit(driver, prefix, subject):  # noqa
+    functions.select_report_summary_prefix_and_fill(driver, prefix)
     functions.select_report_summary_subject_and_fill(driver, subject)
     functions.click_regime_none(driver)
     functions.click_submit(driver)

--- a/ui_tests/caseworker/features/give_advice.feature
+++ b/ui_tests/caseworker/features/give_advice.feature
@@ -59,7 +59,7 @@ Feature: I want to record my user advice and any comments and conditions relatin
     Then I click on Product Assessment
     And I select good
     And I select the CLE "ML1a"
-    And I select "microwave components" as report summary subject and regime to none and submit
+    And I select "components for" / "microwave components" as report summary prefix / subject and regime to none and submit
     When I click move case forward
     Then I don't see previously created application
     # LU

--- a/ui_tests/caseworker/features/routing_rules.feature
+++ b/ui_tests/caseworker/features/routing_rules.feature
@@ -27,7 +27,7 @@ Feature: I want to have cases be automatically routed to relevant work queues an
     Then I click on Product Assessment
     And I select good
     And I select the CLE "ML1a"
-    And I select "microwave components" as report summary subject and regime to none and submit
+    And I select "components for" / "microwave components" as report summary prefix / subject and regime to none and submit
     When I click move case forward
     Then I don't see previously created application
     # LU


### PR DESCRIPTION
### Aim

Add the new report summary prefix into the existing happy path UI test (MOD approve advice and routing rule journeys) to exercise that in addition to the report summary subject.

[LTD-3321](https://uktrade.atlassian.net/browse/LTD-3321)


[LTD-3321]: https://uktrade.atlassian.net/browse/LTD-3321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ