### PR TITLE
Skip failing E2E tests temporarily

### DIFF
--- a/ui_tests/caseworker/features/give_advice.feature
+++ b/ui_tests/caseworker/features/give_advice.feature
@@ -218,7 +218,7 @@ Feature: I want to record my user advice and any comments and conditions relatin
     And I see "1a, 1b, 1c, 1d, 1e, 1f" as the refusal criteria
 
 
-  @lu_consolidate_advice
+  @skip @lu_consolidate_advice
   Scenario: LU consolidate advice journey
     Given I sign in to SSO or am signed into SSO
     And I create standard application or standard application has been previously created
@@ -251,7 +251,7 @@ Feature: I want to record my user advice and any comments and conditions relatin
     And I see the case is not assigned to any queues
 
 
-  @lu_refuse_advice
+  @skip @lu_refuse_advice
   Scenario: LU refuse advice journey
     # Setup
     Given I sign in to SSO or am signed into SSO
@@ -298,7 +298,7 @@ Feature: I want to record my user advice and any comments and conditions relatin
     And I see the case is not assigned to any queues
 
 
-  @lu_nlr_advice
+  @skip @lu_nlr_advice
   Scenario: LU NLR advice journey
     # Setup
     Given I sign in to SSO or am signed into SSO
@@ -336,7 +336,7 @@ Feature: I want to record my user advice and any comments and conditions relatin
     Then I see the case status is now "Finalised"
     And I see the case is not assigned to any queues
 
-  @lu_countersign
+  @skip @lu_countersign
   Scenario: LU countersign
     Given I sign in to SSO or am signed into SSO
     And I create standard application or standard application has been previously created

--- a/ui_tests/exporter/features/licences.feature
+++ b/ui_tests/exporter/features/licences.feature
@@ -1,7 +1,7 @@
 @licences @all
 Feature: I want to be able to view licences as an exporter user
 
-  @current
+  @skip @current
   Scenario: View my standard application licences
     Given I signin and go to exporter homepage and choose Test Org
     And I put the test user in the admin team


### PR DESCRIPTION
### Aim

Once the routing changes to activate LU Countersign routing is merged then we will re-enable them with fixes
