### PR TITLE
Re-enable and fix failing E2E tests

### DIFF
--- a/tests_common/api_client/sub_helpers/cases.py
+++ b/tests_common/api_client/sub_helpers/cases.py
@@ -136,9 +136,30 @@ class Cases:
         )
 
     def create_final_advice(self, case_id, data):
-        self.api_client.make_request(
+        resp = self.api_client.make_request(
             method="POST",
             url="/cases/" + case_id + "/final-advice/",
+            headers=self.api_client.gov_headers,
+            body=data,
+        )
+        return resp.json()["advice"]
+
+    def countersign_advice(self, case_id, advice):
+        gov_user_id = self.api_client.context["gov_user_id"]
+        data = [
+            {
+                "order": 1,
+                "outcome_accepted": True,
+                "reasons": "Agree with the original outcome",
+                "countersigned_user": gov_user_id,
+                "advice": ad["id"],
+                "case": case_id,
+            }
+            for ad in advice
+        ]
+        self.api_client.make_request(
+            method="POST",
+            url="/cases/" + case_id + "/countersign-decision-advice/",
             headers=self.api_client.gov_headers,
             body=data,
         )

--- a/tests_common/api_client/sub_helpers/cases.py
+++ b/tests_common/api_client/sub_helpers/cases.py
@@ -91,12 +91,11 @@ class Cases:
     def manage_case_status(self, draft_id, status="withdrawn"):
         draft_id_to_change = draft_id or self.api_client.context["draft_id"]
         response = self.api_client.make_request(
-            method="PUT",
-            url="/applications/" + draft_id_to_change + "/status/",
+            method="PATCH",
+            url=f"/cases/{draft_id_to_change}/",
             headers=self.api_client.gov_headers,
             body={"status": status},
         )
-
         return response.status_code
 
     def finalise_case(self, draft_id, action, additional_data=None):

--- a/ui_tests/caseworker/features/give_advice.feature
+++ b/ui_tests/caseworker/features/give_advice.feature
@@ -218,7 +218,7 @@ Feature: I want to record my user advice and any comments and conditions relatin
     And I see "1a, 1b, 1c, 1d, 1e, 1f" as the refusal criteria
 
 
-  @skip @lu_consolidate_advice
+  @lu_consolidate_advice
   Scenario: LU consolidate advice journey
     Given I sign in to SSO or am signed into SSO
     And I create standard application or standard application has been previously created
@@ -237,7 +237,24 @@ Feature: I want to record my user advice and any comments and conditions relatin
     And I click submit recommendation
     Then I see "reason for approving" as the reasons for approving
     And I see "licence condition" as the licence condition
-    When I click "Finalise case"
+    And I see countersign required warning message
+    When I click move case forward
+    And I go to my profile page
+    And I change my team to "Licensing Unit" and default queue to "Licensing manager countersigning"
+    And I go to my case list
+    And I click the application previously created
+    And I click the recommendations and decision tab
+    And I click "Review and countersign"
+    And I agree with outcome and provide "licensing manager approved" as countersign comments
+    And I click submit recommendation
+    Then I see "licensing manager approved" as countersign comments
+    When I click move case forward
+    And I go to my profile page
+    And I change my team to "Licensing Unit" and default queue to "Licensing Unit Post-circulation Cases to Finalise"
+    And I go to my case list
+    And I click the application previously created
+    And I click the recommendations and decision tab
+    And I click "Finalise case"
     And I click save
     And I click "Generate"
     And I select the template "SIEL template"
@@ -298,7 +315,7 @@ Feature: I want to record my user advice and any comments and conditions relatin
     And I see the case is not assigned to any queues
 
 
-  @skip @lu_nlr_advice
+  @lu_nlr_advice
   Scenario: LU NLR advice journey
     # Setup
     Given I sign in to SSO or am signed into SSO
@@ -322,7 +339,24 @@ Feature: I want to record my user advice and any comments and conditions relatin
     And I click submit recommendation
     Then I see "reason for approving" as the reasons for approving
     And I see "licence condition" as the licence condition
-    When I click "Finalise case"
+    And I see countersign required warning message
+    When I click move case forward
+    And I go to my profile page
+    And I change my team to "Licensing Unit" and default queue to "Licensing manager countersigning"
+    And I go to my case list
+    And I click the application previously created
+    And I click the recommendations and decision tab
+    And I click "Review and countersign"
+    And I agree with outcome and provide "licensing manager approved" as countersign comments
+    And I click submit recommendation
+    Then I see "licensing manager approved" as countersign comments
+    When I click move case forward
+    And I go to my profile page
+    And I change my team to "Licensing Unit" and default queue to "Licensing Unit Post-circulation Cases to Finalise"
+    And I go to my case list
+    And I click the application previously created
+    And I click the recommendations and decision tab
+    And I click "Finalise case"
     And I click save
     Then the document name should be "No Licence Required"
     When I click "Generate"
@@ -336,40 +370,51 @@ Feature: I want to record my user advice and any comments and conditions relatin
     Then I see the case status is now "Finalised"
     And I see the case is not assigned to any queues
 
-  @skip @lu_countersign
+  @lu_countersign
   Scenario: LU countersign
     Given I sign in to SSO or am signed into SSO
     And I create standard application or standard application has been previously created
     And I prepare the application for final review
     When I go to my profile page
-    And I change my team to "Licensing Unit" and default queue to "Licensing manager countersigning"
-    And I go to my case list
-    And I click the application previously created
-    And I assign myself to the case
-    Then I see the application destinations
-    When I click edit flags on the last destination
-    And I set a "LU Countersign Required" flag
-    And I click I'm done
-    And I click on details
-    And I enter "Decision has been made with reasons" as the countersign note
-    And I click submit
-    And I go to application previously created
-    And I assign myself to the case
-    Then I see the case status is now "Under final review"
-    When I go to my profile page
-    And I change my team to "Licensing Unit" and default queue to "Senior licensing manager countersigning"
-    And I go to my case list
-    And I click the application previously created
-    And I assign myself to the case
-    Then I click on Notes and timeline
-    Then I should see "Decision has been made with reasons" appear in the timeline
-    When I click on "Details" tab
-    And I click I'm done
-    And I click submit
-    Then I don't see previously created application
-    When I go to my profile page
     And I change my team to "Licensing Unit" and default queue to "Licensing Unit Post-circulation Cases to Finalise"
     And I go to my case list
     And I click the application previously created
-    Then I see the case status is now "Under final review"
-    And I see the case is assigned to "Licensing Unit Post-circulation Cases to Finalise"
+    And I assign myself to the case
+    And I go to my case list
+    And I click the application previously created
+    And I click the recommendations and decision tab
+    And I click "Review and combine"
+    And I enter "reason for approving" as the reasons for approving
+    And I enter "licence condition" as the licence condition
+    And I click submit recommendation
+    Then I see "reason for approving" as the reasons for approving
+    And I see "licence condition" as the licence condition
+    And I see countersign required warning message
+    When I click move case forward
+    And I go to my profile page
+    And I change my team to "Licensing Unit" and default queue to "Licensing manager countersigning"
+    And I go to my case list
+    And I click the application previously created
+    And I click the recommendations and decision tab
+    And I click "Review and countersign"
+    And I agree with outcome and provide "licensing manager approved" as countersign comments
+    And I click submit recommendation
+    Then I see "licensing manager approved" as countersign comments
+    When I click move case forward
+    And I go to my profile page
+    And I change my team to "Licensing Unit" and default queue to "Licensing Unit Post-circulation Cases to Finalise"
+    And I go to my case list
+    And I click the application previously created
+    And I click the recommendations and decision tab
+    And I click "Finalise case"
+    And I click save
+    And I click "Generate"
+    And I select the template "SIEL template"
+    And I click continue
+    And I click preview
+    Then I see the licence number on the SIEL licence preview
+    And I see that "16. Control list no" is "ML1a" on the SIEL licence preview
+    When I click continue
+    And I click save and publish to exporter
+    Then I see the case status is now "Finalised"
+    And I see the case is not assigned to any queues

--- a/ui_tests/caseworker/pages/advice.py
+++ b/ui_tests/caseworker/pages/advice.py
@@ -174,3 +174,24 @@ class RecommendationsAndDecisionPage(BasePage):
                 value="//tbody/tr",
             )
         ]
+
+    def get_lu_countersign_warning_message(self):
+        element = self.driver.find_element(by=By.ID, value="countersign-required")
+        return element.text
+
+    def agree_with_outcome_and_countersign(self, comments):
+        self.driver.find_element(by=By.XPATH, value=f"//input[@type='radio' and @value='True']").click()
+        textarea = self.driver.find_element(by=By.CLASS_NAME, value="govuk-textarea")
+        textarea.clear()
+        textarea.send_keys(comments)
+
+    def disagree_with_outcome_and_countersign(self, comments):
+        self.driver.find_element(by=By.XPATH, value=f"//input[@type='radio' and @value='False']").click()
+        textarea = self.driver.find_element(by=By.CLASS_NAME, value="govuk-textarea")
+        textarea.clear()
+        textarea.send_keys(comments)
+
+    def get_countersign_comments(self):
+        countersign_div = self.driver.find_element(by=By.CLASS_NAME, value="countersignatures")
+        comments = countersign_div.find_element(by=By.CLASS_NAME, value="govuk-body")
+        return comments.text

--- a/ui_tests/caseworker/step_defs/test_give_advice.py
+++ b/ui_tests/caseworker/step_defs/test_give_advice.py
@@ -217,3 +217,26 @@ def enter_case_note_text(driver, text, context):
 @then(parsers.parse('I see the case is assigned to "{queue}"'))  # noqa
 def case_not_assigned_to_any_queue(driver, queue):  # noqa
     assert CasePage(driver).get_assigned_queues() == queue
+
+
+@then("I see countersign required warning message")
+def lu_countersign_warning_message(driver):  # noqa
+    countersign_warning_message = (
+        "This case requires countersigning. Moving this case on will pass it to the countersigning work queue."
+    )
+    assert countersign_warning_message in RecommendationsAndDecisionPage(driver).get_lu_countersign_warning_message()
+
+
+@when(parsers.parse('I agree with outcome and provide "{comments}" as countersign comments'))  # noqa
+def agree_with_outcome(driver, comments):  # noqa
+    RecommendationsAndDecisionPage(driver).agree_with_outcome_and_countersign(comments)
+
+
+@when(parsers.parse('I disagree with outcome and provide "{comments}" as countersign comments'))  # noqa
+def disagree_with_outcome(driver, comments):  # noqa
+    RecommendationsAndDecisionPage(driver).disagree_with_outcome_and_countersign(comments)
+
+
+@then(parsers.parse('I see "{comments}" as countersign comments'))
+def check_countersign_comments(driver, comments):  # noqa
+    assert RecommendationsAndDecisionPage(driver).get_countersign_comments() == comments

--- a/ui_tests/exporter/conftest.py
+++ b/ui_tests/exporter/conftest.py
@@ -702,9 +702,15 @@ def get_file_upload_path(filename):  # noqa
 
 @given(parsers.parse('I create "{decision}" final advice'))  # noqa
 def final_advice(context, decision, api_test_client):  # noqa
-    api_test_client.cases.create_final_advice(
+    advice = api_test_client.cases.create_final_advice(
         context.case_id, [{"type": decision, "text": "abc", "note": "", "good": context.goods[0]["good"]["id"]}]
     )
+    context.final_advice = advice
+
+
+@given(parsers.parse("I countersign the advice"))  # noqa
+def countersign_advice(context, decision, api_test_client):  # noqa
+    api_test_client.cases.countersign_advice(context.case_id, context.final_advice)
 
 
 @given("I remove the flags to finalise the licence")  # noqa
@@ -718,6 +724,11 @@ def i_remove_all_flags(context, api_test_client):  # noqa
 @given("I put the test user in the admin team")
 def put_test_user_in_admin_team(api_test_client):  # noqa
     api_test_client.gov_users.put_test_user_in_team("Admin")
+
+
+@given(parsers.parse('I put the test user in the "{team_name}" team'))
+def put_test_user_in_specified_team(api_test_client, team_name):  # noqa
+    api_test_client.gov_users.put_test_user_in_team(team_name)
 
 
 @given(parsers.parse('I create a licence for my application with "{decision}" decision document'))  # noqa

--- a/ui_tests/exporter/features/licences.feature
+++ b/ui_tests/exporter/features/licences.feature
@@ -1,13 +1,15 @@
 @licences @all
 Feature: I want to be able to view licences as an exporter user
 
-  @skip @current
+  @view_standard_application_licences
   Scenario: View my standard application licences
     Given I signin and go to exporter homepage and choose Test Org
     And I put the test user in the admin team
     And I create a standard application via api
     And I remove the flags to finalise the licence
+    And I put the test user in the "Licensing Unit" team
     And I create "approve" final advice
+    And I countersign the advice
     And I create a licence for my application with "approve" decision document and good decisions
     When I go to the licences page
     Then I see my standard licence


### PR DESCRIPTION
### Aim

We temporarily disabled failing E2E tests to merge routing changes that activates Countersign rules.
They are all merged now so we can re-enable them.

The refuse test is still skipped because we need additional fix which we are doing it as a follow-up so it will be re-enabled later.

One of the exporter test is also skipped at the moment but we are adding fix in this PR (in progress) so will update the PR once that is ready.