### PR TITLE
match api changes to cases destinations

### DIFF
--- a/caseworker/queues/views/cases.py
+++ b/caseworker/queues/views/cases.py
@@ -132,7 +132,7 @@ class Cases(LoginRequiredMixin, TemplateView):
         except KeyError:
             destinations = []
 
-        unique_destinations = [dict(t) for t in {tuple(destination["country"].items()) for destination in destinations}]
+        unique_destinations = [dict(t) for t in {tuple(destination.items()) for destination in destinations}]
         return unique_destinations
 
     def _limit_lines(self, text, limit):


### PR DESCRIPTION
### Aim

Reduce queries and time taken when populating destinations for case search (4s currently)

[LTD-3563](https://uktrade.atlassian.net/browse/LTD-3563)


[LTD-3563]: https://uktrade.atlassian.net/browse/LTD-3563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ