### PR TITLE
Stop crispy forms from generating its own form tag

### DIFF
--- a/caseworker/tau/forms.py
+++ b/caseworker/tau/forms.py
@@ -187,6 +187,7 @@ class TAUEditForm(forms.Form):
             self.fields[REPORT_SUMMARY_SUBJECT_KEY].widget.attrs["data-name"] = report_summary_subject_name
 
         self.helper = FormHelper()
+        self.helper.form_tag = False
 
         feature_flagged_regimes = []
         if settings.FEATURE_C6_REGIMES:
@@ -374,8 +375,6 @@ class TAUAssessmentForm(TAUEditForm):
             label="Select a product to begin. Or you can select multiple products to give them the same assessment.",
             error_messages={"required": "Select the products that you want to assess"},
         )
-
-        self.helper.form_tag = False
 
     def get_goods_choices(self, goods):
         return [

--- a/caseworker/tau/templates/tau/edit.html
+++ b/caseworker/tau/templates/tau/edit.html
@@ -20,7 +20,6 @@
             <div class="govuk-grid-column-one-third">
                 {{ cle_suggestions_json|json_script:"cle-suggestions-json" }}
                 <form id="tau-form" method="POST">
-                    {% csrf_token %}
                     <h1 class="govuk-heading-m tau__headline">Assessing {{good.good.name}}</h1>
                     {% crispy form %}
                     {% test_rule 'can_user_assess_products' current_user case as can_user_assess_products %}

--- a/caseworker/tau/templates/tau/home.html
+++ b/caseworker/tau/templates/tau/home.html
@@ -44,7 +44,6 @@
                 {% if unassessed_goods %}
                     {{ cle_suggestions_json|json_script:"cle-suggestions-json" }}
                     <form id="tau-form" action="." method="POST" {% if form.helper.attrs.enctype %}enctype="{{ form.helper.attrs.enctype }}"{% endif %}>
-                        {% csrf_token %}
                         <div class="govuk-grid-column-two-thirds assessment-form__first-column">
                             {{ form.goods|as_crispy_field }}
                         </div>

--- a/unit_tests/caseworker/tau/test_edit.py
+++ b/unit_tests/caseworker/tau/test_edit.py
@@ -491,3 +491,38 @@ def test_form_report_summary_conditions(
         )
     else:
         assert soup.find("form").find(id="report_summary_prefix").attrs.get("value") is None
+
+
+def test_form_only_rendered_once(
+    authorized_client,
+    url,
+    data_standard_case,
+    requests_mock,
+    mock_cle_post,
+    mock_control_list_entries,
+    mock_precedents_api,
+    report_summary_prefix,
+    report_summary_subject,
+    assign_user_to_case,
+    mock_gov_user,
+):
+    # This is to test a bug where we were rendering the form tag in the
+    # template but not suppressing it when crispy forms was rendering the form
+    # itself.
+    # This caused malformed HTML to be rendered by the browser and resulted in
+    # the submit button being rendered in the wrong place.
+
+    assign_user_to_case(mock_gov_user, data_standard_case)
+
+    good = data_standard_case["case"]["data"]["goods"][0]
+    good["is_good_controlled"] = None
+    good["control_list_entries"] = []
+    edit_good = data_standard_case["case"]["data"]["goods"][1]
+    edit_good["control_list_entries"] = [{"rating": "ML1"}, {"rating": "ML1a"}]
+    # Get the edit form
+    response = authorized_client.get(url)
+    soup = BeautifulSoup(response.content, "html.parser")
+
+    tau_form = soup.find(id="tau-form")
+    assert tau_form is not None
+    assert not tau_form.select("form")


### PR DESCRIPTION
This was producing malformed HTML (a form within a form) that eventually caused the submit button to be rendered in the wrong place after we moved it out of the crispy form
