### PR TITLE
Blank out report_summary field if it is None

### DIFF
--- a/caseworker/tau/templates/tau/home.html
+++ b/caseworker/tau/templates/tau/home.html
@@ -93,7 +93,7 @@
                                                 {{ regime_entry.shortened_name|default:regime_entry.name }}<br>
                                             {% endfor %}
                                         </td>
-                                        <td class="govuk-table__cell">{{ good.report_summary }}</td>
+                                        <td class="govuk-table__cell">{{ good.report_summary|default:"" }}</td>
                                         <td class="govuk-table__cell">{{ good.comment|linebreaksbr }}</td>
                                         <td class="govuk-table__cell">
                                             <a class="govuk-link govuk-link--no-visited-state" href="{% url 'cases:tau:edit' queue_pk=queue_id pk=case.id good_id=good.id %}">Edit</a>


### PR DESCRIPTION
### Aim

On the "Assessed Products" table a product with no report summary is showing up as "None". Change this to blank the field out instead.

[LTD-3439](https://uktrade.atlassian.net/browse/LTD-3439)


[LTD-3439]: https://uktrade.atlassian.net/browse/LTD-3439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ