### PR TITLE
Switch control list entry filter to text input from autocomplete

### DIFF
--- a/caseworker/cases/helpers/filters.py
+++ b/caseworker/cases/helpers/filters.py
@@ -1,4 +1,4 @@
-from caseworker.core.services import get_control_list_entries, get_countries, get_regime_entries
+from caseworker.core.services import get_countries, get_regime_entries
 from caseworker.flags.services import get_flags
 from lite_content.lite_internal_frontend.cases import CasesListPage
 from lite_forms.components import (
@@ -130,11 +130,9 @@ def case_filters_bar(request, filters, is_system_queue) -> FiltersBar:
                 options=get_countries(request, convert_to_options=True),
                 initial=selected_filters.get("country"),
             ),
-            AutocompleteInput(
+            TextInput(
                 name="control_list_entry",
                 title=CasesListPage.Filters.CONTROL_LIST_ENTRY,
-                options=get_control_list_entries(request, convert_to_options=True),
-                initial=selected_filters.get("control_list_entry"),
             ),
             AutocompleteInput(
                 name="regime_entry",

--- a/unit_tests/caseworker/queues/views/test_cases.py
+++ b/unit_tests/caseworker/queues/views/test_cases.py
@@ -152,6 +152,23 @@ def test_cases_home_page_case_search_API_error(authorized_client, mock_cases_sea
     assert exception.user_message == "A problem occurred. Please try again later"
 
 
+def test_cases_home_page_control_list_entries_search(authorized_client, mock_cases_search):
+    url = reverse("queues:cases")
+    response = authorized_client.get(url)
+    html = BeautifulSoup(response.content, "html.parser")
+    control_list_entry_filter_input = html.find(id="control_list_entry")
+    assert control_list_entry_filter_input.attrs["type"] == "text"
+    assert control_list_entry_filter_input.attrs["name"] == "control_list_entry"
+
+    url = reverse("queues:cases") + "?control_list_entry=ML1"
+    response = authorized_client.get(url)
+    assert response.status_code == 200
+    assert mock_cases_search.last_request.qs == {
+        **default_params,
+        "control_list_entry": ["ml1"],
+    }
+
+
 def test_cases_home_page_trigger_list_search(authorized_client, mock_cases_search):
     url = reverse("queues:cases") + "?is_trigger_list=True"
     authorized_client.get(url)


### PR DESCRIPTION
### Aim

This updates the control list entry filter so that it's a free text field as opposed to an autocomplete input.

The autocomplete field was creating a select box which contained ~3000 control list entries. This select box was then being progressively enhanced via JS and it was this progressive enhancement that was causing some users' browsers to become unresponsive.

Our initial thoughts were to make this input smarter by getting it to do a realtime lookup of the CLE based on what the user was typing, however we decided it was more likely that the user already knew the exact CLE they were searching for so the extra work involved to make this input smarter is probably not worth the effort.

[LTD-3101](https://uktrade.atlassian.net/browse/LTD-3101)


[LTD-3101]: https://uktrade.atlassian.net/browse/LTD-3101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ