### PR TITLE
Cannot blank out the report summary prefix.

### DIFF
--- a/caseworker/assets/javascripts/tau/ars.js
+++ b/caseworker/assets/javascripts/tau/ars.js
@@ -39,10 +39,11 @@ const initAutocompleteField = (summaryFieldType, summaryFieldPluralised) => {
       },
     },
     onConfirm: (confirmed) => {
-      if (!confirmed) {
-        return;
+      if (confirmed) {
+        originalInput.value = confirmed.id;
+      } else if (summaryFieldType === "prefix") {
+        originalInput.value = "";
       }
-      originalInput.value = confirmed.id;
     },
     // Check the following is actually required:
     defaultValue:


### PR DESCRIPTION
This is a regression. You used to be able to blank out the report summary prefix and save. This ticket is to make that work again.

Issue is that caseworker would validate the prefix id against the value of the field to ensure they match, but when the prefix field was blanked out, the javascript would not blank out the prefix id and so cause the validation error. 

The fix explicitly blanks out the originalInput value when blanking out the prefix, to ensure that the prefix value and stored id match (as empty)

[LTD-3514](https://uktrade.atlassian.net/browse/LTD-3514)


[LTD-3514]: https://uktrade.atlassian.net/browse/LTD-3514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ