### PR TITLE
Ltd 3372 case allocation banner

### DIFF
--- a/caseworker/activities/views.py
+++ b/caseworker/activities/views.py
@@ -13,6 +13,7 @@ from caseworker.cases.services import (
 )
 from caseworker.cases.views.main import CaseTabsMixin
 from caseworker.queues.services import get_queue
+from caseworker.users.services import get_gov_user
 
 
 class NotesAndTimeline(LoginRequiredMixin, CaseTabsMixin, TemplateView):
@@ -25,6 +26,11 @@ class NotesAndTimeline(LoginRequiredMixin, CaseTabsMixin, TemplateView):
     @cached_property
     def case(self):
         return get_case(self.request, self.case_id)
+
+    @cached_property
+    def user(self):
+        user, _ = get_gov_user(self.request, str(self.request.session["lite_api_user_id"]))
+        return user["user"]
 
     @cached_property
     def queue_id(self):
@@ -75,4 +81,5 @@ class NotesAndTimeline(LoginRequiredMixin, CaseTabsMixin, TemplateView):
             "team_filters": self.get_team_filters(),
             "tabs": self.get_standard_application_tabs(),
             "current_tab": "cases:activities:notes-and-timeline",
+            "user": self.user,
         }

--- a/caseworker/advice/templates/advice/view_my_advice.html
+++ b/caseworker/advice/templates/advice/view_my_advice.html
@@ -52,7 +52,7 @@
             </div>
             <div class="govuk-grid-column-one-quarter">
               {% if my_advice and advice_completed and buttons.move_case_forward %}
-                {% test_rule 'can_user_move_case_forward' caseworker case as can_user_move_case_forward %}
+                {% test_rule 'can_user_move_case_forward' user case as can_user_move_case_forward %}
                     {% if can_user_move_case_forward %}
                         {% crispy form %}
                     {% endif %}

--- a/caseworker/advice/views.py
+++ b/caseworker/advice/views.py
@@ -99,7 +99,7 @@ class CaseContextMixin:
             **self.get_context(case=self.case),
             "case": self.case,
             "queue_pk": self.kwargs["queue_pk"],
-            "caseworker": self.caseworker,
+            "user": self.caseworker,
         }
 
 

--- a/caseworker/tau/views.py
+++ b/caseworker/tau/views.py
@@ -152,6 +152,7 @@ class TAUMixin(CaseTabsMixin):
             {
                 "tabs": self.get_standard_application_tabs(),
                 "current_tab": "cases:tau:home",
+                "user": self.caseworker,
             }
         )
 
@@ -222,7 +223,6 @@ class TAUHome(LoginRequiredMixin, TAUMixin, FormView):
             "cle_suggestions_json": get_cle_suggestions_json(self.unassessed_goods),
             "organisation_documents": self.organisation_documents,
             "is_tau": self.caseworker["team"]["alias"] == TAU_ALIAS,
-            "user": self.caseworker,
         }
 
     def get_goods(self, good_ids):

--- a/unit_tests/caseworker/activities/test_views.py
+++ b/unit_tests/caseworker/activities/test_views.py
@@ -63,11 +63,13 @@ def test_notes_and_timelines_context_data(
     standard_case_activity,
     data_queue,
     mock_standard_case_activity_system_user,
+    mock_gov_user,
 ):
     response = authorized_client.get(notes_and_timelines_url)
     assert response.context["case"] == Case(data_standard_case["case"])
     assert response.context["queue"] == data_queue
     assert response.context["activities"] == standard_case_activity["activity"]
+    assert response.context["user"] == mock_gov_user["user"]
     assert not response.context["filtering_by"]
     assert response.context["team_filters"] == [
         (

--- a/unit_tests/caseworker/advice/views/test_advice_view.py
+++ b/unit_tests/caseworker/advice/views/test_advice_view.py
@@ -27,7 +27,7 @@ def setup_mock_api(requests_mock, data):
     requests_mock.get(client._build_absolute_uri(f"/cases/{application_id}"), json=data)
 
 
-def test_advice_view_context(
+def test_user_in_context(
     authorized_client,
     data_standard_case_with_all_trigger_list_products_assessed,
     mock_gov_user,

--- a/unit_tests/caseworker/advice/views/test_advice_view.py
+++ b/unit_tests/caseworker/advice/views/test_advice_view.py
@@ -27,6 +27,19 @@ def setup_mock_api(requests_mock, data):
     requests_mock.get(client._build_absolute_uri(f"/cases/{application_id}"), json=data)
 
 
+def test_advice_view_context(
+    authorized_client,
+    data_standard_case_with_all_trigger_list_products_assessed,
+    mock_gov_user,
+    requests_mock,
+    url,
+):
+    data = data_standard_case_with_all_trigger_list_products_assessed
+    setup_mock_api(requests_mock, data)
+    response = authorized_client.get(url)
+    assert response.context["user"] == mock_gov_user["user"]
+
+
 def test_advice_view_shows_no_assessed_trigger_list_goods_if_some_are_not_assessed(
     authorized_client,
     requests_mock,

--- a/unit_tests/caseworker/advice/views/test_edit_advice.py
+++ b/unit_tests/caseworker/advice/views/test_edit_advice.py
@@ -183,12 +183,7 @@ def test_edit_refuse_advice_post(
 
 
 def test_edit_refuse_advice_get(
-    authorized_client,
-    requests_mock,
-    data_standard_case,
-    standard_case_with_advice,
-    refusal_advice,
-    url,
+    authorized_client, requests_mock, data_standard_case, standard_case_with_advice, refusal_advice, url, mock_gov_user
 ):
 
     case_data = deepcopy(data_standard_case)
@@ -203,3 +198,4 @@ def test_edit_refuse_advice_get(
     response = authorized_client.get(url)
     assert response.context["security_approvals_classified_display"] == "F680"
     assert response.context["edit"] is True
+    assert response.context["user"] == mock_gov_user["user"]

--- a/unit_tests/caseworker/advice/views/test_view_ogd_advice.py
+++ b/unit_tests/caseworker/advice/views/test_view_ogd_advice.py
@@ -49,6 +49,15 @@ def test_advice_view_200(mock_queue, mock_case, authorized_client, data_queue, d
     assert response.status_code == 200
 
 
+def test_user_in_context(
+    authorized_client,
+    mock_gov_user,
+    url,
+):
+    response = authorized_client.get(url)
+    assert response.context["user"] == mock_gov_user["user"]
+
+
 def test_advice_view_heading_no_advice(
     requests_mock, mock_queue, authorized_client, data_queue, data_standard_case, url
 ):

--- a/unit_tests/caseworker/tau/test_home.py
+++ b/unit_tests/caseworker/tau/test_home.py
@@ -74,7 +74,13 @@ def test_tau_home_auth(authorized_client, url, mock_control_list_entries, mock_p
 
 
 def test_home_content(
-    authorized_client, url, data_queue, data_standard_case, mock_control_list_entries, mock_precedents_api
+    authorized_client,
+    url,
+    data_queue,
+    data_standard_case,
+    mock_control_list_entries,
+    mock_precedents_api,
+    mock_gov_user,
 ):
     """GET /tau would return a case info panel"""
     # Remove assessment from a good
@@ -123,6 +129,10 @@ def test_home_content(
         "Report summary",
         "test-report-summary",
     ]
+
+    # test the user is passed through to check rule "can_user_change_case"
+
+    assert response.context["user"] == mock_gov_user["user"]
 
 
 def test_tau_home_noauth(client, url):


### PR DESCRIPTION
### Aim

The “allocate yourself” banner was showing on case sub-pages, for TAU, advice, and notes, even after you have allocated yourself to a case.  
This was happening because the rule in the `case` template checking whether that banner should render needed the `user` in the context.

This PR adds the `user` to the different pages contexts. I'm not sure that I've covered all the different places it might need to be in... I'm also wondering if there were a more centralised way to add the user in the context.

[Link to story](https://uktrade.atlassian.net/jira/software/c/projects/LTD/boards/204?modal=detail&selectedIssue=LTD-3372)
