### PR TITLE
Ensure case-level flags are hidden in flag expander

### DIFF
--- a/caseworker/templates/includes/case-row-flags.html
+++ b/caseworker/templates/includes/case-row-flags.html
@@ -2,7 +2,7 @@
     <ol class="app-flags app-flags--list expander__expand-list">
     	{% for flag in flags %}
     		<li
-    			class="app-flag app-flag--{{ flag.colour }}"
+    			class="app-flag app-flag--{{ flag.colour }} expander__expand-list__item"
     			{% if flag.label %}data-tooltip="{{ flag.label }}"{% endif %}>{{ flag.name }}</li>
     	{% endfor %}
     	{%if destinations_flags %}


### PR DESCRIPTION
### Aim
This fixes the issue where case level flags were not hidden by the flag expander; they were missing a required class.

https://uktrade.atlassian.net/browse/LTD-3402
