### PR TITLE
Removed user profile image

### DIFF
--- a/caseworker/templates/layouts/base.html
+++ b/caseworker/templates/layouts/base.html
@@ -72,7 +72,6 @@
 			<span class="app-header__separator"></span>
 			<a id="link-profile" class="app-header__link" href="{% url 'users:profile' %}" data-tooltip="View profile">
 				{{ request.session.first_name }}
-				{% svg 'user' %}
 			</a>
 		</div>
 	</header>


### PR DESCRIPTION
Latest recommended solution was to remove the imagine entirely

https://uktrade.atlassian.net/jira/software/c/projects/LTD/boards/204?modal=detail&selectedIssue=LTD-1655

![Screenshot of change](https://user-images.githubusercontent.com/17591263/227269332-c3b9d820-8b2d-4bca-8b78-6c7e7583bbf4.png)

[LTD-1655](https://uktrade.atlassian.net/browse/LTD-1655)
