### PR TITLE
Ltd 3421 report summary validation

### DIFF
--- a/caseworker/assets/javascripts/tau/ars.js
+++ b/caseworker/assets/javascripts/tau/ars.js
@@ -54,7 +54,6 @@ const initAutocompleteField = (summaryFieldType, summaryFieldPluralised) => {
     showNoOptionsFound: true,
     autoselect: true,
     showAllValues: true,
-    required: "subject" == summaryFieldType,
     confirmOnBlur: true,
   });
 };

--- a/unit_tests/caseworker/tau/test_forms.py
+++ b/unit_tests/caseworker/tau/test_forms.py
@@ -123,7 +123,6 @@ def report_summary_requests_mock(requests_mock):
             "Valid form",
             {
                 "goods": ["test-id"],
-                "report_summary_subject": SUBJECT_API_RESPONSE[1]["id"],
                 "does_not_have_control_list_entries": True,
                 "regimes": ["NONE"],
             },
@@ -134,7 +133,6 @@ def report_summary_requests_mock(requests_mock):
             "Valid form - with comments",
             {
                 "goods": ["test-id"],
-                "report_summary_subject": SUBJECT_API_RESPONSE[1]["id"],
                 "does_not_have_control_list_entries": True,
                 "regimes": ["NONE"],
                 "comments": "test",
@@ -146,7 +144,6 @@ def report_summary_requests_mock(requests_mock):
             "Invalid good-id",
             {
                 "goods": ["test-id-not"],
-                "report_summary_subject": SUBJECT_API_RESPONSE[1]["id"],
                 "does_not_have_control_list_entries": True,
                 "regimes": ["NONE"],
             },
@@ -157,7 +154,6 @@ def report_summary_requests_mock(requests_mock):
             "Missing goods",
             {
                 "goods": [],
-                "report_summary_subject": SUBJECT_API_RESPONSE[1]["id"],
                 "does_not_have_control_list_entries": True,
                 "regimes": ["NONE"],
             },
@@ -168,8 +164,20 @@ def report_summary_requests_mock(requests_mock):
             "Missing report-summary-subject",
             {
                 "goods": ["test-id"],
+                "does_not_have_control_list_entries": False,
+                "control_list_entries": ["test-rating"],
+                "regimes": ["NONE"],
+            },
+            False,
+            {"report_summary_subject": ["Enter a report summary subject"]},
+        ),
+        (
+            "Blank report-summary-subject",
+            {
+                "goods": ["test-id"],
                 "report_summary_subject": "",
-                "does_not_have_control_list_entries": True,
+                "does_not_have_control_list_entries": False,
+                "control_list_entries": ["test-rating"],
                 "regimes": ["NONE"],
             },
             False,
@@ -755,7 +763,7 @@ def test_tau_assessment_form_goods_choices_summary_has_fields_removed(
         (
             "Valid form",
             {
-                "report_summary_subject": SUBJECT_API_RESPONSE[1]["id"],
+                "report_summary_subject": "",
                 "does_not_have_control_list_entries": True,
                 "regimes": ["NONE"],
             },
@@ -765,7 +773,7 @@ def test_tau_assessment_form_goods_choices_summary_has_fields_removed(
         (
             "Valid form with comments",
             {
-                "report_summary_subject": SUBJECT_API_RESPONSE[1]["id"],
+                "report_summary_subject": "",
                 "does_not_have_control_list_entries": True,
                 "regimes": ["NONE"],
                 "comments": "test",
@@ -778,7 +786,8 @@ def test_tau_assessment_form_goods_choices_summary_has_fields_removed(
             {
                 "report_summary_prefix": "madeupid",
                 "report_summary_subject": "",
-                "does_not_have_control_list_entries": True,
+                "does_not_have_control_list_entries": False,
+                "control_list_entries": ["test-rating"],
                 "regimes": ["NONE"],
             },
             False,
@@ -815,7 +824,7 @@ def test_tau_assessment_form_goods_choices_summary_has_fields_removed(
         (
             "Marked as not have CLEs but has CLEs",
             {
-                "report_summary_subject": SUBJECT_API_RESPONSE[1]["id"],
+                "report_summary_subject": "",
                 "does_not_have_control_list_entries": True,
                 "control_list_entries": ["test-rating"],
                 "regimes": ["NONE"],


### PR DESCRIPTION
### Aim

This updates the validation for report summary to take into account whether the assessment is being marked as not requiring CLEs.

If no CLEs are required then the report summary subject can be blank.

[LTD-3421](https://uktrade.atlassian.net/browse/LTD-3421)


[LTD-3421]: https://uktrade.atlassian.net/browse/LTD-3421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ