### PR TITLE
Multiple countersignatures for LU

### DIFF
--- a/caseworker/advice/services.py
+++ b/caseworker/advice/services.py
@@ -175,7 +175,6 @@ def get_advice_to_countersign(advice, caseworker):
     if settings.FEATURE_LU_POST_CIRC_COUNTERSIGNING:
         if caseworker["team"]["alias"] == LICENSING_UNIT_TEAM:
             advice_levels_to_countersign = [AdviceLevel.FINAL]
-
     advice_by_team = filter_advice_by_users_team(advice, caseworker)
     user_advice = filter_advice_by_level(advice_by_team, advice_levels_to_countersign)
     grouped_user_advice = group_advice_by_user(user_advice)

--- a/caseworker/advice/templates/advice/advice_details.html
+++ b/caseworker/advice/templates/advice/advice_details.html
@@ -84,7 +84,20 @@
 </table>
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
-        {% if advice.0.countersigned_by %}
+        {% if is_lu_countersigning %}
+            <div id="countersignatures">
+                {% for countersign_advice in ordered_countersign_advice %}
+                <div class="govuk-!-padding-4 govuk-!-margin-bottom-2" style="border: 1px solid black;">
+                    <div class="govuk-grid-row">
+                        <div class="govuk-grid-column-three-quarters">
+                            <h2 class="govuk-heading-m">Countersigned by {{ countersign_advice.countersigned_user|full_name }}</h2>
+                            <p class="govuk-body">{{ countersign_advice.reasons }}</p>
+                        </div>
+                    </div>
+                </div>
+            {% endfor %}
+            </div>
+        {% elif advice.0.countersigned_by %}
         <div class="govuk-!-padding-4 govuk-!-margin-bottom-2" style="border: 1px solid black;">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-three-quarters">

--- a/caseworker/advice/templates/advice/view-advice.html
+++ b/caseworker/advice/templates/advice/view-advice.html
@@ -31,7 +31,7 @@
 
     {% if not consolidated_advice %}
         {% if countersign and buttons.review_and_countersign %}
-            {% if is_lu %}
+            {% if is_lu_countersigning %}
                 <a draggable="false" class="govuk-button govuk-button--primary" href="{% url 'cases:countersign_decision_review' queue_pk case.id %}">Review and countersign</a>
             {% else %}
                 <a draggable="false" class="govuk-button govuk-button--primary" href="{% url 'cases:countersign_review' queue_pk case.id %}">Review and countersign</a>

--- a/caseworker/advice/views.py
+++ b/caseworker/advice/views.py
@@ -1,17 +1,13 @@
 from http import HTTPStatus
 
+import sentry_sdk
 from django.conf import settings
 from django.http import Http404, HttpResponseRedirect
-from django.views.generic import FormView, TemplateView
-from django.urls import reverse
 from django.shortcuts import redirect
+from django.urls import reverse
 from django.utils.functional import cached_property
+from django.views.generic import FormView, TemplateView
 from requests.exceptions import HTTPError
-import sentry_sdk
-
-from core import client
-from core.constants import SecurityClassifiedApprovalsType, OrganisationDocumentType
-from core.decorators import expect_status
 
 from caseworker.advice import forms, services, constants
 from caseworker.advice.forms import BEISTriggerListAssessmentForm, BEISTriggerListAssessmentEditForm
@@ -21,7 +17,10 @@ from caseworker.core.helpers import get_organisation_documents
 from caseworker.core.services import get_denial_reasons
 from caseworker.tau.summaries import get_good_on_application_tau_summary
 from caseworker.users.services import get_gov_user
+from core import client
 from core.auth.views import LoginRequiredMixin
+from core.constants import SecurityClassifiedApprovalsType, OrganisationDocumentType
+from core.decorators import expect_status
 
 
 class CaseContextMixin:
@@ -95,20 +94,24 @@ class CaseContextMixin:
         # P.S. the case here is needed for rendering the base
         # template (layouts/case.html) from which we are inheriting.
 
+        is_in_lu_team = self.caseworker["team"]["alias"] == services.LICENSING_UNIT_TEAM
         return {
             **context,
             **self.get_context(case=self.case),
             "case": self.case,
             "queue_pk": self.kwargs["queue_pk"],
             "caseworker": self.caseworker,
-            "is_lu_countersigning": self.caseworker["team"]["alias"] == services.LICENSING_UNIT_TEAM
-            and settings.FEATURE_LU_POST_CIRC_COUNTERSIGNING,
+            "is_lu_countersigning": (is_in_lu_team and settings.FEATURE_LU_POST_CIRC_COUNTERSIGNING),
             "ordered_countersign_advice": self.ordered_countersign_advice(),
         }
 
     def ordered_countersign_advice(self):
-        countersign_advice = [cs for cs in self.case.get("countersign_advice", []) if cs.get("advice", {}).get("good")]
-        return sorted(countersign_advice, key=lambda a: a["order"], reverse=True)
+        """
+        Return a single countersignature per order value in order to filter out duplicates
+        for display in the templates
+        """
+        one_countersignature_per_order_value = {cs["order"]: cs for cs in self.case.get("countersign_advice", [])}
+        return sorted(one_countersignature_per_order_value.values(), key=lambda cs: cs["order"], reverse=True)
 
 
 class BEISNuclearMixin:

--- a/caseworker/advice/views.py
+++ b/caseworker/advice/views.py
@@ -101,7 +101,14 @@ class CaseContextMixin:
             "case": self.case,
             "queue_pk": self.kwargs["queue_pk"],
             "caseworker": self.caseworker,
+            "is_lu_countersigning": self.caseworker["team"]["alias"] == services.LICENSING_UNIT_TEAM
+            and settings.FEATURE_LU_POST_CIRC_COUNTERSIGNING,
+            "ordered_countersign_advice": self.ordered_countersign_advice(),
         }
+
+    def ordered_countersign_advice(self):
+        countersign_advice = [cs for cs in self.case.get("countersign_advice", []) if cs.get("advice", {}).get("good")]
+        return sorted(countersign_advice, key=lambda a: a["order"], reverse=True)
 
 
 class BEISNuclearMixin:
@@ -351,7 +358,6 @@ class AdviceView(LoginRequiredMixin, CaseTabsMixin, CaseContextMixin, BEISNuclea
             "unassessed_trigger_list_goods": self.unassessed_trigger_list_goods,
             "tabs": self.get_standard_application_tabs(),
             "current_tab": "cases:advice_view",
-            "is_lu": self.caseworker["team"]["alias"] == services.LICENSING_UNIT_TEAM,
             **services.get_advice_tab_context(
                 self.case,
                 self.caseworker,

--- a/unit_tests/caseworker/advice/views/test_countersign.py
+++ b/unit_tests/caseworker/advice/views/test_countersign.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 from caseworker.advice.services import LICENSING_UNIT_TEAM
 from core import client
 from caseworker.advice import services
+from unit_tests.caseworker.conftest import countersignatures
 
 
 @pytest.fixture(autouse=True)
@@ -278,7 +279,6 @@ def test_lu_countersign_get_shows_previous_countersignature(
     current_user,
     with_lu_countersigning_enabled,
     final_advice,
-    first_countersignature,
 ):
     case_id = data_standard_case["case"]["id"]
 
@@ -290,7 +290,7 @@ def test_lu_countersign_get_shows_previous_countersignature(
     # Set up advice on the case
     team_id = final_advice["user"]["team"]["id"]
     data_standard_case["case"]["advice"] = [final_advice]
-    data_standard_case["case"]["countersign_advice"] = first_countersignature
+    data_standard_case["case"]["countersign_advice"] = countersignatures()
     # Setup mock API requests
     mock_get_gov_user.return_value = (
         {"user": {"team": {"id": team_id, "alias": LICENSING_UNIT_TEAM}}},

--- a/unit_tests/caseworker/advice/views/test_countersign.py
+++ b/unit_tests/caseworker/advice/views/test_countersign.py
@@ -1,7 +1,11 @@
+from unittest.mock import patch
+
 import pytest
+from bs4 import BeautifulSoup
 
 from django.urls import reverse
 
+from caseworker.advice.services import LICENSING_UNIT_TEAM
 from core import client
 from caseworker.advice import services
 
@@ -263,3 +267,46 @@ def test_lu_countersign_decision_post_success(
             "advice": "c9a96d84-6a6b-421d-bbbb-b12b9577d46e",
         },
     ]
+
+
+@patch("caseworker.advice.views.get_gov_user")
+def test_lu_countersign_get_shows_previous_countersignature(
+    mock_get_gov_user,
+    authorized_client,
+    data_standard_case,
+    standard_case_with_advice,
+    current_user,
+    with_lu_countersigning_enabled,
+    final_advice,
+    first_countersignature,
+):
+    case_id = data_standard_case["case"]["id"]
+
+    queue_details = {
+        "id": "566fd526-bd6d-40c1-94bd-60d10c961234",
+        "name": "Senior licensing manager",
+        "alias": services.LU_SR_LICENSING_MANAGER_QUEUE,
+    }
+    # Set up advice on the case
+    team_id = final_advice["user"]["team"]["id"]
+    data_standard_case["case"]["advice"] = [final_advice]
+    data_standard_case["case"]["countersign_advice"] = first_countersignature
+    # Setup mock API requests
+    mock_get_gov_user.return_value = (
+        {"user": {"team": {"id": team_id, "alias": LICENSING_UNIT_TEAM}}},
+        None,
+    )
+
+    countersign_decision_url = reverse(
+        f"cases:countersign_decision_review",
+        kwargs={"queue_pk": queue_details["id"], "pk": case_id},
+    )
+    response = authorized_client.get(countersign_decision_url)
+    soup = BeautifulSoup(response.content, "html.parser")
+    countersignature_block = soup.find(id="countersignatures")
+    assert response.status_code == 200
+
+    counter_sigs = countersignature_block.find_all("div", recursive=False)
+    assert len(counter_sigs) == 1
+    assert counter_sigs[0].find(class_="govuk-heading-m").text == "Countersigned by Testy McTest"
+    assert counter_sigs[0].find(class_="govuk-body").text == "I concur"

--- a/unit_tests/caseworker/advice/views/test_countersign_view.py
+++ b/unit_tests/caseworker/advice/views/test_countersign_view.py
@@ -1,8 +1,14 @@
+import copy
+from unittest.mock import patch
+
 import pytest
 
 from copy import deepcopy
+
+from bs4 import BeautifulSoup
 from django.urls import reverse
 
+from caseworker.advice.services import LICENSING_UNIT_TEAM
 from core import client
 from caseworker.advice import services
 
@@ -29,3 +35,62 @@ def test_countersign_view_security_approvals(authorized_client, requests_mock, d
     response = authorized_client.get(url)
     assert response.status_code == 200
     assert response.context["security_approvals_classified_display"] == "F680"
+
+
+@patch("caseworker.advice.views.get_gov_user")
+def test_single_lu_countersignature(
+    mock_get_gov_user, authorized_client, requests_mock, data_standard_case, final_advice, first_countersignature, url
+):
+    case_id = data_standard_case["case"]["id"]
+    team_id = final_advice["user"]["team"]["id"]
+    data_standard_case["case"]["advice"] = [final_advice]
+    data_standard_case["case"]["countersign_advice"] = first_countersignature
+    requests_mock.get(client._build_absolute_uri(f"/cases/{case_id}"), json=data_standard_case)
+    mock_get_gov_user.return_value = (
+        {"user": {"team": {"id": team_id, "alias": LICENSING_UNIT_TEAM}}},
+        None,
+    )
+    response = authorized_client.get(url)
+
+    soup = BeautifulSoup(response.content, "html.parser")
+    countersignature_block = soup.find(id="countersignatures")
+    assert response.status_code == 200
+
+    counter_sigs = countersignature_block.find_all("div", recursive=False)
+    assert len(counter_sigs) == 1
+    assert counter_sigs[0].find(class_="govuk-heading-m").text == "Countersigned by Testy McTest"
+    assert counter_sigs[0].find(class_="govuk-body").text == "I concur"
+
+
+@patch("caseworker.advice.views.get_gov_user")
+def test_double_lu_countersignature(
+    mock_get_gov_user,
+    authorized_client,
+    requests_mock,
+    data_standard_case,
+    final_advice,
+    first_countersignature,
+    countersignature_two,
+    url,
+):
+    case_id = data_standard_case["case"]["id"]
+    team_id = final_advice["user"]["team"]["id"]
+    data_standard_case["case"]["advice"] = [final_advice]
+    data_standard_case["case"]["countersign_advice"] = first_countersignature + countersignature_two
+    requests_mock.get(client._build_absolute_uri(f"/cases/{case_id}"), json=data_standard_case)
+    mock_get_gov_user.return_value = (
+        {"user": {"team": {"id": team_id, "alias": LICENSING_UNIT_TEAM}}},
+        None,
+    )
+    response = authorized_client.get(url)
+
+    soup = BeautifulSoup(response.content, "html.parser")
+    countersignature_block = soup.find(id="countersignatures")
+    assert response.status_code == 200
+
+    counter_sigs = countersignature_block.find_all("div", recursive=False)
+    assert len(counter_sigs) == 2
+    assert counter_sigs[0].find(class_="govuk-heading-m").text == "Countersigned by Super Visor"
+    assert counter_sigs[0].find(class_="govuk-body").text == "LGTM"
+    assert counter_sigs[1].find(class_="govuk-heading-m").text == "Countersigned by Testy McTest"
+    assert counter_sigs[1].find(class_="govuk-body").text == "I concur"

--- a/unit_tests/caseworker/advice/views/test_countersign_view.py
+++ b/unit_tests/caseworker/advice/views/test_countersign_view.py
@@ -11,6 +11,7 @@ from django.urls import reverse
 from caseworker.advice.services import LICENSING_UNIT_TEAM
 from core import client
 from caseworker.advice import services
+from unit_tests.caseworker.conftest import countersignatures
 
 
 @pytest.fixture(autouse=True)
@@ -39,12 +40,18 @@ def test_countersign_view_security_approvals(authorized_client, requests_mock, d
 
 @patch("caseworker.advice.views.get_gov_user")
 def test_single_lu_countersignature(
-    mock_get_gov_user, authorized_client, requests_mock, data_standard_case, final_advice, first_countersignature, url
+    mock_get_gov_user,
+    authorized_client,
+    requests_mock,
+    data_standard_case,
+    final_advice,
+    url,
+    with_lu_countersigning_enabled,
 ):
     case_id = data_standard_case["case"]["id"]
     team_id = final_advice["user"]["team"]["id"]
     data_standard_case["case"]["advice"] = [final_advice]
-    data_standard_case["case"]["countersign_advice"] = first_countersignature
+    data_standard_case["case"]["countersign_advice"] = countersignatures(4)
     requests_mock.get(client._build_absolute_uri(f"/cases/{case_id}"), json=data_standard_case)
     mock_get_gov_user.return_value = (
         {"user": {"team": {"id": team_id, "alias": LICENSING_UNIT_TEAM}}},
@@ -69,14 +76,13 @@ def test_double_lu_countersignature(
     requests_mock,
     data_standard_case,
     final_advice,
-    first_countersignature,
-    countersignature_two,
     url,
+    with_lu_countersigning_enabled,
 ):
     case_id = data_standard_case["case"]["id"]
     team_id = final_advice["user"]["team"]["id"]
     data_standard_case["case"]["advice"] = [final_advice]
-    data_standard_case["case"]["countersign_advice"] = first_countersignature + countersignature_two
+    data_standard_case["case"]["countersign_advice"] = countersignatures() + countersignatures(second_countersign=True)
     requests_mock.get(client._build_absolute_uri(f"/cases/{case_id}"), json=data_standard_case)
     mock_get_gov_user.return_value = (
         {"user": {"team": {"id": team_id, "alias": LICENSING_UNIT_TEAM}}},

--- a/unit_tests/caseworker/advice/views/test_view_my_advice_view.py
+++ b/unit_tests/caseworker/advice/views/test_view_my_advice_view.py
@@ -1,10 +1,12 @@
+from unittest.mock import patch
+
 import pytest
 
 from bs4 import BeautifulSoup
 from django.urls import reverse
 import rules
 
-from caseworker.advice.services import FCDO_TEAM
+from caseworker.advice.services import FCDO_TEAM, LICENSING_UNIT_TEAM
 from core import client
 from core.builtins.custom_tags import filter_advice_by_user
 
@@ -262,3 +264,33 @@ def test_move_case_forward_permission(
     # Check if the MoveCaseForwardForm is rendered only when user has permission can_user_move_case_forward
     soup = BeautifulSoup(response.content, "html.parser")
     assert len(soup.find_all("form")) == (1 if is_user_case_advisor else 0)
+
+
+@patch("caseworker.advice.views.get_gov_user")
+def test_lu_countersignatures_not_shown(
+    mock_get_gov_user,
+    authorized_client,
+    requests_mock,
+    data_standard_case,
+    final_advice,
+    first_countersignature,
+    countersignature_two,
+    url,
+):
+    case_id = data_standard_case["case"]["id"]
+    team_id = final_advice["user"]["team"]["id"]
+    data_standard_case["case"]["advice"] = [final_advice]
+    data_standard_case["case"]["countersign_advice"] = first_countersignature + countersignature_two
+    requests_mock.get(client._build_absolute_uri(f"/cases/{case_id}"), json=data_standard_case)
+    mock_get_gov_user.return_value = (
+        {"user": {"team": {"id": team_id, "alias": LICENSING_UNIT_TEAM}}},
+        None,
+    )
+    response = authorized_client.get(url)
+
+    assert response.status_code == 200
+
+    soup = BeautifulSoup(response.content, "html.parser")
+    countersignature_block = soup.find(id="countersignatures")
+
+    assert not countersignature_block

--- a/unit_tests/caseworker/advice/views/test_view_my_advice_view.py
+++ b/unit_tests/caseworker/advice/views/test_view_my_advice_view.py
@@ -9,6 +9,7 @@ import rules
 from caseworker.advice.services import FCDO_TEAM, LICENSING_UNIT_TEAM
 from core import client
 from core.builtins.custom_tags import filter_advice_by_user
+from unit_tests.caseworker.conftest import countersignatures
 
 
 @pytest.fixture(autouse=True)
@@ -273,14 +274,13 @@ def test_lu_countersignatures_not_shown(
     requests_mock,
     data_standard_case,
     final_advice,
-    first_countersignature,
-    countersignature_two,
     url,
+    with_lu_countersigning_enabled,
 ):
     case_id = data_standard_case["case"]["id"]
     team_id = final_advice["user"]["team"]["id"]
     data_standard_case["case"]["advice"] = [final_advice]
-    data_standard_case["case"]["countersign_advice"] = first_countersignature + countersignature_two
+    data_standard_case["case"]["countersign_advice"] = countersignatures() + countersignatures(second_countersign=True)
     requests_mock.get(client._build_absolute_uri(f"/cases/{case_id}"), json=data_standard_case)
     mock_get_gov_user.return_value = (
         {"user": {"team": {"id": team_id, "alias": LICENSING_UNIT_TEAM}}},

--- a/unit_tests/caseworker/conftest.py
+++ b/unit_tests/caseworker/conftest.py
@@ -466,7 +466,18 @@ def FCDO_team_user():
 
 
 @pytest.fixture
-def LU_team_user():
+def lu_team():
+    return {
+        "id": "809eba0f-f197-4f0f-949b-9af309a844fb",
+        "name": "LU Team",
+        "alias": LICENSING_UNIT_TEAM,
+        "part_of_ecju": False,
+        "is_ogd": True,
+    }
+
+
+@pytest.fixture
+def LU_team_user(lu_team):
     return {
         "email": "lu.team@example.com",
         "first_name": "LU Team",
@@ -474,13 +485,7 @@ def LU_team_user():
         "last_name": "User",
         "role_name": "Super User",
         "status": "Active",
-        "team": {
-            "id": "809eba0f-f197-4f0f-949b-9af309a844fb",
-            "name": "LU Team",
-            "alias": "LICENSING_UNIT",
-            "part_of_ecju": False,
-            "is_ogd": True,
-        },
+        "team": lu_team,
     }
 
 
@@ -608,6 +613,82 @@ def advice_for_countersign(current_user):
                 },
             },
         },
+    ]
+
+
+@pytest.fixture
+def final_advice(current_user, lu_team):
+    return {
+        "consignee": None,
+        "country": None,
+        "created_at": "2021-07-14T15:20:35.713348+01:00",
+        "countersigned_by": None,
+        "denial_reasons": [],
+        "end_user": None,
+        "footnote": None,
+        "good": "de385241-ffe3-4e81-96a6-64c0934bc4e2",
+        "goods_type": None,
+        "id": "825bddc9-4e6c-4a26-8231-9c0500b037a6",
+        "level": "final",
+        "note": "",
+        "proviso": None,
+        "text": "",
+        "third_party": None,
+        "type": {"key": "approve", "value": "Approve"},
+        "ultimate_end_user": None,
+        "user": {
+            "email": "yscott@bob-scott.com",
+            "first_name": "Scott",
+            "id": "5d36079b-e921-4598-b0f9-d7a62da6e9ef",
+            "last_name": "Bob",
+            "role_name": "Adviser",
+            "status": "Active",
+            "team": lu_team,
+        },
+    }
+
+
+@pytest.fixture
+def first_countersignature():
+    countersignature = {
+        "reasons": "I concur",
+        "countersigned_user": {
+            "first_name": "Testy",
+            "last_name": "McTest",
+        },
+        "outcome_accepted": True,
+        "order": 1,
+    }
+    good_id = "3268e0b3-5fa2-46c3-9b20-3620b74f1c44"
+    end_user_id = "bd394902-a86e-45f1-8dd2-6b9a11c218a3"
+    ult_end_user_id = "79a0baff-6a71-4d42-8c9f-0f3bec60e199"
+
+    return [
+        {**countersignature, **{"advice": {"good": good_id, "end_user": None, "ultimate_end_user": None}}},
+        {**countersignature, **{"advice": {"good": None, "end_user": end_user_id, "ultimate_end_user": None}}},
+        {**countersignature, **{"advice": {"good": None, "end_user": None, "ultimate_end_user": ult_end_user_id}}},
+    ]
+
+
+@pytest.fixture
+def countersignature_two():
+    countersignature = {
+        "reasons": "LGTM",
+        "countersigned_user": {
+            "first_name": "Super",
+            "last_name": "Visor",
+        },
+        "outcome_accepted": True,
+        "order": 2,
+    }
+    good_id = "3268e0b3-5fa2-46c3-9b20-3620b74f1c44"
+    end_user_id = "bd394902-a86e-45f1-8dd2-6b9a11c218a3"
+    ult_end_user_id = "79a0baff-6a71-4d42-8c9f-0f3bec60e199"
+
+    return [
+        {**countersignature, **{"advice": {"good": good_id, "end_user": None, "ultimate_end_user": None}}},
+        {**countersignature, **{"advice": {"good": None, "end_user": end_user_id, "ultimate_end_user": None}}},
+        {**countersignature, **{"advice": {"good": None, "end_user": None, "ultimate_end_user": ult_end_user_id}}},
     ]
 
 

--- a/unit_tests/caseworker/conftest.py
+++ b/unit_tests/caseworker/conftest.py
@@ -1,5 +1,6 @@
 import re
 import os
+import uuid
 
 import pytest
 from dotenv import load_dotenv
@@ -648,9 +649,8 @@ def final_advice(current_user, lu_team):
     }
 
 
-@pytest.fixture
-def first_countersignature():
-    countersignature = {
+def countersignatures(good_with_advice_count=2, second_countersign=False, end_user=True, ultimate_end_user=True):
+    first_countersignature = {
         "reasons": "I concur",
         "countersigned_user": {
             "first_name": "Testy",
@@ -659,15 +659,32 @@ def first_countersignature():
         "outcome_accepted": True,
         "order": 1,
     }
-    good_id = "3268e0b3-5fa2-46c3-9b20-3620b74f1c44"
-    end_user_id = "bd394902-a86e-45f1-8dd2-6b9a11c218a3"
-    ult_end_user_id = "79a0baff-6a71-4d42-8c9f-0f3bec60e199"
+    second_countersignature = {
+        "reasons": "LGTM",
+        "countersigned_user": {
+            "first_name": "Super",
+            "last_name": "Visor",
+        },
+        "outcome_accepted": True,
+        "order": 2,
+    }
+    countersignature = second_countersignature if second_countersign else first_countersignature
+    out = []
 
-    return [
-        {**countersignature, **{"advice": {"good": good_id, "end_user": None, "ultimate_end_user": None}}},
-        {**countersignature, **{"advice": {"good": None, "end_user": end_user_id, "ultimate_end_user": None}}},
-        {**countersignature, **{"advice": {"good": None, "end_user": None, "ultimate_end_user": ult_end_user_id}}},
-    ]
+    if end_user:
+        out.append(
+            {**countersignature, **{"advice": {"good": None, "end_user": str(uuid.uuid4()), "ultimate_end_user": None}}}
+        )
+    if ultimate_end_user:
+        out.append(
+            {**countersignature, **{"advice": {"good": None, "end_user": None, "ultimate_end_user": str(uuid.uuid4())}}}
+        )
+    for i in range(good_with_advice_count):
+        out.append(
+            {**countersignature, **{"advice": {"good": str(uuid.uuid4()), "end_user": None, "ultimate_end_user": None}}}
+        )
+
+    return out
 
 
 @pytest.fixture


### PR DESCRIPTION
### Aim

Update the various advice views to display LU countersignatures where appropriate. This should be anywhere final advice is displayed if this is an LU case.

[LTD-3413](https://uktrade.atlassian.net/browse/LTD-3413)


[LTD-3413]: https://uktrade.atlassian.net/browse/LTD-3413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ