### PR TITLE
LTD-3503: Use put method to update consolidated advice by LU

### DIFF
--- a/caseworker/advice/services.py
+++ b/caseworker/advice/services.py
@@ -349,6 +349,48 @@ def post_refusal_advice(request, case, data, level="user-advice"):
     return response.json(), response.status_code
 
 
+def update_approval_advice(request, case, caseworker, data, level):
+    user_team_alias = caseworker["team"]["alias"]
+    if user_team_alias != LICENSING_UNIT_TEAM:
+        raise NotImplementedError(f"Implement approval advice update for {user_team_alias}")
+
+    team_advice = filter_advice_by_level(case.advice, ["final"])
+    consolidated_advice = filter_advice_by_team(team_advice, user_team_alias)
+
+    json = [
+        {
+            "id": advice["id"],
+            "text": data["approval_reasons"],
+            "proviso": data["proviso"],
+        }
+        for advice in consolidated_advice
+    ]
+    response = client.put(request, f"/cases/{case['id']}/{level}/", json)
+    response.raise_for_status()
+    return response.json(), response.status_code
+
+
+def update_refusal_advice(request, case, caseworker, data, level):
+    user_team_alias = caseworker["team"]["alias"]
+    if user_team_alias != LICENSING_UNIT_TEAM:
+        raise NotImplementedError(f"Implement refusal advice update for {user_team_alias}")
+
+    team_advice = filter_advice_by_level(case.advice, ["final"])
+    consolidated_advice = filter_advice_by_team(team_advice, user_team_alias)
+
+    json = [
+        {
+            "id": advice["id"],
+            "text": data["refusal_reasons"],
+            "denial_reasons": data["denial_reasons"],
+        }
+        for advice in consolidated_advice
+    ]
+    response = client.put(request, f"/cases/{case['id']}/{level}/", json)
+    response.raise_for_status()
+    return response.json(), response.status_code
+
+
 def delete_user_advice(request, case_pk):
     response = client.delete(request, f"/cases/{case_pk}/user-advice/")
     response.raise_for_status()

--- a/caseworker/advice/views.py
+++ b/caseworker/advice/views.py
@@ -642,9 +642,13 @@ class ConsolidateEditView(ReviewConsolidateView):
         level = "final-advice"
         try:
             if isinstance(form, forms.ConsolidateApprovalForm):
-                services.update_approval_advice(self.request, self.case, self.caseworker, form.cleaned_data, level)
+                services.update_advice(
+                    self.request, self.case, self.caseworker, self.advice_type, form.cleaned_data, level
+                )
             if isinstance(form, forms.RefusalAdviceForm):
-                services.update_refusal_advice(self.request, self.case, self.caseworker, form.cleaned_data, level)
+                services.update_advice(
+                    self.request, self.case, self.caseworker, self.advice_type, form.cleaned_data, level
+                )
         except HTTPError as e:
             errors = e.response.json()["errors"]
             form.add_error(None, errors)

--- a/caseworker/advice/views.py
+++ b/caseworker/advice/views.py
@@ -631,6 +631,26 @@ class ConsolidateEditView(ReviewConsolidateView):
         kwargs["data"] = self.request.POST or self.get_data()
         return kwargs
 
+    def form_valid(self, form):
+        user_team_alias = self.caseworker["team"]["alias"]
+
+        # A new method added to API to support update of 'final' level advice
+        # hence only LU can use these methods at the moment
+        if user_team_alias != services.LICENSING_UNIT_TEAM:
+            return super().form_valid(form)
+
+        level = "final-advice"
+        try:
+            if isinstance(form, forms.ConsolidateApprovalForm):
+                services.update_approval_advice(self.request, self.case, self.caseworker, form.cleaned_data, level)
+            if isinstance(form, forms.RefusalAdviceForm):
+                services.update_refusal_advice(self.request, self.case, self.caseworker, form.cleaned_data, level)
+        except HTTPError as e:
+            errors = e.response.json()["errors"]
+            form.add_error(None, errors)
+            return super().form_invalid(form)
+        return HttpResponseRedirect(self.get_success_url())
+
     def get_success_url(self):
         return reverse("cases:consolidate_view", kwargs={"queue_pk": self.kwargs["queue_pk"], "pk": self.kwargs["pk"]})
 

--- a/unit_tests/caseworker/advice/test_services.py
+++ b/unit_tests/caseworker/advice/test_services.py
@@ -26,8 +26,7 @@ from caseworker.advice.services import (
     get_decision_advices_by_countersigner,
     get_countersign_decision_advice_by_user,
     update_countersign_decision_advice,
-    update_approval_advice,
-    update_refusal_advice,
+    update_advice,
 )
 from caseworker.cases.objects import Case
 from uuid import uuid4
@@ -312,7 +311,26 @@ def test_update_advice_by_team_other_than_LU_raises_error(
     )
 
     with pytest.raises(NotImplementedError):
-        update_approval_advice(requests_mock, case, current_user, {}, "final-advice")
+        update_advice(requests_mock, case, current_user, "approve", {}, "final-advice")
 
     with pytest.raises(NotImplementedError):
-        update_refusal_advice(requests_mock, case, current_user, {}, "final-advice")
+        update_advice(requests_mock, case, current_user, "refuse", {}, "final-advice")
+
+
+@patch("caseworker.advice.views.get_gov_user")
+def test_update_advice_not_supported_advice_type_raises_error(
+    mock_get_gov_user,
+    advice,
+    data_standard_case,
+    current_user,
+    requests_mock,
+):
+    case = Case(data_standard_case["case"])
+    case.advice = advice
+    mock_get_gov_user.return_value = (
+        {"user": {"team": {"id": "34344324-34234-432", "alias": LICENSING_UNIT_TEAM}}},
+        None,
+    )
+
+    with pytest.raises(NotImplementedError):
+        update_advice(requests_mock, case, current_user, "no_licence_required", {}, "final-advice")

--- a/unit_tests/caseworker/advice/views/test_consolidate_edit.py
+++ b/unit_tests/caseworker/advice/views/test_consolidate_edit.py
@@ -315,3 +315,32 @@ def test_edit_consolidated_advice_refuse_by_lu_put(
         }
         for advice in consolidated_advice
     ]
+
+
+@patch("caseworker.advice.views.get_gov_user")
+def test_edit_consolidated_advice_by_LU_error_from_API(
+    mock_get_gov_user,
+    authorized_client,
+    requests_mock,
+    data_standard_case,
+    url,
+    consolidated_advice,
+):
+
+    case_data = data_standard_case
+    case_data["case"]["advice"] = consolidated_advice
+
+    mock_get_gov_user.return_value = (
+        {"user": {"team": {"id": "34344324-34234-432", "alias": services.LICENSING_UNIT_TEAM}}},
+        None,
+    )
+    requests_mock.put(
+        client._build_absolute_uri(f"/cases/{case_data['case']['id']}/final-advice"),
+        json={"errors": ["Failed to put"]},
+        status_code=400,
+    )
+
+    data = {"approval_reasons": "meets the requirements updated", "proviso": "updated conditions"}
+    response = authorized_client.post(url, data=data)
+    assert response.status_code == 200
+    assert "Failed to put" in response.content.decode("utf-8")

--- a/unit_tests/caseworker/advice/views/test_consolidate_edit.py
+++ b/unit_tests/caseworker/advice/views/test_consolidate_edit.py
@@ -1,5 +1,6 @@
 import pytest
 from unittest.mock import patch
+from uuid import uuid4
 
 from django.urls import reverse
 
@@ -24,14 +25,27 @@ def setup(mock_queue, mock_case, mock_denial_reasons, mock_post_team_advice, moc
     yield
 
 
+def get_advice_subjects(case):
+    case_data = case["case"]["data"]
+    parties = [
+        ("consignee", case_data["consignee"]["id"]),
+        ("end_user", case_data["end_user"]["id"]),
+        ("ultimate_end_user", case_data["ultimate_end_users"][0]["id"]),
+    ]
+    goods = [("good", good["id"]) for good in case["case"]["data"]["goods"]]
+
+    return parties + goods
+
+
 @pytest.fixture
-def consolidated_advice(current_user):
+def consolidated_advice(data_standard_case, current_user):
     current_user["team"]["id"] = "2132131d-2432-423424"
     current_user["team"]["alias"] = services.LICENSING_UNIT_TEAM
+    subjects = get_advice_subjects(data_standard_case)
 
     return [
         {
-            "id": "a9206652-93be-4480-97cf-d7d52ba6e2b5",
+            "id": str(uuid4()),
             "user": current_user,
             "type": {"key": "approve", "value": "Approve"},
             "text": "meets the requirements",
@@ -39,106 +53,12 @@ def consolidated_advice(current_user):
             "level": "final",
             "footnote": None,
             "footnote_required": None,
-            "good": None,
-            "end_user_id": "953f330f-4956-4e9f-9b87-7c07b5dc3abc",
-            "ultimate_end_user_id": None,
-            "consignee_id": None,
-            "third_party_id": None,
+            subject_type: subject_id,
             "proviso": "some conditions",
-            "pv_grading": None,
-            "collated_pv_grading": None,
             "countersign_comments": "",
             "countersigned_by_id": None,
-        },
-        {
-            "id": "78833712-fc78-4a52-8616-37a72bfb1e2a",
-            "user": current_user,
-            "type": {"key": "approve", "value": "Approve"},
-            "text": "meets the requirements",
-            "note": "",
-            "level": "final",
-            "footnote": None,
-            "footnote_required": None,
-            "good_id": None,
-            "goods_type_id": None,
-            "country_id": None,
-            "end_user_id": None,
-            "ultimate_end_user_id": None,
-            "consignee_id": "500abd5e-9c9c-4649-bcb4-e5156b39a715",
-            "third_party_id": None,
-            "proviso": "some conditions",
-            "pv_grading": None,
-            "collated_pv_grading": None,
-            "countersign_comments": "",
-            "countersigned_by_id": None,
-        },
-        {
-            "id": "e6c1dbc5-4a39-48ad-84fd-c5d566c3b258",
-            "user": current_user,
-            "type": {"key": "approve", "value": "Approve"},
-            "text": "meets the requirements",
-            "note": "",
-            "level": "final",
-            "footnote": None,
-            "footnote_required": None,
-            "good_id": None,
-            "goods_type_id": None,
-            "country_id": None,
-            "end_user_id": None,
-            "ultimate_end_user_id": "e2ad9d86-c0b3-4560-a8e5-0d7e4cabac4f",
-            "consignee_id": None,
-            "third_party_id": None,
-            "proviso": "some conditions",
-            "pv_grading": None,
-            "collated_pv_grading": None,
-            "countersign_comments": "",
-            "countersigned_by_id": None,
-        },
-        {
-            "id": "da4149af-bee6-4d80-b647-f0b4027c9a0b",
-            "case_id": "79b2a7f2-3cc1-40ef-a0c7-2517e1aff9a8",
-            "user": current_user,
-            "type": {"key": "approve", "value": "Approve"},
-            "text": "meets the requirements",
-            "note": "",
-            "level": "final",
-            "footnote": None,
-            "footnote_required": None,
-            "good_id": None,
-            "goods_type_id": None,
-            "country_id": None,
-            "end_user_id": None,
-            "ultimate_end_user_id": None,
-            "consignee_id": None,
-            "third_party_id": "cdb3e406-2760-47a4-ac08-06da333c20c9",
-            "proviso": "some conditions",
-            "pv_grading": None,
-            "collated_pv_grading": None,
-            "countersign_comments": "",
-            "countersigned_by_id": None,
-        },
-        {
-            "id": "1f8611f2-1e5a-4dbc-bbbe-776db26f8d24",
-            "user": current_user,
-            "type": {"key": "approve", "value": "Approve"},
-            "text": "meets the requirements",
-            "note": "",
-            "level": "final",
-            "footnote": None,
-            "footnote_required": None,
-            "good_id": "55b1e712-7031-47cb-a613-53ebbdc887ed",
-            "goods_type_id": None,
-            "country_id": None,
-            "end_user_id": None,
-            "ultimate_end_user_id": None,
-            "consignee_id": None,
-            "third_party_id": None,
-            "proviso": "some conditions",
-            "pv_grading": None,
-            "collated_pv_grading": None,
-            "countersign_comments": "",
-            "countersigned_by_id": None,
-        },
+        }
+        for subject_type, subject_id in subjects
     ]
 
 
@@ -353,30 +273,11 @@ def test_edit_consolidated_advice_approve_by_lu_put(
     assert history.method == "PUT"
     assert history.json() == [
         {
-            "id": "a9206652-93be-4480-97cf-d7d52ba6e2b5",
+            "id": advice["id"],
             "text": data["approval_reasons"],
             "proviso": data["proviso"],
-        },
-        {
-            "id": "78833712-fc78-4a52-8616-37a72bfb1e2a",
-            "text": data["approval_reasons"],
-            "proviso": data["proviso"],
-        },
-        {
-            "id": "e6c1dbc5-4a39-48ad-84fd-c5d566c3b258",
-            "text": data["approval_reasons"],
-            "proviso": data["proviso"],
-        },
-        {
-            "id": "da4149af-bee6-4d80-b647-f0b4027c9a0b",
-            "text": data["approval_reasons"],
-            "proviso": data["proviso"],
-        },
-        {
-            "id": "1f8611f2-1e5a-4dbc-bbbe-776db26f8d24",
-            "text": data["approval_reasons"],
-            "proviso": data["proviso"],
-        },
+        }
+        for advice in consolidated_advice
     ]
 
 
@@ -408,28 +309,9 @@ def test_edit_consolidated_advice_refuse_by_lu_put(
     assert history.method == "PUT"
     assert history.json() == [
         {
-            "id": "a9206652-93be-4480-97cf-d7d52ba6e2b5",
+            "id": advice["id"],
             "text": data["refusal_reasons"],
             "denial_reasons": data["denial_reasons"],
-        },
-        {
-            "id": "78833712-fc78-4a52-8616-37a72bfb1e2a",
-            "text": data["refusal_reasons"],
-            "denial_reasons": data["denial_reasons"],
-        },
-        {
-            "id": "e6c1dbc5-4a39-48ad-84fd-c5d566c3b258",
-            "text": data["refusal_reasons"],
-            "denial_reasons": data["denial_reasons"],
-        },
-        {
-            "id": "da4149af-bee6-4d80-b647-f0b4027c9a0b",
-            "text": data["refusal_reasons"],
-            "denial_reasons": data["denial_reasons"],
-        },
-        {
-            "id": "1f8611f2-1e5a-4dbc-bbbe-776db26f8d24",
-            "text": data["refusal_reasons"],
-            "denial_reasons": data["denial_reasons"],
-        },
+        }
+        for advice in consolidated_advice
     ]


### PR DESCRIPTION
### Aim

We added new put method in API to support updating of final level Advice. This is the consolidated advice by LU.
Previously updates were supported by that involved deleting existing objects and creating new ones in place of them instead of actually updating original objects. Previous method has unintended effects in terms of cascade deletes.

In this PR, FE is updated the use the new method for updating consolidated advice.
This is required for LU countersigning work hence restricted to LU team only to limit regressions (if any). It can easily be expanded to other advice levels/teams.

[LTD-3503](https://uktrade.atlassian.net/browse/LTD-3503)


[LTD-3503]: https://uktrade.atlassian.net/browse/LTD-3503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ