### PR TITLE
Increase the timeout for form submission step in e2e tests

### DIFF
--- a/ui_tests/caseworker/conftest.py
+++ b/ui_tests/caseworker/conftest.py
@@ -197,7 +197,7 @@ def prepare_case(api_test_client, nlr):  # noqa
 def submit_form(driver):  # noqa
     old_page = driver.find_element(by=By.TAG_NAME, value="html")
     Shared(driver).click_submit()
-    WebDriverWait(driver, 20).until(expected_conditions.staleness_of(old_page))
+    WebDriverWait(driver, 45).until(expected_conditions.staleness_of(old_page))
 
 
 @when(parsers.parse('I click "{button_text}"'))


### PR DESCRIPTION
We have a flaky end-to-end test where, I believe, that after selecting the template the page is taking longer to return than our timeout allows

In this case I am increasing the timeout to hopefully make this test less flaky

In the long term we may want to look at whether there are other issues causing this page to be slow but we should see how this small change works before committing to more extensive work