### PR TITLE
LTD-3324 Fix serial numbers display in select advice view

### DIFF
--- a/caseworker/advice/templates/advice/case_detail.html
+++ b/caseworker/advice/templates/advice/case_detail.html
@@ -79,22 +79,11 @@
                     {% endif %}
                   </td>
                 </tr>
-                {% if good.good.firearm_details %}
+                {% if good.firearm_details %}
                   <tr class="govuk-table__row">
                     <td class="govuk-table__cell govuk-!-font-weight-bold">Serial numbers</td>
                     <td class="govuk-table__cell">
-                      {% if good.good.firearm_details.serial_numbers_available == "LATER" and not good.good.firearm_details.serial_numbers %}
-                        Not added yet
-                      {% else %}
-                        <details class="govuk-details" data-module="govuk-details">
-                          <summary class="govuk-details__summary">
-                            <span class="govuk-details__summary-text">View serial numbers</span>
-                          </summary>
-                          <div class="govuk-details__text">
-                            {{ good.good.firearm_details.serial_numbers|format_serial_numbers:good.quantity|join:"<br>" }}
-                          </div>
-                        </details>
-                      {% endif %}
+                      {% include "goods/includes/serial_numbers.html" with firearm_details=good.firearm_details %}
                     </td>
                   </tr>
                 {% endif %}

--- a/unit_tests/caseworker/advice/views/test_select_advice_view.py
+++ b/unit_tests/caseworker/advice/views/test_select_advice_view.py
@@ -29,9 +29,9 @@ def test_select_advice_post(authorized_client, url, recommendation, redirect):
 
 
 def test_view_serial_numbers_for_firearm_product_in_select_advice_view(authorized_client, data_standard_case, url):
-    good = data_standard_case["case"]["data"]["goods"][0]
-    assert good["good"]["firearm_details"]["serial_numbers"][0] == "12345"
-    assert good["good"]["firearm_details"]["serial_numbers"][1] == "ABC-123"
+    good_on_application = data_standard_case["case"]["data"]["goods"][0]
+    assert good_on_application["firearm_details"]["serial_numbers"][0] == "12345"
+    assert good_on_application["firearm_details"]["serial_numbers"][1] == "ABC-123"
 
     response = authorized_client.get(url)
     soup = BeautifulSoup(response.content, "html.parser")


### PR DESCRIPTION
### Aim

[LTD-3396](https://uktrade.atlassian.net/browse/LTD-3396)

This change fixes the serial numbers display bug by passing the correct object into the template.

In this context we should be using `good.firearm_details` and not `good.good.firearm_details` as the former relates to `good_on_application` and the latter relates to `good`.

Also, two tests are added to make sure the display is correct: when there are serial numbers present, they should display, and when they are not present and `serial_numbers_available` is `LATER`, then the message `Not added yet` should display in place of the serial numbers.


[LTD-3396]: https://uktrade.atlassian.net/browse/LTD-3396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ