### PR TITLE
inline status text for cases view

### DIFF
--- a/caseworker/assets/styles/components/_cases.scss
+++ b/caseworker/assets/styles/components/_cases.scss
@@ -433,6 +433,12 @@ $case-header-text-colour: govuk-colour('white');
   z-index: 0;
 }
 
+@media screen and (min-width: 900px) {
+  .app-case__status {
+    white-space: nowrap;
+  }
+}
+
 .app-case__flags-bar {
   margin-top: govuk-spacing(4);
   display: flex;

--- a/caseworker/templates/includes/case-row.html
+++ b/caseworker/templates/includes/case-row.html
@@ -54,7 +54,7 @@
 			</p>
 			<p class="govuk-hint govuk-!-margin-0 govuk-!-margin-top-2">{{ case.organisation.primary_site.address.postcode }}</p>
 		</address>
-		<p class="govuk-tag govuk-tag--grey govuk-!-margin-0 govuk-!-margin-top-2">{{ case.status.value }}</p>
+		<p class="govuk-tag govuk-tag--grey govuk-!-margin-0 govuk-!-margin-top-2 app-case__status">{{ case.status.value }}</p>
 	</td>
 
     {# case updates #}


### PR DESCRIPTION
### Aim

To either inline the status text or reduce grey space with styling.

Reducing grey space without client side css was not possible.

Inline text has been implemented but there were issues so a min width was implemented. Making the text inline caused the column width to increase regardless of overflow settings etc. The only known alternative css is to use an absolute position (so parent ignores child width) which renders overflow css pointless so not really an option.
At less than 900px screen width the status on 2 rows has minimal additional grey space and the other columns look a lot better for the extra real estate.

Less liked alternative solution: slice the text to a set length before rendering, ie. Final Review Seco..., but as in the example the actual status could be unclear .

Ideally the status text would be kept to ~20 chars by the business in the future.

[LTD-3534](https://uktrade.atlassian.net/browse/LTD-3534)

[LTD-3534]: https://uktrade.atlassian.net/browse/LTD-3534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ