### PR TITLE
Fix paging for licences page

### DIFF
--- a/exporter/licences/services.py
+++ b/exporter/licences/services.py
@@ -4,15 +4,16 @@ from core.helpers import convert_parameters_to_query_params
 
 def get_licences(
     request,
-    page=1,
     licence_type="licence",
+    page=None,
     reference=None,
     clc=None,
     country=None,
     end_user=None,
     active_only=None,
 ):
-    response = client.get(request, "/licences/" + convert_parameters_to_query_params(locals()))
+    url = "/licences/" + convert_parameters_to_query_params(locals())
+    response = client.get(request, url)
     return response.json()
 
 
@@ -23,7 +24,7 @@ def get_licence(request, pk):
 
 def get_nlr_letters(
     request,
-    page=1,
+    page=None,
     reference=None,
     clc=None,
     country=None,

--- a/exporter/licences/views.py
+++ b/exporter/licences/views.py
@@ -82,7 +82,11 @@ class ListOpenAndStandardLicences(AbstractListView):
         filter_bar = filters.get_licences_filters(
             licence_type=self.object_name, control_list_entries=self.control_list, countries=self.countries
         )
-        licences = get_licences(self.request, licence_type="licence")
+        licences = get_licences(
+            self.request,
+            licence_type="licence",
+            **self.params,
+        )
 
         context = super().get_context_data(data=licences, filters=filter_bar, **kwargs)
         context.update(


### PR DESCRIPTION
### Aim

This fixes the paging on the licences page.

The issue was that the page parameter wasn't being passed through to the API correctly.

[LTD-3590](https://uktrade.atlassian.net/browse/LTD-3590)


[LTD-3590]: https://uktrade.atlassian.net/browse/LTD-3590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ