### PR TITLE
LTD-3432-banner-persisting-bug 

### DIFF
--- a/caseworker/core/rules.py
+++ b/caseworker/core/rules.py
@@ -10,10 +10,10 @@ def is_user_case_adviser(user, case):
 @rules.predicate
 def is_user_assigned(user, case):
     if user and case["assigned_users"]:
-        assigned_users_dict = case["assigned_users"].items()
-        assigned_user = next(iter(assigned_users_dict))
-        _, user_list = assigned_user
-        return any(u["id"] == user["id"] for u in user_list)
+        # Loop through all queues to check if user is assigned
+        for _, assigned_users in case["assigned_users"].items():
+            if any(u["id"] == user["id"] for u in assigned_users):
+                return True
     return False
 
 

--- a/unit_tests/caseworker/core/test_permissions.py
+++ b/unit_tests/caseworker/core/test_permissions.py
@@ -14,7 +14,10 @@ mock_gov_user_id = "2a43805b-c082-47e7-9188-c8b3e1a83cb0"  # /PS-IGNORE
             {
                 "fake queue": [
                     {"id": mock_gov_user_id},
-                ]
+                ],
+                "fake queue 2": [
+                    {"id": "12345zyz"},
+                ],
             },
             True,
         ),

--- a/unit_tests/caseworker/core/test_permissions.py
+++ b/unit_tests/caseworker/core/test_permissions.py
@@ -24,6 +24,17 @@ mock_gov_user_id = "2a43805b-c082-47e7-9188-c8b3e1a83cb0"  # /PS-IGNORE
         (
             {
                 "fake queue": [
+                    {"id": "12345zyz"},
+                ],
+                "fake queue 2": [
+                    {"id": mock_gov_user_id},
+                ],
+            },
+            True,
+        ),
+        (
+            {
+                "fake queue": [
                     {"id": "00c341d1-d83e-4a12-b103-c3fb575a5962"},  # /PS-IGNORE
                 ]
             },


### PR DESCRIPTION
Hotfix into UAT which is blocking deployment for case allocation.

When we have multiple assigned users from a queue on a case the banner was persisting. This is because the code assumed only one list and return on the first iteration. We now loop through all assigned users for muliple queue until we have ex the exhausted the complete list

LTD-](https://uktrade.atlassian.net/browse/LTD-)](https://uktrade.atlassian.net/browse/LTD-3432