### PR TITLE
New designs implemented

### DIFF
--- a/caseworker/advice/forms.py
+++ b/caseworker/advice/forms.py
@@ -294,10 +294,10 @@ class FCDORefusalAdviceForm(RefusalAdviceForm):
 
 
 class MoveCaseForwardForm(forms.Form):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, move_case_button_label="Move case forward", *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.helper = FormHelper()
-        self.helper.layout = Layout(Submit("submit", "Move case forward", css_id="move-case-forward-button"))
+        self.helper.layout = Layout(Submit("submit", move_case_button_label, css_id="move-case-forward-button"))
 
 
 class BEISTriggerListFormBase(forms.Form):

--- a/caseworker/advice/templates/advice/advice_details.html
+++ b/caseworker/advice/templates/advice/advice_details.html
@@ -85,35 +85,23 @@
 <div class="govuk-grid-row govuk-details">
     <div class="govuk-grid-column-three-quarters">
         {% if is_lu_countersigning and case|countersignatures_for_advice:advice %}
-            {% if not rejected_lu_countersignature %}
-                <div id="countersignatures">
+            {% if show_rejected_countersignatures or not rejected_lu_countersignature %}
+                <div class="countersignatures">
                     {% for countersign_advice in case|countersignatures_for_advice:advice  %}
                         {%  if countersign_advice.0.outcome_accepted %}
                         <div class="govuk-!-padding-4 govuk-!-margin-bottom-2 countersigned-by">
                             <div class="govuk-grid-row">
                                 <div class="govuk-grid-column-three-quarters">
-                                    <h2 class="govuk-heading-m">
-                                        {% if countersign_advice.0.order == 1 %}
-                                            Countersigned
-                                        {% elif countersign_advice.0.order == 1 %}
-                                            Senior countersigned
-                                        {% endif %}
-                                        by {{ countersign_advice.0.countersigned_user|full_name }}</h2>
+                                    <h2 class="govuk-heading-m">{% if countersign_advice.0.order == 1 %}Countersigned{% elif countersign_advice.0.order == 2 %}Senior countersigned{% endif %} by {{ countersign_advice.0.countersigned_user|full_name }}</h2>
                                     <p class="govuk-body">{{ countersign_advice.0.reasons }}</p>
                                 </div>
                             </div>
                         </div>
                         {% elif show_rejected_countersignatures %}
-                            <div class="govuk-!-padding-4 govuk-!-margin-bottom-2" style="border: 1px solid black;">
+                            <div class="govuk-!-padding-4 govuk-!-margin-bottom-2 rejected-countersignature" style="border: 1px solid black;">
                                 <div class="govuk-grid-row">
                                     <div class="govuk-grid-column-three-quarters">
-                                        <h2 class="govuk-heading-m">
-                                            {% if countersign_advice.0.order == 1 %}
-                                                Countersigner
-                                            {% elif countersign_advice.0.order == 1 %}
-                                                Senior countersigner
-                                            {% endif %}
-                                            {{ countersign_advice.0.countersigned_user|full_name }} disagrees with this recommendation</h2>
+                                        <h2 class="govuk-heading-m">{% if countersign_advice.0.order == 1 %}Countersigner{% elif countersign_advice.0.order == 2 %}Senior countersigner{% endif %} {{ countersign_advice.0.countersigned_user|full_name }} disagrees with this recommendation</h2>
                                         <p class="govuk-body">{{ countersign_advice.0.reasons }}</p>
                                     </div>
                                 </div>

--- a/caseworker/advice/templates/advice/advice_details.html
+++ b/caseworker/advice/templates/advice/advice_details.html
@@ -92,11 +92,32 @@
                         <div class="govuk-!-padding-4 govuk-!-margin-bottom-2 countersigned-by">
                             <div class="govuk-grid-row">
                                 <div class="govuk-grid-column-three-quarters">
-                                    <h2 class="govuk-heading-m">Countersigned by {{ countersign_advice.0.countersigned_user|full_name }}</h2>
+                                    <h2 class="govuk-heading-m">
+                                        {% if countersign_advice.0.order == 1 %}
+                                            Countersigned
+                                        {% elif countersign_advice.0.order == 1 %}
+                                            Senior countersigned
+                                        {% endif %}
+                                        by {{ countersign_advice.0.countersigned_user|full_name }}</h2>
                                     <p class="govuk-body">{{ countersign_advice.0.reasons }}</p>
                                 </div>
                             </div>
                         </div>
+                        {% elif show_rejected_countersignatures %}
+                            <div class="govuk-!-padding-4 govuk-!-margin-bottom-2" style="border: 1px solid black;">
+                                <div class="govuk-grid-row">
+                                    <div class="govuk-grid-column-three-quarters">
+                                        <h2 class="govuk-heading-m">
+                                            {% if countersign_advice.0.order == 1 %}
+                                                Countersigner
+                                            {% elif countersign_advice.0.order == 1 %}
+                                                Senior countersigner
+                                            {% endif %}
+                                            {{ countersign_advice.0.countersigned_user|full_name }} disagrees with this recommendation</h2>
+                                        <p class="govuk-body">{{ countersign_advice.0.reasons }}</p>
+                                    </div>
+                                </div>
+                            </div>
                         {% endif %}
                     {% endfor %}
                 </div>

--- a/caseworker/advice/templates/advice/view_countersign.html
+++ b/caseworker/advice/templates/advice/view_countersign.html
@@ -33,6 +33,16 @@
         <div class="govuk-grid-row">
             <br>
             <div class="govuk-grid-column-two-thirds">
+                {% if is_lu_countersigning and rejected_lu_countersignature %}
+                    <div id="rejected-countersignature" class="govuk-warning-text">
+                        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                        <strong class="govuk-warning-text__text">
+                            <span class="govuk-warning-text__assistive">Warning</span>
+                            This case will be returned to the case officer's queue.
+                            It will come back for countersigning once they have reviewed and moved it forward.
+                        </strong>
+                    </div>
+                {% endif %}
                 <h1 class="govuk-heading-xl">View recommendation</h1>
                 {% if lu_can_edit and buttons.edit_recommendation %}
                 <a role="button" draggable="false" class="govuk-button govuk-button--secondary" href="{% url 'cases:countersign_decision_edit' queue_pk case.id %}">

--- a/caseworker/advice/views.py
+++ b/caseworker/advice/views.py
@@ -83,6 +83,12 @@ class CaseContextMixin:
             if (dest["id"], self.caseworker["team"]["id"]) not in advised_on.items()
         }
 
+    def get_rejected_lu_countersignature(self):
+        if settings.FEATURE_LU_POST_CIRC_COUNTERSIGNING:
+            return self.rejected_countersign_advice()
+        else:
+            return None
+
     def get_context(self, **kwargs):
         return {}
 
@@ -95,6 +101,10 @@ class CaseContextMixin:
         # template (layouts/case.html) from which we are inheriting.
 
         is_in_lu_team = self.caseworker["team"]["alias"] == services.LICENSING_UNIT_TEAM
+        rejected_lu_countersignature = None
+        if is_in_lu_team:
+            rejected_lu_countersignature = self.get_rejected_lu_countersignature()
+
         return {
             **context,
             **self.get_context(case=self.case),
@@ -102,6 +112,7 @@ class CaseContextMixin:
             "queue_pk": self.kwargs["queue_pk"],
             "caseworker": self.caseworker,
             "is_lu_countersigning": (is_in_lu_team and settings.FEATURE_LU_POST_CIRC_COUNTERSIGNING),
+            "rejected_lu_countersignature": rejected_lu_countersignature,
         }
 
     def rejected_countersign_advice(self):
@@ -695,12 +706,6 @@ class ViewConsolidatedAdviceView(AdviceView, FormView):
 
         return lu_countersign_required
 
-    def get_rejected_lu_countersignature(self):
-        if settings.FEATURE_LU_POST_CIRC_COUNTERSIGNING:
-            return self.rejected_countersign_advice()
-        else:
-            return None
-
     def get_context(self, **kwargs):
         user_team_alias = self.caseworker["team"]["alias"]
         consolidated_advice = []
@@ -708,7 +713,6 @@ class ViewConsolidatedAdviceView(AdviceView, FormView):
             consolidated_advice = services.get_consolidated_advice(self.case.advice, user_team_alias)
         nlr_products = services.filter_nlr_products(self.case["data"]["goods"])
 
-        rejected_lu_countersignature = False
         lu_countersign_required = False
         finalise_case = False
 
@@ -722,7 +726,6 @@ class ViewConsolidatedAdviceView(AdviceView, FormView):
             "consolidated_advice": consolidated_advice,
             "nlr_products": nlr_products,
             "denial_reasons_display": self.denial_reasons_display,
-            "rejected_lu_countersignature": rejected_lu_countersignature,
             "lu_countersign_required": lu_countersign_required,
             "finalise_case": finalise_case,
         }

--- a/caseworker/advice/views.py
+++ b/caseworker/advice/views.py
@@ -411,6 +411,18 @@ class ReviewCountersignView(LoginRequiredMixin, CaseContextMixin, TemplateView):
 class ViewCountersignedAdvice(AdviceDetailView):
     template_name = "advice/view_countersign.html"
 
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+
+        is_in_lu_team = self.caseworker["team"]["alias"] == services.LICENSING_UNIT_TEAM
+        is_lu_countersigning = ((is_in_lu_team and settings.FEATURE_LU_POST_CIRC_COUNTERSIGNING),)
+        if is_in_lu_team:
+            rejected_lu_countersignature = self.get_rejected_lu_countersignature()
+            if rejected_lu_countersignature and is_lu_countersigning:
+                kwargs["move_case_button_label"] = "Move case back"
+
+        return kwargs
+
     def can_edit(self, advice_to_countersign):
         """Determine of the current user can edit the countersign comments.
         This will be the case if the current user made those comments.

--- a/caseworker/advice/views.py
+++ b/caseworker/advice/views.py
@@ -418,6 +418,7 @@ class ViewCountersignedAdvice(AdviceDetailView):
         )
         context["denial_reasons_display"] = self.denial_reasons_display
         context["current_tab"] = "cases:countersign_view"
+        context["show_rejected_countersignatures"] = True
 
         return context
 

--- a/unit_tests/caseworker/advice/views/test_consolidate.py
+++ b/unit_tests/caseworker/advice/views/test_consolidate.py
@@ -877,7 +877,7 @@ def test_case_returned_info_for_first_countersignature_rejection(
     rejected_div = soup.find(id="rejected-countersignature")
     rejected_detail_div = soup.find(id="rejected-countersignature-detail")
     countersignature_required_div = soup.find(id="countersign-required")
-    countersignature_div = soup.find(id="countersignatures")
+    countersignature_div = soup.find(class_="countersignatures")
     assert rejected_div is not None
     assert rejected_detail_div is not None
     assert countersignature_required_div is None
@@ -937,7 +937,7 @@ def test_case_returned_info_for_second_countersignature_rejection(
     rejected_div = soup.find(id="rejected-countersignature")
     rejected_detail_div = soup.find(id="rejected-countersignature-detail")
     countersignature_required_div = soup.find(id="countersign-required")
-    countersignature_div = soup.find(id="countersignatures")
+    countersignature_div = soup.find(class_="countersignatures")
     assert rejected_div is not None
     assert rejected_detail_div is not None
     assert countersignature_required_div is None
@@ -982,10 +982,10 @@ def test_finalise_button_shown_if_no_rejected_countersignatures(
 
     soup = BeautifulSoup(response.content, "html.parser")
     rejected_div = soup.find(id="rejected-countersignature")
-    countersignature_div = soup.find(id="countersignatures")
+    countersignature_div = soup.find(class_="countersignatures")
     assert rejected_div is None
     assert countersignature_div is not None
-    assert "Countersigned by Super Visor" in countersignature_div.find_all("h2")[0].text
+    assert "Senior countersigned by Super Visor" in countersignature_div.find_all("h2")[0].text
     assert "LGTM" in countersignature_div.find_all("p")[0].text
     assert "Countersigned by Testy McTest" in countersignature_div.find_all("h2")[1].text
     assert "I concur" in countersignature_div.find_all("p")[1].text

--- a/unit_tests/caseworker/advice/views/test_countersign.py
+++ b/unit_tests/caseworker/advice/views/test_countersign.py
@@ -308,7 +308,7 @@ def test_lu_countersign_get_shows_previous_countersignature(
     )
     response = authorized_client.get(countersign_decision_url)
     soup = BeautifulSoup(response.content, "html.parser")
-    countersignature_block = soup.find(id="countersignatures")
+    countersignature_block = soup.find(class_="countersignatures")
     assert response.status_code == 200
 
     counter_sigs = countersignature_block.find_all("div", recursive=False)

--- a/unit_tests/caseworker/advice/views/test_countersign_edit.py
+++ b/unit_tests/caseworker/advice/views/test_countersign_edit.py
@@ -304,7 +304,7 @@ def test_lu_countersign_edit_get_shows_previous_countersignature(
 
     response = authorized_client.get(countersign_decision_edit_url)
     soup = BeautifulSoup(response.content, "html.parser")
-    countersignature_block = soup.find(id="countersignatures")
+    countersignature_block = soup.find(class_="countersignatures")
     assert response.status_code == 200
 
     counter_sigs = countersignature_block.find_all("div", recursive=False)

--- a/unit_tests/caseworker/advice/views/test_countersign_view.py
+++ b/unit_tests/caseworker/advice/views/test_countersign_view.py
@@ -67,6 +67,8 @@ def test_single_lu_countersignature(
     assert len(counter_sigs) == 1
     assert counter_sigs[0].find(class_="govuk-heading-m").text == "Countersigned by Testy McTest"
     assert counter_sigs[0].find(class_="govuk-body").text == "I concur"
+    rejected_warning = soup.find(id="rejected-countersignature")
+    assert not rejected_warning
 
 
 @patch("caseworker.advice.views.get_gov_user")
@@ -102,6 +104,8 @@ def test_double_lu_countersignature(
     assert counter_sigs[0].find(class_="govuk-body").text == "LGTM"
     assert counter_sigs[1].find(class_="govuk-heading-m").text == "Countersigned by Testy McTest"
     assert counter_sigs[1].find(class_="govuk-body").text == "I concur"
+    rejected_warning = soup.find(id="rejected-countersignature")
+    assert not rejected_warning
 
 
 @patch("caseworker.advice.views.get_gov_user")
@@ -134,6 +138,10 @@ def test_single_lu_rejected_countersignature(
     assert len(rejected_counter_sigs) == 1
     assert rejected_counter_sigs[0].find("h2").text == "Countersigner Testy McTest disagrees with this recommendation"
     assert rejected_counter_sigs[0].find("p").text == "I disagree"
+    rejected_warning = soup.find(id="rejected-countersignature")
+    assert rejected_warning
+    assert "This case will be returned to the case officer's queue." in rejected_warning.text
+    assert "It will come back for countersigning once they have reviewed and moved it forward." in rejected_warning.text
 
 
 @patch("caseworker.advice.views.get_gov_user")
@@ -169,3 +177,7 @@ def test_lu_rejected_senior_countersignature(
     assert counter_sigs[0].find("p").text == "Nope"
     assert counter_sigs[1].find("h2").text == "Countersigned by Testy McTest"
     assert counter_sigs[1].find("p").text == "I concur"
+    rejected_warning = soup.find(id="rejected-countersignature")
+    assert rejected_warning
+    assert "This case will be returned to the case officer's queue." in rejected_warning.text
+    assert "It will come back for countersigning once they have reviewed and moved it forward." in rejected_warning.text

--- a/unit_tests/caseworker/advice/views/test_countersign_view.py
+++ b/unit_tests/caseworker/advice/views/test_countersign_view.py
@@ -134,3 +134,38 @@ def test_single_lu_rejected_countersignature(
     assert len(rejected_counter_sigs) == 1
     assert rejected_counter_sigs[0].find("h2").text == "Countersigner Testy McTest disagrees with this recommendation"
     assert rejected_counter_sigs[0].find("p").text == "I disagree"
+
+
+@patch("caseworker.advice.views.get_gov_user")
+def test_lu_rejected_senior_countersignature(
+    mock_get_gov_user,
+    authorized_client,
+    requests_mock,
+    data_standard_case,
+    final_advice,
+    url,
+    with_lu_countersigning_enabled,
+):
+    case_id = data_standard_case["case"]["id"]
+    team_id = final_advice["user"]["team"]["id"]
+    data_standard_case["case"]["advice"] = [final_advice]
+    data_standard_case["case"]["countersign_advice"] = countersignatures_for_advice(
+        [final_advice], accepted=[True, False]
+    )
+    requests_mock.get(client._build_absolute_uri(f"/cases/{case_id}"), json=data_standard_case)
+    mock_get_gov_user.return_value = (
+        {"user": {"team": {"id": team_id, "alias": LICENSING_UNIT_TEAM}}},
+        None,
+    )
+    response = authorized_client.get(url)
+
+    soup = BeautifulSoup(response.content, "html.parser")
+    assert response.status_code == 200
+
+    counter_sigs = soup.find_all(class_=["countersigned-by", "rejected-countersignature"])
+    assert len(counter_sigs) == 2
+    # We expect the senior countersignature at the top.
+    assert counter_sigs[0].find("h2").text == "Senior countersigner Super Visor disagrees with this recommendation"
+    assert counter_sigs[0].find("p").text == "Nope"
+    assert counter_sigs[1].find("h2").text == "Countersigned by Testy McTest"
+    assert counter_sigs[1].find("p").text == "I concur"


### PR DESCRIPTION
### Aim
Previously we were not showing countersignatures where there is rejected advice in favour of a warning message that there is a rejection. This is fine for most use cases, but it is required that the countersigner can see any rejected advice (for example any rejected advice that they have made) in addition to any previous approved countersignatures.

This PR implements the updated designs in the ticket.

[LTD-3521](https://uktrade.atlassian.net/browse/LTD-3521)


[LTD-3521]: https://uktrade.atlassian.net/browse/LTD-3521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ