### PR TITLE
Fix to allow user to clear the prefix during edit

### DIFF
--- a/caseworker/assets/javascripts/tau/ars.js
+++ b/caseworker/assets/javascripts/tau/ars.js
@@ -17,6 +17,7 @@ const initAutocompleteField = (summaryFieldType, summaryFieldPluralised) => {
     id: `_report_summary_${summaryFieldType}`,
     source: debounce((query, populateResults) => {
       if (!query) {
+        populateResults([{ id: null, name: "" }]);
         return;
       }
       fetch(`/tau/report_summary/${summaryFieldType}?name=${query}`)
@@ -45,10 +46,16 @@ const initAutocompleteField = (summaryFieldType, summaryFieldPluralised) => {
       }
       originalInput.value = confirmed.id;
     },
-    defaultValue: originalInput.dataset.name,
+    // Check the following is actually required:
+    defaultValue:
+      "subject" == summaryFieldType
+        ? originalInput.dataset.name
+        : originalInput.dataset.name || "",
     showNoOptionsFound: true,
-    autoselect: false,
+    autoselect: true,
     showAllValues: true,
+    required: "subject" == summaryFieldType,
+    confirmOnBlur: true,
   });
 };
 

--- a/caseworker/assets/styles/overrides/_autocomplete.scss
+++ b/caseworker/assets/styles/overrides/_autocomplete.scss
@@ -3,3 +3,6 @@
         color: #fff;
     }
 }
+.lite-autocomplete__option {
+    min-height: 2ex;
+}

--- a/caseworker/tau/forms.py
+++ b/caseworker/tau/forms.py
@@ -23,6 +23,8 @@ from ..report_summary.services import get_report_summary_prefix, get_report_summ
 
 REPORT_SUMMARY_SUBJECT_KEY = "report_summary_subject"
 REPORT_SUMMARY_PREFIX_KEY = "report_summary_prefix"
+INVALID_REPORT_SUMMARY_SUBJECT = "Enter a valid report summary subject"
+INVALID_REPORT_SUMMARY_PREFIX = "Enter a valid report summary prefix"
 
 
 class TAUEditForm(forms.Form):
@@ -305,23 +307,36 @@ class TAUEditForm(forms.Form):
 
     def validate_report_summary_subject(self, cleaned_data):
         subject_id = cleaned_data.get(REPORT_SUMMARY_SUBJECT_KEY)
+        subject_name_as_typed = self.data.get("_report_summary_subject")
+
         if not subject_id:
+            if subject_name_as_typed:
+                self.add_error(REPORT_SUMMARY_SUBJECT_KEY, INVALID_REPORT_SUMMARY_SUBJECT)
             return
 
         try:
-            get_report_summary_subject(self.request, subject_id)
+            actual_name = get_report_summary_subject(self.request, subject_id)[REPORT_SUMMARY_SUBJECT_KEY]["name"]
+            if "_report_summary_subject" in self.data and subject_name_as_typed != actual_name:
+                self.add_error(REPORT_SUMMARY_SUBJECT_KEY, INVALID_REPORT_SUMMARY_SUBJECT)
         except HTTPError:
-            self.add_error(REPORT_SUMMARY_SUBJECT_KEY, "Enter a valid report summary subject")
+            self.add_error(REPORT_SUMMARY_SUBJECT_KEY, INVALID_REPORT_SUMMARY_SUBJECT)
 
     def validate_report_summary_prefix(self, cleaned_data):
         prefix_id = cleaned_data.get(REPORT_SUMMARY_PREFIX_KEY)
+        prefix_name_as_typed = self.data.get("_report_summary_prefix")
+
         if not prefix_id:
+            if prefix_name_as_typed:
+                self.add_error(REPORT_SUMMARY_PREFIX_KEY, INVALID_REPORT_SUMMARY_PREFIX)
             return
 
         try:
-            get_report_summary_prefix(self.request, prefix_id)
+            actual_name = get_report_summary_prefix(self.request, prefix_id)[REPORT_SUMMARY_PREFIX_KEY]["name"]
+            if "_report_summary_prefix" in self.data:
+                if prefix_name_as_typed != actual_name:
+                    self.add_error(REPORT_SUMMARY_PREFIX_KEY, INVALID_REPORT_SUMMARY_PREFIX)
         except HTTPError:
-            self.add_error(REPORT_SUMMARY_PREFIX_KEY, "Enter a valid report summary prefix")
+            self.add_error(REPORT_SUMMARY_PREFIX_KEY, INVALID_REPORT_SUMMARY_PREFIX)
 
 
 class TAUAssessmentForm(TAUEditForm):

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -9,4 +9,4 @@ Include any context that will help reviewers understand the reason for these cha
 * Have you included any relevant screenshots in the JIRA ticket?
 -->
 
-[Link to story](insert Jira link here)
+[LTD-](https://uktrade.atlassian.net/browse/LTD-)

--- a/unit_tests/caseworker/tau/test_forms.py
+++ b/unit_tests/caseworker/tau/test_forms.py
@@ -1024,15 +1024,31 @@ def test_report_summary_valid_prefix(
     assert form.fields["report_summary_prefix"].widget.attrs.get("data-name") == expected_prefix_name
 
 
-def test_report_summary_invalid_prefix(report_summary_requests_mock, rf, client):
+@pytest.mark.parametrize(
+    "name, additional_data, expected_name",
+    (
+        ("Invalid ID", {"report_summary_prefix": "madeupid"}, ""),
+        (
+            "Invalid prefix entered, no previous selection",
+            {"report_summary_prefix": "", "_report_summary_prefix": "no matching entry"},
+            None,
+        ),
+        (
+            "Invalid prefix entered with previous selection",
+            {"report_summary_prefix": PREFIX_API_RESPONSE[1]["id"], "_report_summary_prefix": "no matching entry"},
+            PREFIX_API_RESPONSE[1]["name"],
+        ),
+    ),
+)
+def test_report_summary_invalid_prefix(name, additional_data, expected_name, report_summary_requests_mock, rf, client):
     request = configure_mock_request(client, rf)
     data = {
         "goods": ["test-id"],
         "report_summary_subject": SUBJECT_API_RESPONSE[1]["id"],
         "does_not_have_control_list_entries": True,
         "regimes": ["NONE"],
-        "report_summary_prefix": "madeupid",
     }
+    data.update(additional_data)
 
     form = forms.TAUEditForm(
         request=request,
@@ -1046,7 +1062,7 @@ def test_report_summary_invalid_prefix(report_summary_requests_mock, rf, client)
     )
     assert not form.is_valid()
     assert form.errors["report_summary_prefix"] == ["Enter a valid report summary prefix"]
-    assert form.fields["report_summary_prefix"].widget.attrs["data-name"] == ""
+    assert form.fields["report_summary_prefix"].widget.attrs.get("data-name") == expected_name
 
 
 @pytest.mark.parametrize(
@@ -1093,15 +1109,31 @@ def test_report_summary_valid_subject(
     assert form.fields["report_summary_subject"].widget.attrs["data-name"] == expected_subject_name
 
 
-def test_report_summary_invalid_subject(report_summary_requests_mock, rf, client):
+@pytest.mark.parametrize(
+    "name, additional_data, expected_name",
+    (
+        ("Invalid ID", {"report_summary_subject": "madeupid"}, ""),
+        (
+            "Invalid prefix entered, no previous selection",
+            {"report_summary_subject": "", "_report_summary_subject": "no matching entry"},
+            None,
+        ),
+        (
+            "Invalid prefix entered with previous selection",
+            {"report_summary_subject": SUBJECT_API_RESPONSE[1]["id"], "_report_summary_subject": "no matching entry"},
+            SUBJECT_API_RESPONSE[1]["name"],
+        ),
+    ),
+)
+def test_report_summary_invalid_subject(name, additional_data, expected_name, report_summary_requests_mock, rf, client):
     request = configure_mock_request(client, rf)
     data = {
         "goods": ["test-id"],
         "report_summary_prefix": "",
         "does_not_have_control_list_entries": True,
         "regimes": ["NONE"],
-        "report_summary_subject": "madeupid",
     }
+    data.update(additional_data)
 
     form = forms.TAUEditForm(
         request=request,
@@ -1114,5 +1146,5 @@ def test_report_summary_invalid_subject(report_summary_requests_mock, rf, client
         data=data,
     )
     assert not form.is_valid()
-    assert form.errors["report_summary_subject"]
-    assert form.fields["report_summary_subject"].widget.attrs["data-name"] == ""
+    assert "Enter a valid report summary subject" in form.errors["report_summary_subject"]
+    assert form.fields["report_summary_subject"].widget.attrs.get("data-name") == expected_name


### PR DESCRIPTION
### Aim
Fixed these bugs:
1. Could not edit a prefix to remove it.
2. No error displayed if an invalid value was added for prefix.

The latter was also solved for report summary.

[JIRA-3395](https://uktrade.atlassian.net/browse/LTD-3395)
