### PR TITLE
Cookie banner css removing padding when above 2000px

### DIFF
--- a/caseworker/advice/templates/advice/advice_details.html
+++ b/caseworker/advice/templates/advice/advice_details.html
@@ -82,7 +82,7 @@
         {% endfor %}
     </tbody>
 </table>
-<div class="govuk-grid-row">
+<div class="govuk-grid-row govuk-details">
     <div class="govuk-grid-column-three-quarters">
         {% if is_lu_countersigning %}
             {% if not rejected_lu_countersignature %}

--- a/caseworker/advice/templates/advice/advice_details.html
+++ b/caseworker/advice/templates/advice/advice_details.html
@@ -110,44 +110,35 @@
         </div>
         {% endif %}
         {% if decision == 'approve' or decision == 'proviso' %}
-        <div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="Reason for approving">
-            <div class="govuk-cookie-banner__message govuk-width-container">
-                <div class="govuk-grid-row">
+        <div class="recommendation-and-decision" data-nosnippet role="region" aria-label="Reason for approving">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <h2 class="govuk-heading-m">Reason for approving</h2>
-                    <div class="govuk-cookie-banner__content">
-                        <p class="govuk-body">{{ advice.0.text|linebreaks }}</p>
-                    </div>
+                    <p class="govuk-body">{{ advice.0.text|linebreaks }}</p>
+
                     {% if advice.0.proviso %}
                     <h2 class="govuk-heading-m">Licence condition</h2>
-                    <div class="govuk-cookie-banner__content">
-                        <p class="govuk-body">{{ advice.0.proviso|linebreaks }}</p>
-                    </div>
+                    <p class="govuk-body">{{ advice.0.proviso|linebreaks }}</p>
                     {% endif %}
 
                     {% if advice.0.note %}
                     <h2 class="govuk-heading-m">Additional instructions</h2>
-                    <div class="govuk-cookie-banner__content">
-                        <p class="govuk-body">{{ advice.0.note|linebreaks }}</p>
-                    </div>
+                    <p class="govuk-body">{{ advice.0.note|linebreaks }}</p>
                     {% endif %}
 
                     {% if advice.0.footnote %}
                     <h2 class="govuk-heading-m">Reporting footnote</h2>
-                    <div class="govuk-cookie-banner__content">
-                        <p class="govuk-body">{{ advice.0.footnote|linebreaks }}</p>
-                    </div>
+                    <p class="govuk-body">{{ advice.0.footnote|linebreaks }}</p>
                     {% endif %}
                 </div>
             </div>
         </div>
         {% elif decision == 'refuse' %}
-        <div class="govuk-cookie-banner " data-nosnippet role="region" aria-label="Reason for refusing">
-            <div class="govuk-cookie-banner__message govuk-width-container">
-              <div class="govuk-grid-row">
+        <div class="recommendation-and-decision" data-nosnippet role="region" aria-label="Reason for refusing">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                 <h2 class="govuk-heading-m">Reason for refusing</h2>
-                <div class="govuk-cookie-banner__content">
                 <p class="govuk-body">{{ advice.0.text|linebreaks }}</p>
-                </div>
               </div>
             </div>
         </div>

--- a/caseworker/advice/templates/advice/advice_details.html
+++ b/caseworker/advice/templates/advice/advice_details.html
@@ -88,7 +88,7 @@
             {% if not rejected_lu_countersignature %}
                 <div id="countersignatures">
                     {% for countersign_advice in ordered_countersign_advice %}
-                        <div class="govuk-!-padding-4 govuk-!-margin-bottom-2" style="border: 1px solid black;">
+                        <div class="govuk-!-padding-4 govuk-!-margin-bottom-2 countersigned-by">
                             <div class="govuk-grid-row">
                                 <div class="govuk-grid-column-three-quarters">
                                     <h2 class="govuk-heading-m">Countersigned by {{ countersign_advice.countersigned_user|full_name }}</h2>
@@ -100,7 +100,7 @@
                 </div>
             {% endif %}
         {% elif advice.0.countersigned_by %}
-        <div class="govuk-!-padding-4 govuk-!-margin-bottom-2" style="border: 1px solid black;">
+        <div class="govuk-!-padding-4 govuk-!-margin-bottom-2 countersigned-by">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-three-quarters">
                     <h2 class="govuk-heading-m">Countersigned by {{ advice.0.countersigned_by|full_name }}</h2>

--- a/caseworker/advice/templates/advice/advice_details.html
+++ b/caseworker/advice/templates/advice/advice_details.html
@@ -110,7 +110,7 @@
         </div>
         {% endif %}
         {% if decision == 'approve' or decision == 'proviso' %}
-        <div class="recommendation-and-decision" data-nosnippet role="region" aria-label="Reason for approving">
+        <div class="govuk-!-padding-4 govuk-!-margin-bottom-2 recommendation-and-decision" data-nosnippet role="region" aria-label="Reason for approving">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <h2 class="govuk-heading-m">Reason for approving</h2>
@@ -134,7 +134,7 @@
             </div>
         </div>
         {% elif decision == 'refuse' %}
-        <div class="recommendation-and-decision" data-nosnippet role="region" aria-label="Reason for refusing">
+        <div class="govuk-!-padding-4 govuk-!-margin-bottom-2 recommendation-and-decision" data-nosnippet role="region" aria-label="Reason for refusing">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                 <h2 class="govuk-heading-m">Reason for refusing</h2>

--- a/caseworker/advice/templates/advice/approve-advice-details.html
+++ b/caseworker/advice/templates/advice/approve-advice-details.html
@@ -61,39 +61,29 @@
       </div>
     {% endif %}
 
-    <div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="Reason for approving">
-        <div class="govuk-cookie-banner__message govuk-width-container">
+    <div class="recommendation-and-decision" data-nosnippet role="region" aria-label="Reason for approving">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          <h2 class="govuk-heading-m">Reason for approving</h2>
+          <p class="govuk-body">{{ advice.text }}</p>
 
-          <div class="govuk-grid-row">
-            <div class="govuk-grid-column-two-thirds">
-                <h2 class="govuk-heading-m">Reason for approving</h2>
-                <div class="govuk-cookie-banner__content">
-                <p class="govuk-body">{{ advice.text }}</p>
-                </div>
 
-                {% if advice.proviso %}
-                <h2 class="govuk-heading-m">Licence condition</h2>
-                <div class="govuk-cookie-banner__content">
-                    <p class="govuk-body">{{ advice.proviso }}</p>
-                </div>
-                {% endif %}
+          {% if advice.proviso %}
+          <h2 class="govuk-heading-m">Licence condition</h2>
+          <p class="govuk-body">{{ advice.proviso }}</p>
+          {% endif %}
 
-                {% if advice.note %}
-                <h2 class="govuk-heading-m">Additional instructions</h2>
-                <div class="govuk-cookie-banner__content">
-                    <p class="govuk-body">{{ advice.note }}</p>
-                </div>
-                {% endif %}
+          {% if advice.note %}
+          <h2 class="govuk-heading-m">Additional instructions</h2>
+          <p class="govuk-body">{{ advice.note }}</p>
+          {% endif %}
 
-                {% if advice.footnote %}
-                <h2 class="govuk-heading-m">Reporting footnote</h2>
-                <div class="govuk-cookie-banner__content">
-                    <p class="govuk-body">{{ advice.footnote }}</p>
-                </div>
-                {% endif %}
-            </div>
-          </div>
+          {% if advice.footnote %}
+          <h2 class="govuk-heading-m">Reporting footnote</h2>
+          <p class="govuk-body">{{ advice.footnote }}</p>
+          {% endif %}
         </div>
+      </div>
     </div>
 
     <br><br>

--- a/caseworker/advice/templates/advice/approve-advice-details.html
+++ b/caseworker/advice/templates/advice/approve-advice-details.html
@@ -48,7 +48,7 @@
     </tbody>
 </table>
 
-<div class="govuk-grid-row">
+<div class="govuk-grid-row govuk-details">
   <div class="govuk-grid-column-three-quarters">
     {% if display_countersign %}
       <div class="govuk-!-padding-4 govuk-!-margin-bottom-2 countersigned-by">

--- a/caseworker/advice/templates/advice/approve-advice-details.html
+++ b/caseworker/advice/templates/advice/approve-advice-details.html
@@ -61,7 +61,7 @@
       </div>
     {% endif %}
 
-    <div class="recommendation-and-decision" data-nosnippet role="region" aria-label="Reason for approving">
+    <div class="govuk-!-padding-4 govuk-!-margin-bottom-2 recommendation-and-decision" data-nosnippet role="region" aria-label="Reason for approving">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
           <h2 class="govuk-heading-m">Reason for approving</h2>

--- a/caseworker/advice/templates/advice/approve-advice-details.html
+++ b/caseworker/advice/templates/advice/approve-advice-details.html
@@ -51,7 +51,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
     {% if display_countersign %}
-      <div class="govuk-!-padding-4 govuk-!-margin-bottom-2" style="border: 1px solid black;">
+      <div class="govuk-!-padding-4 govuk-!-margin-bottom-2 countersigned-by">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-three-quarters">
             <h2 class="govuk-heading-m">Countersigned by {{ advice.countersigned_by|full_name }}</h2>

--- a/caseworker/advice/templates/advice/group-advice.html
+++ b/caseworker/advice/templates/advice/group-advice.html
@@ -68,23 +68,21 @@
                     </div>
                     {% endif %}
                     <div class="recommendation-and-decision" data-nosnippet role="region" aria-label="Reasons for approving">
-                        <div class="govuk-width-container">
-                            <div class="govuk-grid-row">
-                                <div class="govuk-grid-column-full govuk-!-padding-left-1">
-                                    {% if decision_advice.decision == "Approve" or decision_advice.decision == "Proviso" %}
-                                        <h3 class="govuk-heading-s">Reasons for approving</h3>
-                                    {% elif decision_advice.decision == "Refuse" %}
-                                        <h3 class="govuk-heading-s">Reasons for refusing</h3>
+                        <div class="govuk-grid-row">
+                            <div class="govuk-grid-column-full">
+                                {% if decision_advice.decision == "Approve" or decision_advice.decision == "Proviso" %}
+                                    <h3 class="govuk-heading-s">Reasons for approving</h3>
+                                {% elif decision_advice.decision == "Refuse" %}
+                                    <h3 class="govuk-heading-s">Reasons for refusing</h3>
+                                {% endif %}
+                                <div>
+                                    <p class="govuk-body">
+                                    {% if advice.text %}
+                                        {{ advice.text|linebreaks }}
+                                    {% else %}
+                                        No criteria concerns
                                     {% endif %}
-                                    <div>
-                                        <p class="govuk-body">
-                                        {% if advice.text %}
-                                            {{ advice.text|linebreaks }}
-                                        {% else %}
-                                            No criteria concerns
-                                        {% endif %}
-                                        </p>
-                                    </div>
+                                    </p>
                                 </div>
                             </div>
                         </div>
@@ -92,13 +90,11 @@
                 </div>
                 {% if decision_advice.decision == "Proviso" %}
                 <div class="recommendation-and-decision" data-nosnippet role="region" aria-label="Licence condition">
-                    <div class="govuk-width-container">
-                        <div class="govuk-grid-row">
-                            <div class="govuk-grid-column-full govuk-!-padding-left-1">
-                                <h3 class="govuk-heading-s">Licence condition</h3>
-                                <div>
-                                    <p class="govuk-body">{{ advice.proviso|linebreaks }}</p>
-                                </div>
+                    <div class="govuk-grid-row">
+                        <div class="govuk-grid-column-full">
+                            <h3 class="govuk-heading-s">Licence condition</h3>
+                            <div>
+                                <p class="govuk-body">{{ advice.proviso|linebreaks }}</p>
                             </div>
                         </div>
                     </div>
@@ -106,13 +102,11 @@
                 {% endif %}
                 {% if advice.note %}
                 <div class="recommendation-and-decision" data-nosnippet role="region" aria-label="Additional instructions">
-                    <div class="govuk-width-container">
-                        <div class="govuk-grid-row">
-                            <div class="govuk-grid-column-full govuk-!-padding-left-1">
-                                <h3 class="govuk-heading-s">Additional instructions</h3>
-                                <div>
-                                    <p class="govuk-body">{{ advice.note|linebreaks }}</p>
-                                </div>
+                    <div class="govuk-grid-row">
+                        <div class="govuk-grid-column-full">
+                            <h3 class="govuk-heading-s">Additional instructions</h3>
+                            <div>
+                                <p class="govuk-body">{{ advice.note|linebreaks }}</p>
                             </div>
                         </div>
                     </div>
@@ -120,13 +114,11 @@
                 {% endif %}
                 {% if advice.footnote %}
                 <div class="recommendation-and-decision" data-nosnippet role="region" aria-label="Reporting footnote">
-                    <div class="govuk-width-container">
-                        <div class="govuk-grid-row">
-                            <div class="govuk-grid-column-full govuk-!-padding-left-1">
-                                <h3 class="govuk-heading-s">Reporting footnote</h3>
-                                <div>
-                                    <p class="govuk-body">{{ advice.footnote|linebreaks }}</p>
-                                </div>
+                    <div class="govuk-grid-row">
+                        <div class="govuk-grid-column-full govuk-!-padding-left-1">
+                            <h3 class="govuk-heading-s">Reporting footnote</h3>
+                            <div>
+                                <p class="govuk-body">{{ advice.footnote|linebreaks }}</p>
                             </div>
                         </div>
                     </div>

--- a/caseworker/advice/templates/advice/group-advice.html
+++ b/caseworker/advice/templates/advice/group-advice.html
@@ -56,42 +56,40 @@
                     </tbody>
                 </table>
                 {% with decision_advice.advice.0.advice as advice %}
-                <!-- <div class="govuk-grid-row"> -->
-                    <div>
-                        {% if advice.countersigned_by %}
-                        <div class="govuk-!-padding-4 govuk-!-margin-bottom-2 border-1-black">
-                            <div class="govuk-grid-row">
-                                <div>
-                                    <h2 class="govuk-heading-m">Countersigned by {{ advice.countersigned_by|full_name }}</h2>
-                                    <p class="govuk-body">{{ advice.countersign_comments }}</p>
-                                </div>
+                <div>
+                    {% if advice.countersigned_by %}
+                    <div class="govuk-!-padding-4 govuk-!-margin-bottom-2 border-1-black">
+                        <div class="govuk-grid-row">
+                            <div>
+                                <h2 class="govuk-heading-m">Countersigned by {{ advice.countersigned_by|full_name }}</h2>
+                                <p class="govuk-body">{{ advice.countersign_comments }}</p>
                             </div>
                         </div>
-                        {% endif %}
-                        <div class="recommendation-and-decision" data-nosnippet role="region" aria-label="Reasons for approving">
-                            <div class="govuk-width-container">
-                                <div class="govuk-grid-row">
-                                    <div class="govuk-grid-column-full govuk-!-padding-left-1">
-                                        {% if decision_advice.decision == "Approve" or decision_advice.decision == "Proviso" %}
-                                            <h3 class="govuk-heading-s">Reasons for approving</h3>
-                                        {% elif decision_advice.decision == "Refuse" %}
-                                            <h3 class="govuk-heading-s">Reasons for refusing</h3>
+                    </div>
+                    {% endif %}
+                    <div class="recommendation-and-decision" data-nosnippet role="region" aria-label="Reasons for approving">
+                        <div class="govuk-width-container">
+                            <div class="govuk-grid-row">
+                                <div class="govuk-grid-column-full govuk-!-padding-left-1">
+                                    {% if decision_advice.decision == "Approve" or decision_advice.decision == "Proviso" %}
+                                        <h3 class="govuk-heading-s">Reasons for approving</h3>
+                                    {% elif decision_advice.decision == "Refuse" %}
+                                        <h3 class="govuk-heading-s">Reasons for refusing</h3>
+                                    {% endif %}
+                                    <div>
+                                        <p class="govuk-body">
+                                        {% if advice.text %}
+                                            {{ advice.text|linebreaks }}
+                                        {% else %}
+                                            No criteria concerns
                                         {% endif %}
-                                        <div>
-                                            <p class="govuk-body">
-                                            {% if advice.text %}
-                                                {{ advice.text|linebreaks }}
-                                            {% else %}
-                                                No criteria concerns
-                                            {% endif %}
-                                            </p>
-                                        </div>
+                                        </p>
                                     </div>
                                 </div>
                             </div>
                         </div>
                     </div>
-                <!-- </div> -->
+                </div>
                 {% if decision_advice.decision == "Proviso" %}
                 <div class="recommendation-and-decision" data-nosnippet role="region" aria-label="Licence condition">
                     <div class="govuk-width-container">

--- a/caseworker/advice/templates/advice/group-advice.html
+++ b/caseworker/advice/templates/advice/group-advice.html
@@ -59,12 +59,14 @@
                 {% if advice.countersigned_by %}
                 <div class="govuk-!-padding-4 govuk-!-margin-bottom-2 countersigned-by">
                     <div class="govuk-grid-row">
-                        <h2 class="govuk-heading-m">Countersigned by {{ advice.countersigned_by|full_name }}</h2>
-                        <p class="govuk-body">{{ advice.countersign_comments }}</p>
+                        <div class="govuk-grid-column-full">
+                            <h2 class="govuk-heading-m">Countersigned by {{ advice.countersigned_by|full_name }}</h2>
+                            <p class="govuk-body">{{ advice.countersign_comments }}</p>
+                        </div>
                     </div>
                 </div>
                 {% endif %}
-                <div class="recommendation-and-decision" data-nosnippet role="region" aria-label="Reasons for approving">
+                <div class="govuk-!-padding-4 govuk-!-margin-bottom-2 recommendation-and-decision" data-nosnippet role="region" aria-label="Reasons for approving">
                     <div class="govuk-grid-row">
                         <div class="govuk-grid-column-full">
                             {% if decision_advice.decision == "Approve" or decision_advice.decision == "Proviso" %}
@@ -83,7 +85,7 @@
                     </div>
                 </div>
                 {% if decision_advice.decision == "Proviso" %}
-                <div class="recommendation-and-decision" data-nosnippet role="region" aria-label="Licence condition">
+                <div class="govuk-!-padding-4 govuk-!-margin-bottom-2 recommendation-and-decision" data-nosnippet role="region" aria-label="Licence condition">
                     <div class="govuk-grid-row">
                         <div class="govuk-grid-column-full">
                             <h3 class="govuk-heading-s">Licence condition</h3>
@@ -93,7 +95,7 @@
                 </div>
                 {% endif %}
                 {% if advice.note %}
-                <div class="recommendation-and-decision" data-nosnippet role="region" aria-label="Additional instructions">
+                <div class="govuk-!-padding-4 govuk-!-margin-bottom-2 recommendation-and-decision" data-nosnippet role="region" aria-label="Additional instructions">
                     <div class="govuk-grid-row">
                         <div class="govuk-grid-column-full">
                             <h3 class="govuk-heading-s">Additional instructions</h3>
@@ -103,7 +105,7 @@
                 </div>
                 {% endif %}
                 {% if advice.footnote %}
-                <div class="recommendation-and-decision" data-nosnippet role="region" aria-label="Reporting footnote">
+                <div class="govuk-!-padding-4 govuk-!-margin-bottom-2 recommendation-and-decision" data-nosnippet role="region" aria-label="Reporting footnote">
                     <div class="govuk-grid-row">
                         <div class="govuk-grid-column-full govuk-!-padding-left-1">
                             <h3 class="govuk-heading-s">Reporting footnote</h3>

--- a/caseworker/advice/templates/advice/group-advice.html
+++ b/caseworker/advice/templates/advice/group-advice.html
@@ -56,35 +56,29 @@
                     </tbody>
                 </table>
                 {% with decision_advice.advice.0.advice as advice %}
-                <div>
-                    {% if advice.countersigned_by %}
-                    <div class="govuk-!-padding-4 govuk-!-margin-bottom-2 border-1-black">
-                        <div class="govuk-grid-row">
-                            <div>
-                                <h2 class="govuk-heading-m">Countersigned by {{ advice.countersigned_by|full_name }}</h2>
-                                <p class="govuk-body">{{ advice.countersign_comments }}</p>
-                            </div>
-                        </div>
+                {% if advice.countersigned_by %}
+                <div class="govuk-!-padding-4 govuk-!-margin-bottom-2 countersigned-by">
+                    <div class="govuk-grid-row">
+                        <h2 class="govuk-heading-m">Countersigned by {{ advice.countersigned_by|full_name }}</h2>
+                        <p class="govuk-body">{{ advice.countersign_comments }}</p>
                     </div>
-                    {% endif %}
-                    <div class="recommendation-and-decision" data-nosnippet role="region" aria-label="Reasons for approving">
-                        <div class="govuk-grid-row">
-                            <div class="govuk-grid-column-full">
-                                {% if decision_advice.decision == "Approve" or decision_advice.decision == "Proviso" %}
-                                    <h3 class="govuk-heading-s">Reasons for approving</h3>
-                                {% elif decision_advice.decision == "Refuse" %}
-                                    <h3 class="govuk-heading-s">Reasons for refusing</h3>
-                                {% endif %}
-                                <div>
-                                    <p class="govuk-body">
-                                    {% if advice.text %}
-                                        {{ advice.text|linebreaks }}
-                                    {% else %}
-                                        No criteria concerns
-                                    {% endif %}
-                                    </p>
-                                </div>
-                            </div>
+                </div>
+                {% endif %}
+                <div class="recommendation-and-decision" data-nosnippet role="region" aria-label="Reasons for approving">
+                    <div class="govuk-grid-row">
+                        <div class="govuk-grid-column-full">
+                            {% if decision_advice.decision == "Approve" or decision_advice.decision == "Proviso" %}
+                                <h3 class="govuk-heading-s">Reasons for approving</h3>
+                            {% elif decision_advice.decision == "Refuse" %}
+                                <h3 class="govuk-heading-s">Reasons for refusing</h3>
+                            {% endif %}
+                            <p class="govuk-body">
+                            {% if advice.text %}
+                                {{ advice.text|linebreaks }}
+                            {% else %}
+                                No criteria concerns
+                            {% endif %}
+                            </p>
                         </div>
                     </div>
                 </div>
@@ -93,9 +87,7 @@
                     <div class="govuk-grid-row">
                         <div class="govuk-grid-column-full">
                             <h3 class="govuk-heading-s">Licence condition</h3>
-                            <div>
-                                <p class="govuk-body">{{ advice.proviso|linebreaks }}</p>
-                            </div>
+                            <p class="govuk-body">{{ advice.proviso|linebreaks }}</p>
                         </div>
                     </div>
                 </div>
@@ -105,9 +97,7 @@
                     <div class="govuk-grid-row">
                         <div class="govuk-grid-column-full">
                             <h3 class="govuk-heading-s">Additional instructions</h3>
-                            <div>
-                                <p class="govuk-body">{{ advice.note|linebreaks }}</p>
-                            </div>
+                            <p class="govuk-body">{{ advice.note|linebreaks }}</p>
                         </div>
                     </div>
                 </div>
@@ -117,9 +107,7 @@
                     <div class="govuk-grid-row">
                         <div class="govuk-grid-column-full govuk-!-padding-left-1">
                             <h3 class="govuk-heading-s">Reporting footnote</h3>
-                            <div>
-                                <p class="govuk-body">{{ advice.footnote|linebreaks }}</p>
-                            </div>
+                            <p class="govuk-body">{{ advice.footnote|linebreaks }}</p>
                         </div>
                     </div>
                 </div>

--- a/caseworker/advice/templates/advice/group-advice.html
+++ b/caseworker/advice/templates/advice/group-advice.html
@@ -56,20 +56,20 @@
                     </tbody>
                 </table>
                 {% with decision_advice.advice.0.advice as advice %}
-                <div class="govuk-grid-row">
-                    <div class="govuk-grid-column-three-quarters">
+                <!-- <div class="govuk-grid-row"> -->
+                    <div>
                         {% if advice.countersigned_by %}
-                        <div class="govuk-!-padding-4 govuk-!-margin-bottom-2" style="border: 1px solid black;">
+                        <div class="govuk-!-padding-4 govuk-!-margin-bottom-2 border-1-black">
                             <div class="govuk-grid-row">
-                                <div class="govuk-grid-column-three-quarters">
+                                <div>
                                     <h2 class="govuk-heading-m">Countersigned by {{ advice.countersigned_by|full_name }}</h2>
                                     <p class="govuk-body">{{ advice.countersign_comments }}</p>
                                 </div>
                             </div>
                         </div>
                         {% endif %}
-                        <div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="Reasons for approving">
-                            <div class="govuk-cookie-banner__message govuk-width-container">
+                        <div class="recommendation-and-decision" data-nosnippet role="region" aria-label="Reasons for approving">
+                            <div class="govuk-width-container">
                                 <div class="govuk-grid-row">
                                     <div class="govuk-grid-column-full govuk-!-padding-left-1">
                                         {% if decision_advice.decision == "Approve" or decision_advice.decision == "Proviso" %}
@@ -77,7 +77,7 @@
                                         {% elif decision_advice.decision == "Refuse" %}
                                             <h3 class="govuk-heading-s">Reasons for refusing</h3>
                                         {% endif %}
-                                        <div class="govuk-cookie-banner__content">
+                                        <div>
                                             <p class="govuk-body">
                                             {% if advice.text %}
                                                 {{ advice.text|linebreaks }}
@@ -91,14 +91,14 @@
                             </div>
                         </div>
                     </div>
-                </div>
+                <!-- </div> -->
                 {% if decision_advice.decision == "Proviso" %}
-                <div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="Licence condition">
-                    <div class="govuk-cookie-banner__message govuk-width-container">
+                <div class="recommendation-and-decision" data-nosnippet role="region" aria-label="Licence condition">
+                    <div class="govuk-width-container">
                         <div class="govuk-grid-row">
                             <div class="govuk-grid-column-full govuk-!-padding-left-1">
                                 <h3 class="govuk-heading-s">Licence condition</h3>
-                                <div class="govuk-cookie-banner__content">
+                                <div>
                                     <p class="govuk-body">{{ advice.proviso|linebreaks }}</p>
                                 </div>
                             </div>
@@ -107,12 +107,12 @@
                 </div>
                 {% endif %}
                 {% if advice.note %}
-                <div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="Additional instructions">
-                    <div class="govuk-cookie-banner__message govuk-width-container">
+                <div class="recommendation-and-decision" data-nosnippet role="region" aria-label="Additional instructions">
+                    <div class="govuk-width-container">
                         <div class="govuk-grid-row">
                             <div class="govuk-grid-column-full govuk-!-padding-left-1">
                                 <h3 class="govuk-heading-s">Additional instructions</h3>
-                                <div class="govuk-cookie-banner__content">
+                                <div>
                                     <p class="govuk-body">{{ advice.note|linebreaks }}</p>
                                 </div>
                             </div>
@@ -121,12 +121,12 @@
                 </div>
                 {% endif %}
                 {% if advice.footnote %}
-                <div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="Reporting footnote">
-                    <div class="govuk-cookie-banner__message govuk-width-container">
+                <div class="recommendation-and-decision" data-nosnippet role="region" aria-label="Reporting footnote">
+                    <div class="govuk-width-container">
                         <div class="govuk-grid-row">
                             <div class="govuk-grid-column-full govuk-!-padding-left-1">
                                 <h3 class="govuk-heading-s">Reporting footnote</h3>
-                                <div class="govuk-cookie-banner__content">
+                                <div>
                                     <p class="govuk-body">{{ advice.footnote|linebreaks }}</p>
                                 </div>
                             </div>

--- a/caseworker/advice/templates/advice/refuse-advice-details.html
+++ b/caseworker/advice/templates/advice/refuse-advice-details.html
@@ -54,7 +54,7 @@
 
 <br>
 
-<div class="recommendation-and-decision" data-nosnippet role="region" aria-label="Reason for refusing">
+<div class="govuk-!-padding-4 govuk-!-margin-bottom-2 recommendation-and-decision" data-nosnippet role="region" aria-label="Reason for refusing">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h2 class="govuk-heading-m">Reason for refusing</h2>

--- a/caseworker/advice/templates/advice/refuse-advice-details.html
+++ b/caseworker/advice/templates/advice/refuse-advice-details.html
@@ -54,7 +54,7 @@
 
 <br>
 
-<div class="govuk-!-padding-4 govuk-!-margin-bottom-2 recommendation-and-decision" data-nosnippet role="region" aria-label="Reason for refusing">
+<div class="govuk-!-padding-4 govuk-!-margin-bottom-2 recommendation-and-decision govuk-details" data-nosnippet role="region" aria-label="Reason for refusing">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h2 class="govuk-heading-m">Reason for refusing</h2>

--- a/caseworker/advice/templates/advice/refuse-advice-details.html
+++ b/caseworker/advice/templates/advice/refuse-advice-details.html
@@ -54,17 +54,13 @@
 
 <br>
 
-<div class="govuk-cookie-banner " data-nosnippet role="region" aria-label="Reason for refusing">
-    <div class="govuk-cookie-banner__message govuk-width-container">
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <h2 class="govuk-heading-m">Reason for refusing</h2>
-            <div class="govuk-cookie-banner__content">
-            <p class="govuk-body">{{ advice.text }}</p>
-            </div>
-        </div>
-      </div>
+<div class="recommendation-and-decision" data-nosnippet role="region" aria-label="Reason for refusing">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <h2 class="govuk-heading-m">Reason for refusing</h2>
+      <p class="govuk-body">{{ advice.text }}</p>
     </div>
+  </div>
 </div>
 
 <br><br>

--- a/caseworker/advice/templates/advice/view-advice.html
+++ b/caseworker/advice/templates/advice/view-advice.html
@@ -66,7 +66,7 @@
                             </strong>
                         </div>
                         <div id="rejected-countersignature-detail">
-                            <div class="govuk-!-padding-4 govuk-!-margin-bottom-2" style="border: 1px solid black;">
+                            <div class="govuk-!-padding-4 govuk-!-margin-bottom-2 countersigned-by">
                                 <div class="govuk-grid-row">
                                     <div class="govuk-grid-column-three-quarters">
                                         <h2 class="govuk-heading-m">Reason for returning</h2>

--- a/caseworker/assets/styles/components/notes_and_timeline/_case-note.scss
+++ b/caseworker/assets/styles/components/notes_and_timeline/_case-note.scss
@@ -14,7 +14,7 @@
 
 .recommendation-and-decision {
     background-color: govuk-colour("light-grey");
-    padding-top:10px;
+    padding: 15px;
 }
 
 .border-1-black {

--- a/caseworker/assets/styles/components/notes_and_timeline/_case-note.scss
+++ b/caseworker/assets/styles/components/notes_and_timeline/_case-note.scss
@@ -14,7 +14,6 @@
 
 .recommendation-and-decision {
     background-color: govuk-colour("light-grey");
-    padding: 15px;
 }
 
 .countersigned-by{

--- a/caseworker/assets/styles/components/notes_and_timeline/_case-note.scss
+++ b/caseworker/assets/styles/components/notes_and_timeline/_case-note.scss
@@ -17,6 +17,6 @@
     padding: 15px;
 }
 
-.border-1-black {
+.countersigned-by{
     border: 1px solid black;
 }

--- a/caseworker/assets/styles/components/notes_and_timeline/_case-note.scss
+++ b/caseworker/assets/styles/components/notes_and_timeline/_case-note.scss
@@ -11,3 +11,12 @@
         padding-bottom: govuk-spacing(4);
     }
 }
+
+.recommendation-and-decision {
+    background-color: govuk-colour("light-grey");
+    padding-top:10px;
+}
+
+.border-1-black {
+    border: 1px solid black;
+}

--- a/ui_tests/caseworker/pages/advice.py
+++ b/ui_tests/caseworker/pages/advice.py
@@ -138,33 +138,31 @@ class RecommendationsAndDecisionPage(BasePage):
     def get_reasons_for_approving(self):
         return self.driver.find_element(
             by=By.XPATH,
-            value="//p[preceding-sibling::*[self::h2 or self::h3]"
-            "[contains(text(), 'Reason for approving') or contains(text(), 'Reasons for approving')]][2]",
+            value="//p[preceding-sibling::*[self::h2 or self::h3][contains(text(), 'Reason for approving') or contains(text(), 'Reasons for approving')]][2]",
         ).text
 
     def get_reasons_for_refusal(self):
         return self.driver.find_element(
             by=By.XPATH,
-            value="//p[preceding-sibling::*[self::h2 or self::h3]"
-            "[contains(text(), 'Reason for refusing') or contains(text(), 'Reasons for refusing')]][2]",
+            value="//p[preceding-sibling::*[self::h2 or self::h3][contains(text(), 'Reason for refusing') or contains(text(), 'Reasons for refusing')]][2]",
         ).text
 
     def get_licence_condition(self):
         return self.driver.find_element(
             by=By.XPATH,
-            value="//p[preceding-sibling::*[self::h2 or self::h3]" "[contains(text(), 'Licence condition')]][2]",
+            value="//p[preceding-sibling::*[self::h2 or self::h3][contains(text(), 'Licence condition')]][2]",
         ).text
 
     def get_instructions_for_exporter(self):
         return self.driver.find_element(
             by=By.XPATH,
-            value="//p[preceding-sibling::*[self::h2 or self::h3]" "[contains(text(), 'Additional instructions')]][2]",
+            value="//p[preceding-sibling::*[self::h2 or self::h3][contains(text(), 'Additional instructions')]][2]",
         ).text
 
     def get_reporting_footnote(self):
         return self.driver.find_element(
             by=By.XPATH,
-            value="//p[preceding-sibling::*[self::h2 or self::h3]" "[contains(text(), 'Reporting footnote')]][2]",
+            value="//p[preceding-sibling::*[self::h2 or self::h3][contains(text(), 'Reporting footnote')]][2]",
         ).text
 
     def get_refusal_criteria(self):

--- a/ui_tests/caseworker/pages/advice.py
+++ b/ui_tests/caseworker/pages/advice.py
@@ -138,36 +138,33 @@ class RecommendationsAndDecisionPage(BasePage):
     def get_reasons_for_approving(self):
         return self.driver.find_element(
             by=By.XPATH,
-            value="//p[ancestor::div[preceding-sibling::*[self::h2 or self::h3]"
-            "[contains(text(), 'Reason for approving') or contains(text(), 'Reasons for approving')]]][2]",
+            value="//p[preceding-sibling::*[self::h2 or self::h3]"
+            "[contains(text(), 'Reason for approving') or contains(text(), 'Reasons for approving')]][2]",
         ).text
 
     def get_reasons_for_refusal(self):
         return self.driver.find_element(
             by=By.XPATH,
-            value="//p[ancestor::div[preceding-sibling::*[self::h2 or self::h3]"
-            "[contains(text(), 'Reason for refusing') or contains(text(), 'Reasons for refusing')]]][2]",
+            value="//p[preceding-sibling::*[self::h2 or self::h3]"
+            "[contains(text(), 'Reason for refusing') or contains(text(), 'Reasons for refusing')]][2]",
         ).text
 
     def get_licence_condition(self):
         return self.driver.find_element(
             by=By.XPATH,
-            value="//p[ancestor::div[preceding-sibling::*[self::h2 or self::h3]"
-            "[contains(text(), 'Licence condition')]]][2]",
+            value="//p[preceding-sibling::*[self::h2 or self::h3]" "[contains(text(), 'Licence condition')]][2]",
         ).text
 
     def get_instructions_for_exporter(self):
         return self.driver.find_element(
             by=By.XPATH,
-            value="//p[ancestor::div[preceding-sibling::*[self::h2 or self::h3]"
-            "[contains(text(), 'Additional instructions')]]][2]",
+            value="//p[preceding-sibling::*[self::h2 or self::h3]" "[contains(text(), 'Additional instructions')]][2]",
         ).text
 
     def get_reporting_footnote(self):
         return self.driver.find_element(
             by=By.XPATH,
-            value="//p[ancestor::div[preceding-sibling::*[self::h2 or self::h3]"
-            "[contains(text(), 'Reporting footnote')]]][2]",
+            value="//p[preceding-sibling::*[self::h2 or self::h3]" "[contains(text(), 'Reporting footnote')]][2]",
         ).text
 
     def get_refusal_criteria(self):


### PR DESCRIPTION
Changed cookie banner to recommendation-and-decision, removed some inconsistent three quarters classes and fixed the border not appearing and being inline

* Good test case: GBSIEL/2022/0000203/P

[LTD-](https://uktrade.atlassian.net/browse/LTD-3353)