### PR TITLE
LU Countersignature Rework.

### DIFF
--- a/caseworker/advice/templates/advice/advice_details.html
+++ b/caseworker/advice/templates/advice/advice_details.html
@@ -85,18 +85,20 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
         {% if is_lu_countersigning %}
-            <div id="countersignatures">
-                {% for countersign_advice in ordered_countersign_advice %}
-                <div class="govuk-!-padding-4 govuk-!-margin-bottom-2" style="border: 1px solid black;">
-                    <div class="govuk-grid-row">
-                        <div class="govuk-grid-column-three-quarters">
-                            <h2 class="govuk-heading-m">Countersigned by {{ countersign_advice.countersigned_user|full_name }}</h2>
-                            <p class="govuk-body">{{ countersign_advice.reasons }}</p>
+            {% if not rejected_lu_countersignature %}
+                <div id="countersignatures">
+                    {% for countersign_advice in ordered_countersign_advice %}
+                        <div class="govuk-!-padding-4 govuk-!-margin-bottom-2" style="border: 1px solid black;">
+                            <div class="govuk-grid-row">
+                                <div class="govuk-grid-column-three-quarters">
+                                    <h2 class="govuk-heading-m">Countersigned by {{ countersign_advice.countersigned_user|full_name }}</h2>
+                                    <p class="govuk-body">{{ countersign_advice.reasons }}</p>
+                                </div>
+                            </div>
                         </div>
-                    </div>
+                    {% endfor %}
                 </div>
-            {% endfor %}
-            </div>
+            {% endif %}
         {% elif advice.0.countersigned_by %}
         <div class="govuk-!-padding-4 govuk-!-margin-bottom-2" style="border: 1px solid black;">
             <div class="govuk-grid-row">

--- a/caseworker/advice/templates/advice/view-advice.html
+++ b/caseworker/advice/templates/advice/view-advice.html
@@ -98,7 +98,7 @@
                     {% endif %}
 
                     <br><br>
-                    {% include "advice/advice_details.html" with advice=consolidated_advice team=True outcome_accepted_countersignatures_to_display="ACCEPTED" %}
+                    {% include "advice/advice_details.html" with advice=consolidated_advice team=True %}
                     <br>
                 </div>
 

--- a/caseworker/advice/templates/advice/view-advice.html
+++ b/caseworker/advice/templates/advice/view-advice.html
@@ -56,14 +56,24 @@
         <div class="govuk-width-container">
             <div class="govuk-grid-row govuk-!-margin-top-6">
                 <div class="govuk-grid-column-three-quarters">
-                    {% if is_lu_countersigning and rejected_lu_countersignatures %}
+                    {% if is_lu_countersigning and rejected_lu_countersignature %}
                         <div id="rejected-countersignature" class="govuk-warning-text">
                             <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
                             <strong class="govuk-warning-text__text">
                                 <span class="govuk-warning-text__assistive">Warning</span>
-                                This case has been returned for editing, by countersigner {{ rejected_lu_countersignatures.0.0.countersigned_user|full_name }}.
+                                This case has been returned for editing, by countersigner {{ rejected_lu_countersignature.countersigned_user|full_name }}.
                                 When you have finished making changes, move case forward.
                             </strong>
+                        </div>
+                        <div id="rejected-countersignature-detail">
+                            <div class="govuk-!-padding-4 govuk-!-margin-bottom-2" style="border: 1px solid black;">
+                                <div class="govuk-grid-row">
+                                    <div class="govuk-grid-column-three-quarters">
+                                        <h2 class="govuk-heading-m">Reason for returning</h2>
+                                        <p class="govuk-body">{{ rejected_lu_countersignature.reasons }}</p>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                     {% elif lu_countersign_required %}
                         <div id="countersign-required" class="govuk-warning-text">
@@ -88,7 +98,7 @@
                     {% endif %}
 
                     <br><br>
-                    {% include "advice/advice_details.html" with advice=consolidated_advice team=True %}
+                    {% include "advice/advice_details.html" with advice=consolidated_advice team=True outcome_accepted_countersignatures_to_display="ACCEPTED" %}
                     <br>
                 </div>
 

--- a/caseworker/advice/views.py
+++ b/caseworker/advice/views.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 from http import HTTPStatus
 
 import sentry_sdk

--- a/caseworker/advice/views.py
+++ b/caseworker/advice/views.py
@@ -112,17 +112,17 @@ class CaseContextMixin:
         for display in the templates
         """
         one_countersignature_per_order_value = {cs["order"]: cs for cs in self.case.get("countersign_advice", [])}
-        return sorted(one_countersignature_per_order_value.values(), key=lambda cs: cs["order"], reverse=True)
+        return sorted(one_countersignature_per_order_value.values(), key=lambda cs: cs["order"])
 
     def rejected_countersign_advice(self):
         """
-        Return all rejected countersignatures grouped per order value
+        Return rejected countersignature. Due to the routing, there should only ever be one
+        rejection (case will be returned to edit the advice once a rejection has occurred.
         """
-        rejected_countersignatures = defaultdict(list)
         for cs in self.case.get("countersign_advice", []):
             if not cs["outcome_accepted"]:
-                rejected_countersignatures[cs["order"]].append(cs)
-        return list(rejected_countersignatures.values())
+                return cs
+        return None
 
 
 class BEISNuclearMixin:
@@ -646,13 +646,13 @@ class ViewConsolidatedAdviceView(AdviceView, FormView):
         nlr_products = services.filter_nlr_products(self.case["data"]["goods"])
         lu_countersign_flags = {services.LU_COUNTERSIGN_REQUIRED_ID, services.LU_SR_MGR_CHECK_REQUIRED_ID}
         case_flag_ids = {flag["id"] for flag in self.case.all_flags}
-        rejected_lu_countersignatures = []
+        rejected_lu_countersignature = None
 
         if settings.FEATURE_LU_POST_CIRC_COUNTERSIGNING:
             lu_countersign_flags.update({services.MANPADS_ID, services.AP_LANDMINE_ID})
-            rejected_lu_countersignatures = self.rejected_countersign_advice()
+            rejected_lu_countersignature = self.rejected_countersign_advice()
 
-            if rejected_lu_countersignatures:
+            if rejected_lu_countersignature:
                 lu_countersign_required = False
             else:
                 lu_countersign_required = user_team_alias == services.LICENSING_UNIT_TEAM and bool(
@@ -662,7 +662,7 @@ class ViewConsolidatedAdviceView(AdviceView, FormView):
             finalise_case = (
                 user_team_alias == services.LICENSING_UNIT_TEAM
                 and not lu_countersign_required
-                and not rejected_lu_countersignatures
+                and not rejected_lu_countersignature
             )
         else:
             lu_countersign_required = user_team_alias == services.LICENSING_UNIT_TEAM and bool(
@@ -676,7 +676,7 @@ class ViewConsolidatedAdviceView(AdviceView, FormView):
             "nlr_products": nlr_products,
             "finalise_case": finalise_case,
             "lu_countersign_required": lu_countersign_required,
-            "rejected_lu_countersignatures": rejected_lu_countersignatures,
+            "rejected_lu_countersignature": rejected_lu_countersignature,
             "denial_reasons_display": self.denial_reasons_display,
         }
 

--- a/caseworker/advice/views.py
+++ b/caseworker/advice/views.py
@@ -111,7 +111,7 @@ class CaseContextMixin:
         for display in the templates
         """
         one_countersignature_per_order_value = {cs["order"]: cs for cs in self.case.get("countersign_advice", [])}
-        return sorted(one_countersignature_per_order_value.values(), key=lambda cs: cs["order"])
+        return sorted(one_countersignature_per_order_value.values(), key=lambda cs: cs["order"], reverse=True)
 
     def rejected_countersign_advice(self):
         """

--- a/unit_tests/caseworker/advice/views/test_consolidate.py
+++ b/unit_tests/caseworker/advice/views/test_consolidate.py
@@ -982,10 +982,10 @@ def test_finalise_button_shown_if_no_rejected_countersignatures(
     countersignature_div = soup.find(id="countersignatures")
     assert rejected_div is None
     assert countersignature_div is not None
-    assert "Countersigned by Testy McTest" in countersignature_div.find_all("h2")[0].text
-    assert "I concur" in countersignature_div.find_all("p")[0].text
-    assert "Countersigned by Super Visor" in countersignature_div.find_all("h2")[1].text
-    assert "LGTM" in countersignature_div.find_all("p")[1].text
+    assert "Countersigned by Super Visor" in countersignature_div.find_all("h2")[0].text
+    assert "LGTM" in countersignature_div.find_all("p")[0].text
+    assert "Countersigned by Testy McTest" in countersignature_div.find_all("h2")[1].text
+    assert "I concur" in countersignature_div.find_all("p")[1].text
     assert soup.find(id="finalise-case-button")
 
 

--- a/unit_tests/caseworker/advice/views/test_consolidate.py
+++ b/unit_tests/caseworker/advice/views/test_consolidate.py
@@ -15,7 +15,7 @@ from caseworker.advice.services import (
     LU_SR_MGR_CHECK_REQUIRED_ID,
 )
 from core import client
-from unit_tests.caseworker.conftest import countersignatures
+from unit_tests.caseworker.conftest import countersignatures_for_advice
 
 
 @pytest.fixture
@@ -820,7 +820,7 @@ def test_view_consolidate_approve_outcome_countersign_warning_message(
     response = authorized_client.get(view_consolidate_outcome_url)
     assert response.status_code == 200
 
-    assert not response.context["rejected_lu_countersignatures"]
+    assert not response.context["rejected_lu_countersignature"]
     if team_alias == services.LICENSING_UNIT_TEAM:
         assert response.context["lu_countersign_required"] is True
         assert response.context["finalise_case"] is False
@@ -838,7 +838,7 @@ def test_view_consolidate_approve_outcome_countersign_warning_message(
         ([AP_LANDMINE_ID, GREEN_COUNTRIES_ID]),
     ),
 )
-def test_case_returned_info_for_rejection_countersignature(
+def test_case_returned_info_for_first_countersignature_rejection(
     requests_mock,
     authorized_client,
     data_standard_case,
@@ -850,7 +850,9 @@ def test_case_returned_info_for_rejection_countersignature(
 ):
     data_standard_case["case"]["advice"] = consolidated_advice
     # Rejected countersignature
-    data_standard_case["case"]["countersign_advice"] = countersignatures(accepted=False)
+    data_standard_case["case"]["countersign_advice"] = countersignatures_for_advice(
+        consolidated_advice, accepted=[False]
+    )
     data_standard_case["case"]["all_flags"] = [FLAG_MAP[k] for k in flags]
 
     gov_user["user"]["team"]["name"] = "LU Team"
@@ -864,18 +866,85 @@ def test_case_returned_info_for_rejection_countersignature(
     response = authorized_client.get(view_consolidate_outcome_url)
     assert response.status_code == 200
 
-    assert len(response.context["rejected_lu_countersignatures"]) > 0
-    assert len(response.context["rejected_lu_countersignatures"][0]) > 0
-    assert not response.context["rejected_lu_countersignatures"][0][0]["outcome_accepted"]
-    assert response.context["rejected_lu_countersignatures"][0][0]["reasons"] == "I disagree"
+    assert response.context["rejected_lu_countersignature"]
+    assert not response.context["rejected_lu_countersignature"]["outcome_accepted"]
+    assert response.context["rejected_lu_countersignature"]["reasons"] == "I disagree"
 
     soup = BeautifulSoup(response.content, "html.parser")
     rejected_div = soup.find(id="rejected-countersignature")
+    rejected_detail_div = soup.find(id="rejected-countersignature-detail")
     countersignature_required_div = soup.find(id="countersign-required")
+    countersignature_div = soup.find(id="countersignatures")
     assert rejected_div is not None
+    assert rejected_detail_div is not None
     assert countersignature_required_div is None
+    assert countersignature_div is None
     warning = rejected_div.find(class_="govuk-warning-text__text").text
     assert "This case has been returned for editing, by countersigner Testy McTest" in warning
+    rejected_by = rejected_detail_div.find("h2").text
+    assert "Reason for returning" in rejected_by
+    rejected_detail = rejected_detail_div.find("p").text
+    assert "I disagree" in rejected_detail
+
+    assert not soup.find(id="finalise-case-button")
+
+
+@pytest.mark.parametrize(
+    "flags",
+    (
+        ([LU_COUNTERSIGN_REQUIRED_ID, GREEN_COUNTRIES_ID]),
+        ([LU_SR_MGR_CHECK_REQUIRED_ID, GREEN_COUNTRIES_ID]),
+        ([MANPADS_ID, GREEN_COUNTRIES_ID]),
+        ([AP_LANDMINE_ID, GREEN_COUNTRIES_ID]),
+    ),
+)
+def test_case_returned_info_for_second_countersignature_rejection(
+    requests_mock,
+    authorized_client,
+    data_standard_case,
+    view_consolidate_outcome_url,
+    consolidated_advice,
+    gov_user,
+    flags,
+    with_lu_countersigning_enabled,
+):
+    data_standard_case["case"]["advice"] = consolidated_advice
+    # Rejected countersignature
+    data_standard_case["case"]["countersign_advice"] = countersignatures_for_advice(
+        consolidated_advice, accepted=[True, False]
+    )
+    data_standard_case["case"]["all_flags"] = [FLAG_MAP[k] for k in flags]
+
+    gov_user["user"]["team"]["name"] = "LU Team"
+    gov_user["user"]["team"]["alias"] = services.LICENSING_UNIT_TEAM
+
+    requests_mock.get(
+        client._build_absolute_uri("/gov-users/2a43805b-c082-47e7-9188-c8b3e1a83cb0"),
+        json=gov_user,
+    )
+
+    response = authorized_client.get(view_consolidate_outcome_url)
+    assert response.status_code == 200
+
+    assert response.context["rejected_lu_countersignature"]
+    assert not response.context["rejected_lu_countersignature"]["outcome_accepted"]
+    assert response.context["rejected_lu_countersignature"]["reasons"] == "Nope"
+
+    soup = BeautifulSoup(response.content, "html.parser")
+    rejected_div = soup.find(id="rejected-countersignature")
+    rejected_detail_div = soup.find(id="rejected-countersignature-detail")
+    countersignature_required_div = soup.find(id="countersign-required")
+    countersignature_div = soup.find(id="countersignatures")
+    assert rejected_div is not None
+    assert rejected_detail_div is not None
+    assert countersignature_required_div is None
+    assert countersignature_div is None
+    warning = rejected_div.find(class_="govuk-warning-text__text").text
+    assert "This case has been returned for editing, by countersigner Super Visor" in warning
+    rejected_by = rejected_detail_div.find("h2").text
+    assert "Reason for returning" in rejected_by
+    rejected_detail = rejected_detail_div.find("p").text
+    assert "Nope" in rejected_detail
 
     assert not soup.find(id="finalise-case-button")
 
@@ -891,7 +960,9 @@ def test_finalise_button_shown_if_no_rejected_countersignatures(
 ):
     data_standard_case["case"]["advice"] = consolidated_advice
     # Rejected countersignature
-    data_standard_case["case"]["countersign_advice"] = countersignatures(accepted=True)
+    data_standard_case["case"]["countersign_advice"] = countersignatures_for_advice(
+        consolidated_advice, accepted=[True, True]
+    )
     data_standard_case["case"]["all_flags"] = [FLAG_MAP[GREEN_COUNTRIES_ID]]
 
     gov_user["user"]["team"]["name"] = "LU Team"
@@ -904,14 +975,27 @@ def test_finalise_button_shown_if_no_rejected_countersignatures(
 
     response = authorized_client.get(view_consolidate_outcome_url)
     assert response.status_code == 200
-    assert len(response.context["rejected_lu_countersignatures"]) == 0
+    assert not response.context["rejected_lu_countersignature"]
 
     soup = BeautifulSoup(response.content, "html.parser")
     rejected_div = soup.find(id="rejected-countersignature")
+    countersignature_div = soup.find(id="countersignatures")
     assert rejected_div is None
+    assert countersignature_div is not None
+    assert "Countersigned by Testy McTest" in countersignature_div.find_all("h2")[0].text
+    assert "I concur" in countersignature_div.find_all("p")[0].text
+    assert "Countersigned by Super Visor" in countersignature_div.find_all("h2")[1].text
+    assert "LGTM" in countersignature_div.find_all("p")[1].text
     assert soup.find(id="finalise-case-button")
 
 
+@pytest.mark.parametrize(
+    "accepted_countersignatures",
+    (
+        [False],
+        [True, False],
+    ),
+)
 def test_rejection_countersignature_not_displayed_if_feature_flag_off(
     requests_mock,
     authorized_client,
@@ -920,10 +1004,13 @@ def test_rejection_countersignature_not_displayed_if_feature_flag_off(
     consolidated_advice,
     gov_user,
     with_lu_countersigning_disabled,
+    accepted_countersignatures,
 ):
     data_standard_case["case"]["advice"] = consolidated_advice
     # Rejected countersignature
-    data_standard_case["case"]["countersign_advice"] = countersignatures(accepted=False)
+    data_standard_case["case"]["countersign_advice"] = countersignatures_for_advice(
+        consolidated_advice, accepted=accepted_countersignatures
+    )
     data_standard_case["case"]["all_flags"] = [FLAG_MAP[k] for k in [LU_COUNTERSIGN_REQUIRED_ID, GREEN_COUNTRIES_ID]]
 
     gov_user["user"]["team"]["name"] = "LU Team"
@@ -936,7 +1023,7 @@ def test_rejection_countersignature_not_displayed_if_feature_flag_off(
 
     response = authorized_client.get(view_consolidate_outcome_url)
     assert response.status_code == 200
-    assert len(response.context["rejected_lu_countersignatures"]) == 0
+    assert not response.context["rejected_lu_countersignature"]
 
     soup = BeautifulSoup(response.content, "html.parser")
     rejected_div = soup.find(id="rejected-countersignature")

--- a/unit_tests/caseworker/advice/views/test_countersign.py
+++ b/unit_tests/caseworker/advice/views/test_countersign.py
@@ -8,7 +8,7 @@ from django.urls import reverse
 from caseworker.advice.services import LICENSING_UNIT_TEAM
 from core import client
 from caseworker.advice import services
-from unit_tests.caseworker.conftest import countersignatures
+from unit_tests.caseworker.conftest import countersignatures_for_advice
 
 
 @pytest.fixture(autouse=True)
@@ -295,7 +295,7 @@ def test_lu_countersign_get_shows_previous_countersignature(
     # Set up advice on the case
     team_id = final_advice["user"]["team"]["id"]
     data_standard_case["case"]["advice"] = [final_advice]
-    data_standard_case["case"]["countersign_advice"] = countersignatures()
+    data_standard_case["case"]["countersign_advice"] = countersignatures_for_advice([final_advice])
     # Setup mock API requests
     mock_get_gov_user.return_value = (
         {"user": {"team": {"id": team_id, "alias": LICENSING_UNIT_TEAM}}},

--- a/unit_tests/caseworker/advice/views/test_countersign_view.py
+++ b/unit_tests/caseworker/advice/views/test_countersign_view.py
@@ -11,7 +11,7 @@ from django.urls import reverse
 from caseworker.advice.services import LICENSING_UNIT_TEAM
 from core import client
 from caseworker.advice import services
-from unit_tests.caseworker.conftest import countersignatures
+from unit_tests.caseworker.conftest import countersignatures_for_advice
 
 
 @pytest.fixture(autouse=True)
@@ -51,7 +51,7 @@ def test_single_lu_countersignature(
     case_id = data_standard_case["case"]["id"]
     team_id = final_advice["user"]["team"]["id"]
     data_standard_case["case"]["advice"] = [final_advice]
-    data_standard_case["case"]["countersign_advice"] = countersignatures(4)
+    data_standard_case["case"]["countersign_advice"] = countersignatures_for_advice([final_advice])
     requests_mock.get(client._build_absolute_uri(f"/cases/{case_id}"), json=data_standard_case)
     mock_get_gov_user.return_value = (
         {"user": {"team": {"id": team_id, "alias": LICENSING_UNIT_TEAM}}},
@@ -82,7 +82,9 @@ def test_double_lu_countersignature(
     case_id = data_standard_case["case"]["id"]
     team_id = final_advice["user"]["team"]["id"]
     data_standard_case["case"]["advice"] = [final_advice]
-    data_standard_case["case"]["countersign_advice"] = countersignatures() + countersignatures(second_countersign=True)
+    data_standard_case["case"]["countersign_advice"] = countersignatures_for_advice(
+        [final_advice], accepted=[True, True]
+    )
     requests_mock.get(client._build_absolute_uri(f"/cases/{case_id}"), json=data_standard_case)
     mock_get_gov_user.return_value = (
         {"user": {"team": {"id": team_id, "alias": LICENSING_UNIT_TEAM}}},
@@ -96,7 +98,7 @@ def test_double_lu_countersignature(
 
     counter_sigs = countersignature_block.find_all("div", recursive=False)
     assert len(counter_sigs) == 2
-    assert counter_sigs[0].find(class_="govuk-heading-m").text == "Countersigned by Super Visor"
-    assert counter_sigs[0].find(class_="govuk-body").text == "LGTM"
-    assert counter_sigs[1].find(class_="govuk-heading-m").text == "Countersigned by Testy McTest"
-    assert counter_sigs[1].find(class_="govuk-body").text == "I concur"
+    assert counter_sigs[0].find(class_="govuk-heading-m").text == "Countersigned by Testy McTest"
+    assert counter_sigs[0].find(class_="govuk-body").text == "I concur"
+    assert counter_sigs[1].find(class_="govuk-heading-m").text == "Countersigned by Super Visor"
+    assert counter_sigs[1].find(class_="govuk-body").text == "LGTM"

--- a/unit_tests/caseworker/advice/views/test_countersign_view.py
+++ b/unit_tests/caseworker/advice/views/test_countersign_view.py
@@ -98,7 +98,7 @@ def test_double_lu_countersignature(
 
     counter_sigs = countersignature_block.find_all("div", recursive=False)
     assert len(counter_sigs) == 2
-    assert counter_sigs[0].find(class_="govuk-heading-m").text == "Countersigned by Testy McTest"
-    assert counter_sigs[0].find(class_="govuk-body").text == "I concur"
-    assert counter_sigs[1].find(class_="govuk-heading-m").text == "Countersigned by Super Visor"
-    assert counter_sigs[1].find(class_="govuk-body").text == "LGTM"
+    assert counter_sigs[0].find(class_="govuk-heading-m").text == "Countersigned by Super Visor"
+    assert counter_sigs[0].find(class_="govuk-body").text == "LGTM"
+    assert counter_sigs[1].find(class_="govuk-heading-m").text == "Countersigned by Testy McTest"
+    assert counter_sigs[1].find(class_="govuk-body").text == "I concur"

--- a/unit_tests/caseworker/advice/views/test_view_my_advice_view.py
+++ b/unit_tests/caseworker/advice/views/test_view_my_advice_view.py
@@ -4,12 +4,11 @@ import pytest
 
 from bs4 import BeautifulSoup
 from django.urls import reverse
-import rules
 
 from caseworker.advice.services import FCDO_TEAM, LICENSING_UNIT_TEAM
 from core import client
 from core.builtins.custom_tags import filter_advice_by_user
-from unit_tests.caseworker.conftest import countersignatures
+from unit_tests.caseworker.conftest import countersignatures_for_advice
 
 
 @pytest.fixture(autouse=True)
@@ -280,7 +279,9 @@ def test_lu_countersignatures_not_shown(
     case_id = data_standard_case["case"]["id"]
     team_id = final_advice["user"]["team"]["id"]
     data_standard_case["case"]["advice"] = [final_advice]
-    data_standard_case["case"]["countersign_advice"] = countersignatures() + countersignatures(second_countersign=True)
+    data_standard_case["case"]["countersign_advice"] = countersignatures_for_advice(
+        [final_advice], accepted=[True, True]
+    )
     requests_mock.get(client._build_absolute_uri(f"/cases/{case_id}"), json=data_standard_case)
     mock_get_gov_user.return_value = (
         {"user": {"team": {"id": team_id, "alias": LICENSING_UNIT_TEAM}}},

--- a/unit_tests/caseworker/conftest.py
+++ b/unit_tests/caseworker/conftest.py
@@ -821,58 +821,53 @@ def final_advice(current_user, lu_team):
     }
 
 
-def countersignatures(
-    good_with_advice_count=2, second_countersign=False, end_user=True, ultimate_end_user=True, accepted=True
-):
-    first_countersignature = {
-        "reasons": "I concur" if accepted else "I disagree",
-        "countersigned_user": {
-            "id": "654165",
-            "first_name": "Testy",
-            "last_name": "McTest",
-            "team": {
-                "id": "809eba0f-f197-4f0f-949b-9af309a844fb",
-                "name": "LU Team",
-                "alias": LICENSING_UNIT_TEAM,
-                "part_of_ecju": False,
-                "is_ogd": True,
+def countersignatures_for_advice(all_advice, accepted=[True]):
+    def first_countersignature(advice):
+        return {
+            "reasons": "I concur" if accepted[0] else "I disagree",
+            "countersigned_user": {
+                "id": "654165",
+                "first_name": "Testy",
+                "last_name": "McTest",
+                "team": {
+                    "id": "809eba0f-f197-4f0f-949b-9af309a844fb",
+                    "name": "LU Team",
+                    "alias": LICENSING_UNIT_TEAM,
+                    "part_of_ecju": False,
+                    "is_ogd": True,
+                },
             },
-        },
-        "outcome_accepted": accepted,
-        "order": 1,
-    }
-    second_countersignature = {
-        "reasons": "LGTM" if accepted else "Nope",
-        "countersigned_user": {
-            "id": "546544",
-            "first_name": "Super",
-            "last_name": "Visor",
-            "team": {
-                "id": "809eba0f-f197-4f0f-949b-9af309a844fb",
-                "name": "LU Team",
-                "alias": LICENSING_UNIT_TEAM,
-                "part_of_ecju": False,
-                "is_ogd": True,
+            "outcome_accepted": accepted[0],
+            "order": 1,
+            "advice": advice,
+        }
+
+    def second_countersignature(advice):
+        return {
+            "reasons": "LGTM" if accepted[1] else "Nope",
+            "countersigned_user": {
+                "id": "546544",
+                "first_name": "Super",
+                "last_name": "Visor",
+                "team": {
+                    "id": "809eba0f-f197-4f0f-949b-9af309a844fb",
+                    "name": "LU Team",
+                    "alias": LICENSING_UNIT_TEAM,
+                    "part_of_ecju": False,
+                    "is_ogd": True,
+                },
             },
-        },
-        "outcome_accepted": accepted,
-        "order": 2,
-    }
-    countersignature = second_countersignature if second_countersign else first_countersignature
+            "outcome_accepted": accepted[1],
+            "order": 2,
+            "advice": advice,
+        }
+
     out = []
 
-    if end_user:
-        out.append(
-            {**countersignature, **{"advice": {"good": None, "end_user": str(uuid.uuid4()), "ultimate_end_user": None}}}
-        )
-    if ultimate_end_user:
-        out.append(
-            {**countersignature, **{"advice": {"good": None, "end_user": None, "ultimate_end_user": str(uuid.uuid4())}}}
-        )
-    for i in range(good_with_advice_count):
-        out.append(
-            {**countersignature, **{"advice": {"good": str(uuid.uuid4()), "end_user": None, "ultimate_end_user": None}}}
-        )
+    for adv in all_advice:
+        for i, acceptance in enumerate(accepted):
+            countersignature = [first_countersignature, second_countersignature][i](adv)
+            out.append(countersignature)
 
     return out
 


### PR DESCRIPTION
New message box for rejected countersignature detail. 
Refactoring to support this. 
Also removal of rejected countersignatures from the display of countersignatures in the advice view further down.
In addition, as per comments, we only show the accepted countersignatures if there were no rejections (i.e. the case where the caseworker accepts the advice but the supervisor rejects it will prevent the accepted countersignatures from being displayed to avoid confusion)

Detail in this ticket:

[LTD-3482](https://uktrade.atlassian.net/browse/LTD-3482)


[LTD-3482]: https://uktrade.atlassian.net/browse/LTD-3482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ