### PR TITLE
LTD-3515: Ignore invalid countersignatures

### DIFF
--- a/caseworker/advice/services.py
+++ b/caseworker/advice/services.py
@@ -135,7 +135,7 @@ def filter_advice_by_teams(all_advice, teams_list):
 
 
 def filter_countersign_advice_by_order(countersign_advice, order):
-    return [advice for advice in countersign_advice if advice["order"] == order]
+    return [advice for advice in countersign_advice if advice["valid"] is True and advice["order"] == order]
 
 
 def get_my_advice(advice, caseworker):
@@ -221,7 +221,7 @@ def get_countersigners_decision_advice(case, caseworker):
     """
     countersigned_by = set()
     for advice in case.countersign_advice:
-        if advice["countersigned_user"]["team"]["id"] == caseworker["team"]["id"]:
+        if advice["valid"] is True and advice["countersigned_user"]["team"]["id"] == caseworker["team"]["id"]:
             countersigned_by.add(advice["countersigned_user"]["id"])
     return countersigned_by
 

--- a/caseworker/advice/templates/advice/advice_details.html
+++ b/caseworker/advice/templates/advice/advice_details.html
@@ -89,7 +89,7 @@
                 <div class="countersignatures">
                     {% for countersign_advice in case|countersignatures_for_advice:advice  %}
                         {%  if countersign_advice.0.outcome_accepted %}
-                        <div class="govuk-!-padding-4 govuk-!-margin-bottom-2 countersigned-by">
+                        <div class="govuk-!-padding-4 govuk-!-margin-bottom-2 countersigned-by" style="border: 1px solid black;">
                             <div class="govuk-grid-row">
                                 <div class="govuk-grid-column-three-quarters">
                                     <h2 class="govuk-heading-m">{% if countersign_advice.0.order == 1 %}Countersigned{% elif countersign_advice.0.order == 2 %}Senior countersigned{% endif %} by {{ countersign_advice.0.countersigned_user|full_name }}</h2>

--- a/caseworker/advice/templatetags/advice_tags.py
+++ b/caseworker/advice/templatetags/advice_tags.py
@@ -69,7 +69,7 @@ def countersignatures_for_advice(case, advice):
     advice_ids = {ad["id"] for ad in advice}
     countersignatures_grouped_by_order = defaultdict(list)
     for cs in case.get("countersign_advice", []):
-        if cs.get("advice", {}).get("id") in advice_ids:
+        if cs["valid"] is True and cs.get("advice", {}).get("id") in advice_ids:
             countersignatures_grouped_by_order[cs["order"]].append(cs)
     return [
         countersignatures_grouped_by_order[order]

--- a/caseworker/advice/views.py
+++ b/caseworker/advice/views.py
@@ -121,7 +121,7 @@ class CaseContextMixin:
         rejection (case will be returned to edit the advice once a rejection has occurred.
         """
         for cs in self.case.get("countersign_advice", []):
-            if not cs["outcome_accepted"]:
+            if cs["valid"] is True and cs["outcome_accepted"] is False:
                 return cs
         return None
 

--- a/unit_tests/caseworker/advice/test_services.py
+++ b/unit_tests/caseworker/advice/test_services.py
@@ -84,6 +84,7 @@ def countersign_advice(data_standard_case, advice_for_countersign, current_user)
     return [
         {
             "id": str(uuid4()),
+            "valid": True,
             "order": 1,
             "outcome_accepted": True,
             "reasons": "reasons",

--- a/unit_tests/caseworker/advice/views/test_consolidate.py
+++ b/unit_tests/caseworker/advice/views/test_consolidate.py
@@ -684,20 +684,13 @@ def test_consolidate_review_refuse(requests_mock, authorized_client, data_standa
 
 
 def test_view_consolidate_approve_outcome(
-    requests_mock,
     authorized_client,
     data_standard_case,
     view_consolidate_outcome_url,
     consolidated_advice,
-    gov_user,
+    mock_gov_lu_user,
 ):
     data_standard_case["case"]["advice"] = consolidated_advice
-    gov_user["user"]["team"]["name"] = "Licensing Unit"
-    gov_user["user"]["team"]["alias"] = LICENSING_UNIT_TEAM
-    requests_mock.get(
-        client._build_absolute_uri("/gov-users/2a43805b-c082-47e7-9188-c8b3e1a83cb0"),
-        json=gov_user,
-    )
 
     response = authorized_client.get(view_consolidate_outcome_url)
     assert response.status_code == 200
@@ -723,21 +716,13 @@ def test_view_consolidate_approve_outcome(
 
 
 def test_view_consolidate_refuse_outcome(
-    requests_mock,
     authorized_client,
     data_standard_case,
     view_consolidate_outcome_url,
     consolidated_refusal_outcome,
-    gov_user,
+    mock_gov_lu_user,
 ):
     data_standard_case["case"]["advice"] = consolidated_refusal_outcome
-    gov_user["user"]["team"]["name"] = "Licensing Unit"
-    gov_user["user"]["team"]["alias"] = LICENSING_UNIT_TEAM
-
-    requests_mock.get(
-        client._build_absolute_uri("/gov-users/2a43805b-c082-47e7-9188-c8b3e1a83cb0"),
-        json=gov_user,
-    )
 
     response = authorized_client.get(view_consolidate_outcome_url)
     assert response.status_code == 200
@@ -845,12 +830,11 @@ def test_view_consolidate_approve_outcome_countersign_warning_message(
     ),
 )
 def test_case_returned_info_for_first_countersignature_rejection(
-    requests_mock,
     authorized_client,
     data_standard_case,
     view_consolidate_outcome_url,
     advice_for_lu_countersign,
-    gov_user,
+    mock_gov_lu_user,
     flags,
     with_lu_countersigning_enabled,
 ):
@@ -861,14 +845,6 @@ def test_case_returned_info_for_first_countersignature_rejection(
         advice_for_lu_countersign, countersigning_data
     )
     data_standard_case["case"]["all_flags"] = [FLAG_MAP[k] for k in flags]
-
-    gov_user["user"]["team"]["name"] = "LU Team"
-    gov_user["user"]["team"]["alias"] = services.LICENSING_UNIT_TEAM
-
-    requests_mock.get(
-        client._build_absolute_uri("/gov-users/2a43805b-c082-47e7-9188-c8b3e1a83cb0"),
-        json=gov_user,
-    )
 
     response = authorized_client.get(view_consolidate_outcome_url)
     assert response.status_code == 200
@@ -905,12 +881,11 @@ def test_case_returned_info_for_first_countersignature_rejection(
     ),
 )
 def test_case_returned_info_for_second_countersignature_rejection(
-    requests_mock,
     authorized_client,
     data_standard_case,
     view_consolidate_outcome_url,
     advice_for_lu_countersign,
-    gov_user,
+    mock_gov_lu_user,
     flags,
     with_lu_countersigning_enabled,
 ):
@@ -923,14 +898,6 @@ def test_case_returned_info_for_second_countersignature_rejection(
         advice_for_lu_countersign, countersigning_data
     )
     data_standard_case["case"]["all_flags"] = [FLAG_MAP[k] for k in flags]
-
-    gov_user["user"]["team"]["name"] = "LU Team"
-    gov_user["user"]["team"]["alias"] = services.LICENSING_UNIT_TEAM
-
-    requests_mock.get(
-        client._build_absolute_uri("/gov-users/2a43805b-c082-47e7-9188-c8b3e1a83cb0"),
-        json=gov_user,
-    )
 
     response = authorized_client.get(view_consolidate_outcome_url)
     assert response.status_code == 200
@@ -959,12 +926,11 @@ def test_case_returned_info_for_second_countersignature_rejection(
 
 
 def test_finalise_button_shown_if_no_rejected_countersignatures(
-    requests_mock,
     authorized_client,
     data_standard_case,
     view_consolidate_outcome_url,
     advice_for_lu_countersign,
-    gov_user,
+    mock_gov_lu_user,
     with_lu_countersigning_enabled,
 ):
     data_standard_case["case"]["advice"] = advice_for_lu_countersign
@@ -976,14 +942,6 @@ def test_finalise_button_shown_if_no_rejected_countersignatures(
         advice_for_lu_countersign, countersigning_data
     )
     data_standard_case["case"]["all_flags"] = [FLAG_MAP[GREEN_COUNTRIES_ID]]
-
-    gov_user["user"]["team"]["name"] = "LU Team"
-    gov_user["user"]["team"]["alias"] = services.LICENSING_UNIT_TEAM
-
-    requests_mock.get(
-        client._build_absolute_uri("/gov-users/2a43805b-c082-47e7-9188-c8b3e1a83cb0"),
-        json=gov_user,
-    )
 
     response = authorized_client.get(view_consolidate_outcome_url)
     assert response.status_code == 200
@@ -1135,12 +1093,11 @@ def test_finalise_button_shown_correctly_for_lu_countersigning_scenarios(
     ),
 )
 def test_rejection_countersignature_not_displayed_if_feature_flag_off(
-    requests_mock,
     authorized_client,
     data_standard_case,
     view_consolidate_outcome_url,
     advice_for_lu_countersign,
-    gov_user,
+    mock_gov_lu_user,
     with_lu_countersigning_disabled,
     countersigning_data,
 ):
@@ -1150,14 +1107,6 @@ def test_rejection_countersignature_not_displayed_if_feature_flag_off(
         advice_for_lu_countersign, countersigning_data
     )
     data_standard_case["case"]["all_flags"] = [FLAG_MAP[k] for k in [LU_COUNTERSIGN_REQUIRED_ID, GREEN_COUNTRIES_ID]]
-
-    gov_user["user"]["team"]["name"] = "LU Team"
-    gov_user["user"]["team"]["alias"] = services.LICENSING_UNIT_TEAM
-
-    requests_mock.get(
-        client._build_absolute_uri("/gov-users/2a43805b-c082-47e7-9188-c8b3e1a83cb0"),
-        json=gov_user,
-    )
 
     response = authorized_client.get(view_consolidate_outcome_url)
     assert response.status_code == 200

--- a/unit_tests/caseworker/advice/views/test_consolidate.py
+++ b/unit_tests/caseworker/advice/views/test_consolidate.py
@@ -886,8 +886,7 @@ def test_case_returned_info_for_first_countersignature_rejection(
     assert "This case has been returned for editing, by countersigner Testy McTest" in warning
     rejected_by = rejected_detail_div.find("h2").text
     assert "Reason for returning" in rejected_by
-    rejected_detail = rejected_detail_div.find("p").text
-    assert "I disagree" in rejected_detail
+    assert "I disagree" in rejected_detail_div.find("p").text
 
     assert not soup.find(id="finalise-case-button")
 

--- a/unit_tests/caseworker/advice/views/test_consolidate_edit.py
+++ b/unit_tests/caseworker/advice/views/test_consolidate_edit.py
@@ -386,7 +386,12 @@ def test_edit_advice_get_displays_correct_counteradvice(
     case_data["case"]["advice"] += more_advice
 
     # Add some new-style countersignatures to the case.
-    case_data["case"]["countersign_advice"] = countersignatures_for_advice(case_data["case"]["advice"], accepted=[True])
+    case_data["case"]["countersign_advice"] = countersignatures_for_advice(
+        case_data["case"]["advice"],
+        [
+            {"order": services.FIRST_COUNTERSIGN, "outcome_accepted": True},
+        ],
+    )
 
     # Add FCDO/MOD advice with old-style countersignature
     fcdo_or_mod_advice = {"FCDO": fcdo_countersigned_advice, "MOD": mod_countersigned_advice}[advice_type]

--- a/unit_tests/caseworker/advice/views/test_countersign.py
+++ b/unit_tests/caseworker/advice/views/test_countersign.py
@@ -295,7 +295,9 @@ def test_lu_countersign_get_shows_previous_countersignature(
     # Set up advice on the case
     team_id = final_advice["user"]["team"]["id"]
     data_standard_case["case"]["advice"] = [final_advice]
-    data_standard_case["case"]["countersign_advice"] = countersignatures_for_advice([final_advice])
+    data_standard_case["case"]["countersign_advice"] = countersignatures_for_advice(
+        [final_advice], [{"order": services.FIRST_COUNTERSIGN, "outcome_accepted": True}]
+    )
     # Setup mock API requests
     mock_get_gov_user.return_value = (
         {"user": {"team": {"id": team_id, "alias": LICENSING_UNIT_TEAM}}},

--- a/unit_tests/caseworker/advice/views/test_countersign_edit.py
+++ b/unit_tests/caseworker/advice/views/test_countersign_edit.py
@@ -35,7 +35,8 @@ def countersign_advice(data_standard_case, advice_for_countersign, current_user)
     return [
         {
             "id": str(uuid4()),
-            "order": 1,
+            "valid": True,
+            "order": services.FIRST_COUNTERSIGN,
             "outcome_accepted": True,
             "reasons": "I concur",
             "countersigned_user": current_user,

--- a/unit_tests/caseworker/advice/views/test_countersign_view.py
+++ b/unit_tests/caseworker/advice/views/test_countersign_view.py
@@ -1,16 +1,12 @@
-import copy
-from unittest.mock import patch
-
 import pytest
 
-from copy import deepcopy
+from unittest.mock import patch
 
 from bs4 import BeautifulSoup
 from django.urls import reverse
 
-from caseworker.advice.services import LICENSING_UNIT_TEAM
+from caseworker.advice.services import LICENSING_UNIT_TEAM, FIRST_COUNTERSIGN, SECOND_COUNTERSIGN
 from core import client
-from caseworker.advice import services
 from unit_tests.caseworker.conftest import countersignatures_for_advice
 
 
@@ -51,7 +47,12 @@ def test_single_lu_countersignature(
     case_id = data_standard_case["case"]["id"]
     team_id = final_advice["user"]["team"]["id"]
     data_standard_case["case"]["advice"] = [final_advice]
-    data_standard_case["case"]["countersign_advice"] = countersignatures_for_advice([final_advice])
+    data_standard_case["case"]["countersign_advice"] = countersignatures_for_advice(
+        [final_advice],
+        [
+            {"order": FIRST_COUNTERSIGN, "outcome_accepted": True},
+        ],
+    )
     requests_mock.get(client._build_absolute_uri(f"/cases/{case_id}"), json=data_standard_case)
     mock_get_gov_user.return_value = (
         {"user": {"team": {"id": team_id, "alias": LICENSING_UNIT_TEAM}}},
@@ -85,7 +86,11 @@ def test_double_lu_countersignature(
     team_id = final_advice["user"]["team"]["id"]
     data_standard_case["case"]["advice"] = [final_advice]
     data_standard_case["case"]["countersign_advice"] = countersignatures_for_advice(
-        [final_advice], accepted=[True, True]
+        [final_advice],
+        [
+            {"order": FIRST_COUNTERSIGN, "outcome_accepted": True},
+            {"order": SECOND_COUNTERSIGN, "outcome_accepted": True},
+        ],
     )
     requests_mock.get(client._build_absolute_uri(f"/cases/{case_id}"), json=data_standard_case)
     mock_get_gov_user.return_value = (
@@ -121,7 +126,12 @@ def test_single_lu_rejected_countersignature(
     case_id = data_standard_case["case"]["id"]
     team_id = final_advice["user"]["team"]["id"]
     data_standard_case["case"]["advice"] = [final_advice]
-    data_standard_case["case"]["countersign_advice"] = countersignatures_for_advice([final_advice], accepted=[False])
+    data_standard_case["case"]["countersign_advice"] = countersignatures_for_advice(
+        [final_advice],
+        [
+            {"order": FIRST_COUNTERSIGN, "outcome_accepted": False},
+        ],
+    )
     requests_mock.get(client._build_absolute_uri(f"/cases/{case_id}"), json=data_standard_case)
     mock_get_gov_user.return_value = (
         {"user": {"team": {"id": team_id, "alias": LICENSING_UNIT_TEAM}}},
@@ -158,7 +168,11 @@ def test_lu_rejected_senior_countersignature(
     team_id = final_advice["user"]["team"]["id"]
     data_standard_case["case"]["advice"] = [final_advice]
     data_standard_case["case"]["countersign_advice"] = countersignatures_for_advice(
-        [final_advice], accepted=[True, False]
+        [final_advice],
+        [
+            {"order": FIRST_COUNTERSIGN, "outcome_accepted": True},
+            {"order": SECOND_COUNTERSIGN, "outcome_accepted": False},
+        ],
     )
     requests_mock.get(client._build_absolute_uri(f"/cases/{case_id}"), json=data_standard_case)
     mock_get_gov_user.return_value = (

--- a/unit_tests/caseworker/advice/views/test_view_my_advice_view.py
+++ b/unit_tests/caseworker/advice/views/test_view_my_advice_view.py
@@ -5,7 +5,7 @@ import pytest
 from bs4 import BeautifulSoup
 from django.urls import reverse
 
-from caseworker.advice.services import FCDO_TEAM, LICENSING_UNIT_TEAM
+from caseworker.advice.services import FCDO_TEAM, LICENSING_UNIT_TEAM, FIRST_COUNTERSIGN, SECOND_COUNTERSIGN
 from core import client
 from core.builtins.custom_tags import filter_advice_by_user
 from unit_tests.caseworker.conftest import countersignatures_for_advice
@@ -280,7 +280,11 @@ def test_lu_countersignatures_not_shown(
     team_id = final_advice["user"]["team"]["id"]
     data_standard_case["case"]["advice"] = [final_advice]
     data_standard_case["case"]["countersign_advice"] = countersignatures_for_advice(
-        [final_advice], accepted=[True, True]
+        [final_advice],
+        [
+            {"order": FIRST_COUNTERSIGN, "outcome_accepted": True},
+            {"order": SECOND_COUNTERSIGN, "outcome_accepted": True},
+        ],
     )
     requests_mock.get(client._build_absolute_uri(f"/cases/{case_id}"), json=data_standard_case)
     mock_get_gov_user.return_value = (

--- a/unit_tests/caseworker/conftest.py
+++ b/unit_tests/caseworker/conftest.py
@@ -12,7 +12,7 @@ import rules
 from caseworker.advice import services
 from core import client
 from core.helpers import convert_value_to_query_param
-from caseworker.advice.services import LICENSING_UNIT_TEAM
+from caseworker.advice.services import LICENSING_UNIT_TEAM, FIRST_COUNTERSIGN, SECOND_COUNTERSIGN
 
 application_id = "094eed9a-23cc-478a-92ad-9a05ac17fad0"
 second_application_id = "08e69b60-8fbd-4111-b6ae-096b565fe4ea"
@@ -908,7 +908,8 @@ def countersignatures_for_advice(all_advice, accepted=[True]):
                 },
             },
             "outcome_accepted": accepted[0],
-            "order": 1,
+            "order": FIRST_COUNTERSIGN,
+            "valid": True,
             "advice": advice,
         }
 
@@ -928,7 +929,8 @@ def countersignatures_for_advice(all_advice, accepted=[True]):
                 },
             },
             "outcome_accepted": accepted[1],
-            "order": 2,
+            "order": SECOND_COUNTERSIGN,
+            "valid": True,
             "advice": advice,
         }
 
@@ -951,7 +953,8 @@ def countersignature_two():
             "last_name": "Visor",
         },
         "outcome_accepted": True,
-        "order": 2,
+        "valid": True,
+        "order": SECOND_COUNTERSIGN,
     }
     good_id = "3268e0b3-5fa2-46c3-9b20-3620b74f1c44"
     end_user_id = "bd394902-a86e-45f1-8dd2-6b9a11c218a3"


### PR DESCRIPTION
### Aim

Countersignatures when they are created initially by countersigning managers are `valid`.
If a countersigning manager rejects countersigning then the Case is sent back to caseworker to edit their recommendation. Depending on the comments they update their recommendation and send it again for countersigning. At this point (after editing) we mark all previous countersignatures as `invalid` because it will start the journey again.
So we need to ignore invalid countersignatures otherwise we end up showing warnings etc even for invalid countersignatures.

 - Refactored a method that generates countersignatures to make it clear on what is happening and easy to parameterize in other tests
 - Add tests that check for presence warning message that the case is sent back when countersignatures are `valid` and the usual warning about case requiring countersignatures when they are `invalid`
 - Use `mock_gov_lu_user` where possible instead of mocking it in every test

[LTD-3515](https://uktrade.atlassian.net/browse/LTD-3515)
