### PR TITLE
Http error middleware

### DIFF
--- a/conf/base.py
+++ b/conf/base.py
@@ -73,6 +73,7 @@ MIDDLEWARE = [
     "core.middleware.ValidateReturnToMiddleware",
     "core.middleware.XRobotsTagMiddleware",
     "core.middleware.SessionTimeoutMiddleware",
+    "core.middleware.HttpErrorHandlerMiddleware",
 ]
 
 if not DEBUG:

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -232,3 +232,17 @@ class XRobotsTagMiddleware:
         response = self.get_response(request)
         response["X-Robots-Tag"] = ",".join(["noindex", "nofollow"])
         return response
+
+
+class HttpErrorHandlerMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        return response
+
+    def process_exception(self, request, exception):
+        if isinstance(exception, requests.HTTPError):
+            logger.info(exception.response.text)
+        return None

--- a/unit_tests/core/middleware/test_http_error.py
+++ b/unit_tests/core/middleware/test_http_error.py
@@ -1,0 +1,28 @@
+from requests import HTTPError
+from requests.models import Response
+
+from core.middleware import HttpErrorHandlerMiddleware
+
+
+def test_http_error_handler_non_http_error_exception(rf, mocker, caplog):
+    get_response = mocker.MagicMock()
+    http_error_handler = HttpErrorHandlerMiddleware(get_response)
+
+    request = rf.get("/")
+    not_http_error = Exception()
+    assert http_error_handler.process_exception(request, not_http_error) is None
+    assert not caplog.records
+
+
+def test_http_error_handler_with_http_error(rf, mocker, caplog):
+    get_response = mocker.MagicMock()
+    http_error_handler = HttpErrorHandlerMiddleware(get_response)
+
+    response = Response()
+    response.status_code = 400
+    response._content = b'{"error": "this is an error"}'
+
+    http_error = HTTPError(response=response)
+    request = rf.get("/")
+    assert http_error_handler.process_exception(request, http_error) is None
+    assert ("INFO", '{"error": "this is an error"}') in [(r.levelname, r.msg) for r in caplog.records]

--- a/unit_tests/core/middleware/test_no_cache.py
+++ b/unit_tests/core/middleware/test_no_cache.py
@@ -1,0 +1,11 @@
+from rest_framework.response import Response
+
+from core.middleware import NoCacheMiddleware
+
+
+def test_no_cache_middleware(rf, mocker):
+    request = rf.get("/")
+    get_response = mocker.Mock(return_value=Response())
+    instance = NoCacheMiddleware(get_response)
+    response = instance(request)
+    assert response["Cache-Control"] == "max-age=0, no-cache, no-store, must-revalidate, private"

--- a/unit_tests/core/middleware/test_return_to.py
+++ b/unit_tests/core/middleware/test_return_to.py
@@ -1,0 +1,30 @@
+import pytest
+
+from rest_framework import status
+from rest_framework.response import Response
+
+from core.middleware import ValidateReturnToMiddleware
+
+
+@pytest.mark.parametrize(
+    "url,response_code",
+    [
+        ("?return_to=hello", status.HTTP_200_OK),
+        ("?return_to=hello/", status.HTTP_200_OK),
+        ("?return_to=/hello", status.HTTP_200_OK),
+        ("?return_to=/hello/", status.HTTP_200_OK),
+        ("?return_to=http://example.com", status.HTTP_403_FORBIDDEN),
+        ("?return_to=http://example.com/", status.HTTP_403_FORBIDDEN),
+        ("?return_to=https://example.com/", status.HTTP_403_FORBIDDEN),
+        ('?return_to=javascript:alert("hello!")', status.HTTP_403_FORBIDDEN),
+        # Protocol-relative URL
+        ("?return_to=////example.com", status.HTTP_403_FORBIDDEN),
+        ("?return_to=///example.com", status.HTTP_403_FORBIDDEN),
+        ("?return_to=//example.com", status.HTTP_403_FORBIDDEN),
+    ],
+)
+def test_validate_return_to_middleware(rf, url, response_code, mocker):
+    request = rf.get(url)
+    get_response = mocker.Mock(return_value=Response())
+    response = ValidateReturnToMiddleware(get_response)(request)
+    assert response.status_code == response_code

--- a/unit_tests/core/middleware/test_x_robots_tag.py
+++ b/unit_tests/core/middleware/test_x_robots_tag.py
@@ -1,0 +1,16 @@
+from rest_framework import status
+from rest_framework.response import Response
+
+from core.middleware import XRobotsTagMiddleware
+
+
+def test_x_robots_tag_middleware(rf, mocker):
+    # Set up mock request and response
+    request = rf.get("/")
+    get_response = mocker.Mock(return_value=Response())
+    # Instantiate and call the middleware
+    instance = XRobotsTagMiddleware(get_response)
+    # We should get a 200 and the token should be cached
+    response = instance(request)
+    assert response.status_code == status.HTTP_200_OK
+    assert response.headers["x-robots-tag"] == "noindex,nofollow"


### PR DESCRIPTION
### Aim

There are many cases where we make a service call and then check for an invalid response by running `raise_for_status`. When this fails we then get a HTTPError thrown and this ends up in Sentry.

The problem with the above is that in some cases the API is returning a 400 _and_ some text in the payload that would be important for us to know about, however just surfacing the HTTPError ends up hiding the response we are getting from the API.

This adds a middleware that adds a logger call of the response text which will end up in the breadcrumbs of the Sentry exception when we receive these errors.
