### PR TITLE
Report Summary Improvements

### DIFF
--- a/caseworker/assets/javascripts/tau/ars.js
+++ b/caseworker/assets/javascripts/tau/ars.js
@@ -53,7 +53,6 @@ const initAutocompleteField = (summaryFieldType, summaryFieldPluralised) => {
         : originalInput.dataset.name || "",
     showNoOptionsFound: true,
     autoselect: true,
-    showAllValues: true,
     confirmOnBlur: true,
   });
 };

--- a/caseworker/assets/javascripts/tau/ars.js
+++ b/caseworker/assets/javascripts/tau/ars.js
@@ -34,9 +34,7 @@ const initAutocompleteField = (summaryFieldType, summaryFieldPluralised) => {
           return suggestion;
         }
         return `
-          <div class="govuk-body govuk-!-margin-bottom-0">
-            ${suggestion.name}
-          </div>
+          <div class="govuk-body govuk-!-margin-bottom-0">${suggestion.name}</div>
         `;
       },
     },

--- a/caseworker/assets/styles/overrides/_autocomplete.scss
+++ b/caseworker/assets/styles/overrides/_autocomplete.scss
@@ -6,3 +6,11 @@
 .lite-autocomplete__option {
     min-height: 2ex;
 }
+.lite-autocomplete__option--focused {
+    div.govuk-body {
+        color: white;
+    }
+}
+.lite-autocomplete__hint {
+    padding-left: 3px;
+}

--- a/caseworker/assets/styles/overrides/_autocomplete.scss
+++ b/caseworker/assets/styles/overrides/_autocomplete.scss
@@ -9,9 +9,7 @@
     border: none;
 }
 .lite-autocomplete__option:has(.govuk-body:empty)  {
-    padding-bottom: 0;
-    padding-top: 0;
-    min-height: 0;
+    display: none;
 }
 .lite-autocomplete__option--focused {
     div.govuk-body {

--- a/caseworker/assets/styles/overrides/_autocomplete.scss
+++ b/caseworker/assets/styles/overrides/_autocomplete.scss
@@ -3,8 +3,15 @@
         color: #fff;
     }
 }
-.lite-autocomplete__option {
-    min-height: 2ex;
+// The following selectors hide the blank option if it is the only
+// option in the dropdown.
+.lite-autocomplete__menu:has(.govuk-body:empty)  {
+    border: none;
+}
+.lite-autocomplete__option:has(.govuk-body:empty)  {
+    padding-bottom: 0;
+    padding-top: 0;
+    min-height: 0;
 }
 .lite-autocomplete__option--focused {
     div.govuk-body {


### PR DESCRIPTION
Remove 'blur' on autoselected item.
Added proper copy. Fixed pointer.
Minimise the "empty" option if the prefix or subject dropdowns are empty.

[LTD-3416](https://uktrade.atlassian.net/browse/LTD-3416)


[LTD-3416]: https://uktrade.atlassian.net/browse/LTD-3416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ