### PR TITLE
LTD-3372: use `current_user` to check assessment permissions

### DIFF
--- a/caseworker/advice/templates/advice/view_my_advice.html
+++ b/caseworker/advice/templates/advice/view_my_advice.html
@@ -52,7 +52,7 @@
             </div>
             <div class="govuk-grid-column-one-quarter">
               {% if my_advice and advice_completed and buttons.move_case_forward %}
-                {% test_rule 'can_user_move_case_forward' caseworker case as can_user_move_case_forward %}
+                {% test_rule 'can_user_move_case_forward' current_user case as can_user_move_case_forward %}
                     {% if can_user_move_case_forward %}
                         {% crispy form %}
                     {% endif %}

--- a/caseworker/tau/templates/tau/home.html
+++ b/caseworker/tau/templates/tau/home.html
@@ -25,7 +25,7 @@
                     {% endif %}
                 </div>
                 <!-- Move case forward form -->
-                {% test_rule 'can_user_move_case_forward' user case as can_user_move_case_forward %}
+                {% test_rule 'can_user_move_case_forward' current_user case as can_user_move_case_forward %}
                 {% if can_user_move_case_forward  %}
                     <div class="govuk-grid-column-one-third">
                         {% if not unassessed_goods and is_tau and not is_all_cases_queue %}

--- a/caseworker/tau/views.py
+++ b/caseworker/tau/views.py
@@ -222,7 +222,6 @@ class TAUHome(LoginRequiredMixin, TAUMixin, FormView):
             "cle_suggestions_json": get_cle_suggestions_json(self.unassessed_goods),
             "organisation_documents": self.organisation_documents,
             "is_tau": self.caseworker["team"]["alias"] == TAU_ALIAS,
-            "user": self.caseworker,
         }
 
     def get_goods(self, good_ids):

--- a/caseworker/templates/case/slices/summary.html
+++ b/caseworker/templates/case/slices/summary.html
@@ -1,5 +1,5 @@
 {% load rules %}
-{% test_rule 'can_user_change_case' user case as can_user_change_case %}
+{% test_rule 'can_user_change_case' current_user case as can_user_change_case %}
 
 <dl class="app-case__summary-list">
 	{% if case.case_type.reference.key == "comp_v" %}

--- a/caseworker/templates/layouts/case.html
+++ b/caseworker/templates/layouts/case.html
@@ -115,7 +115,7 @@
 				</div>
 			{% endif %}
 		</div>
-		{% test_rule 'can_user_change_case' user case as can_user_change_case %}
+		{% test_rule 'can_user_change_case' current_user case as can_user_change_case %}
 		{% if not can_user_change_case %}
 			<div class="app-case-warning-banner">
 				<span class="app-case-warning-banner__icon" aria-hidden="true">!</span>
@@ -141,7 +141,7 @@
 							{% endif %}
 							{% govuk_link_button id='rerun-routing-rules' text='cases.ApplicationPage.Actions.RERUN_ROUTING_RULES' url='cases:rerun_routing_rules' url_param=button_params query_params='?return_to='|add:CURRENT_PATH classes='govuk-button--secondary' %}
 							{% if can_set_done and case.case_type.reference.key != "comp_c" %}
-							{% test_rule 'can_user_move_case_forward' user case as can_user_move_case_forward %}
+							{% test_rule 'can_user_move_case_forward' current_user case as can_user_move_case_forward %}
                                 {% if can_user_move_case_forward %}
 									{% govuk_link_button id='done' text='cases.ApplicationPage.DONE_WITH_CASE' url='cases:done' url_param=button_params classes='govuk-button--secondary' hidden=hide_im_done %}
 								{% endif %}

--- a/caseworker/templates/layouts/case.html
+++ b/caseworker/templates/layouts/case.html
@@ -117,7 +117,7 @@
 		</div>
 		{% test_rule 'can_user_change_case' current_user case as can_user_change_case %}
 		{% if not can_user_change_case %}
-			<div class="app-case-warning-banner">
+			<div id="allocation-warning" class="app-case-warning-banner">
 				<span class="app-case-warning-banner__icon" aria-hidden="true">!</span>
 				<span class="app-case-warning-banner__text">
 					You need to allocate yourself or someone else to this case to work on it <a class="app-case-warning-banner__action" href="{% url 'queues:case_assignment_select_role' queue.id %}?&cases={{ case.id }}">Allocate case</a>

--- a/unit_tests/caseworker/activities/test_views.py
+++ b/unit_tests/caseworker/activities/test_views.py
@@ -63,11 +63,13 @@ def test_notes_and_timelines_context_data(
     standard_case_activity,
     data_queue,
     mock_standard_case_activity_system_user,
+    mock_gov_user,
 ):
     response = authorized_client.get(notes_and_timelines_url)
     assert response.context["case"] == Case(data_standard_case["case"])
     assert response.context["queue"] == data_queue
     assert response.context["activities"] == standard_case_activity["activity"]
+    assert response.context["current_user"] == mock_gov_user["user"]
     assert not response.context["filtering_by"]
     assert response.context["team_filters"] == [
         (

--- a/unit_tests/caseworker/advice/views/test_advice_view.py
+++ b/unit_tests/caseworker/advice/views/test_advice_view.py
@@ -27,6 +27,21 @@ def setup_mock_api(requests_mock, data):
     requests_mock.get(client._build_absolute_uri(f"/cases/{application_id}"), json=data)
 
 
+def test_user_in_context(
+    authorized_client,
+    data_standard_case_with_all_trigger_list_products_assessed,
+    mock_gov_user,
+    requests_mock,
+    url,
+):
+    data = data_standard_case_with_all_trigger_list_products_assessed
+    setup_mock_api(requests_mock, data)
+    response = authorized_client.get(url)
+    # "current_user" passed in from caseworker context processor
+    # used to test rule "can_user_change_case"
+    assert response.context["current_user"] == mock_gov_user["user"]
+
+
 def test_advice_view_shows_no_assessed_trigger_list_goods_if_some_are_not_assessed(
     authorized_client,
     requests_mock,

--- a/unit_tests/caseworker/advice/views/test_edit_advice.py
+++ b/unit_tests/caseworker/advice/views/test_edit_advice.py
@@ -183,12 +183,7 @@ def test_edit_refuse_advice_post(
 
 
 def test_edit_refuse_advice_get(
-    authorized_client,
-    requests_mock,
-    data_standard_case,
-    standard_case_with_advice,
-    refusal_advice,
-    url,
+    authorized_client, requests_mock, data_standard_case, standard_case_with_advice, refusal_advice, url, mock_gov_user
 ):
 
     case_data = deepcopy(data_standard_case)
@@ -203,3 +198,4 @@ def test_edit_refuse_advice_get(
     response = authorized_client.get(url)
     assert response.context["security_approvals_classified_display"] == "F680"
     assert response.context["edit"] is True
+    assert response.context["current_user"] == mock_gov_user["user"]

--- a/unit_tests/caseworker/advice/views/test_view_ogd_advice.py
+++ b/unit_tests/caseworker/advice/views/test_view_ogd_advice.py
@@ -49,6 +49,17 @@ def test_advice_view_200(mock_queue, mock_case, authorized_client, data_queue, d
     assert response.status_code == 200
 
 
+def test_user_in_context(
+    authorized_client,
+    mock_gov_user,
+    url,
+):
+    response = authorized_client.get(url)
+    # "current_user" passed in from caseworker context processor
+    # used to test rule "can_user_change_case"
+    assert response.context["current_user"] == mock_gov_user["user"]
+
+
 def test_advice_view_heading_no_advice(
     requests_mock, mock_queue, authorized_client, data_queue, data_standard_case, url
 ):

--- a/unit_tests/caseworker/cases/test_permissions.py
+++ b/unit_tests/caseworker/cases/test_permissions.py
@@ -1,12 +1,12 @@
 import pytest
-from django.urls import reverse
+import re
+from core import client
 
-import rules
 from bs4 import BeautifulSoup
 from django.urls import reverse
 
 
-mock_gov_user_id = "2a43805b-c082-47e7-9188-c8b3e1a83cb0"
+mock_gov_user_id = "2a43805b-c082-47e7-9188-c8b3e1a83cb0"  # /PS-IGNORE
 
 
 @pytest.fixture(autouse=True)
@@ -90,3 +90,58 @@ def test_permission_move_case_forward_done_button(
         assert id_html_find_result
     else:
         assert id_html_find_result is None
+
+
+@pytest.fixture
+def mock_regime_entries_get(requests_mock, wassenaar_regime_entry):
+    regime_entries_url = client._build_absolute_uri("/static/regimes/entries/")
+    requests_mock.get(
+        re.compile(f"{regime_entries_url}ag|cwc|mtcr|nsg|wassenaar"),
+        json=[wassenaar_regime_entry],
+    )
+
+
+@pytest.mark.parametrize(
+    "view_name, is_user_case_officer, is_user_assigned",
+    (
+        ["cases:case", False, False],
+        ["cases:activities:notes-and-timeline", False, False],
+        ["cases:advice_view", False, False],
+        ["cases:tau:home", False, False],
+        ["cases:case", True, False],
+        ["cases:activities:notes-and-timeline", True, False],
+        ["cases:advice_view", True, False],
+        ["cases:tau:home", True, False],
+        ["cases:case", False, True],
+        ["cases:activities:notes-and-timeline", False, True],
+        ["cases:advice_view", False, True],
+        ["cases:tau:home", False, True],
+    ),
+)
+def test_warning_renders_when_expected(
+    authorized_client,
+    data_queue,
+    mock_gov_user,
+    mock_denial_reasons,
+    mock_control_list_entries_get,
+    mock_regime_entries_get,
+    mock_precedents_api,
+    data_standard_case,
+    view_name,
+    is_user_case_officer,
+    is_user_assigned,
+):
+    if is_user_case_officer:
+        data_standard_case["case"]["case_officer"] = mock_gov_user["user"]
+    elif is_user_assigned:
+        data_standard_case["case"]["assigned_users"] = {data_queue["name"]: [mock_gov_user["user"]]}
+    else:
+        data_standard_case["case"]["case_officer"] = None
+        data_standard_case["case"]["assigned_users"] = {}
+    url = reverse(view_name, kwargs={"queue_pk": data_queue["id"], "pk": data_standard_case["case"]["id"]})
+    response = authorized_client.get(url)
+    soup = BeautifulSoup(response.content, "html.parser")
+    if is_user_case_officer or is_user_assigned:
+        assert not soup.find(id="allocation-warning")
+    else:
+        assert soup.find(id="allocation-warning")

--- a/unit_tests/caseworker/tau/test_home.py
+++ b/unit_tests/caseworker/tau/test_home.py
@@ -74,7 +74,13 @@ def test_tau_home_auth(authorized_client, url, mock_control_list_entries, mock_p
 
 
 def test_home_content(
-    authorized_client, url, data_queue, data_standard_case, mock_control_list_entries, mock_precedents_api
+    authorized_client,
+    url,
+    data_queue,
+    data_standard_case,
+    mock_control_list_entries,
+    mock_precedents_api,
+    mock_gov_user,
 ):
     """GET /tau would return a case info panel"""
     # Remove assessment from a good
@@ -123,6 +129,10 @@ def test_home_content(
         "Report summary",
         "test-report-summary",
     ]
+
+    # "current_user" passed in from caseworker context processor
+    # used to test rule "can_user_change_case"
+    assert response.context["current_user"] == mock_gov_user["user"]
 
 
 def test_tau_home_noauth(client, url):

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -2339,3 +2339,14 @@ def data_ecju_queries():
             },
         ]
     }
+
+
+@pytest.fixture
+def mock_control_list_entries_get(requests_mock):
+    url = client._build_absolute_uri(f"/static/control-list-entries/")
+    return requests_mock.get(
+        url=url,
+        json={
+            "control_list_entries": [{"rating": "ML1a", "text": "some text"}, {"rating": "ML22b", "text": "some text"}]
+        },
+    )

--- a/unit_tests/exporter/applications/views/conftest.py
+++ b/unit_tests/exporter/applications/views/conftest.py
@@ -112,12 +112,6 @@ def mock_good_on_application_put(requests_mock, good_on_application):
 
 
 @pytest.fixture
-def mock_control_list_entries_get(requests_mock):
-    url = client._build_absolute_uri(f"/static/control-list-entries/")
-    return requests_mock.get(url=url, json={"control_list_entries": [{"rating": "ML1a"}, {"rating": "ML22b"}]})
-
-
-@pytest.fixture
 def mock_regimes_get(requests_mock):
     url = client._build_absolute_uri(f"/static/regimes/entries/")
     return requests_mock.get(url=url, json={"regimes": [{"rating": "T1"}, {"rating": "T5"}]})


### PR DESCRIPTION
### aim

The “allocate yourself” banner was showing on case sub-pages, for TAU, advice, and notes, even after you have allocated yourself to a case.  
This was happening because the rules `can_user_change_case` and `can_user_move_case_forward` are checked in several templates to decide whether to render buttons/forms and require a `user` key to be present in the context, which some didn't have.

This PR uses the already-present `current_user` from the caseworker `context_processor`, so we don't need to add or use a different value in these templates.

## feedback

I don't know how useful the context-checking tests really are, but it was a quick way for me to check every view when developing. I've added some frontend-y tests to `test_permissions.py` - possibly have been optimised with parameters at the expense of readability...  

[Link to story](https://uktrade.atlassian.net/jira/software/c/projects/LTD/boards/204?modal=detail&selectedIssue=LTD-3372)
