### PR TITLE
Fix queue view customiser show/hide bug

### DIFF
--- a/caseworker/templates/includes/case-row.html
+++ b/caseworker/templates/includes/case-row.html
@@ -170,7 +170,7 @@
 	</td>
 
 	{# CLEs #}
-	<td class="govuk-table__cell lite-mobile-hide" data-customiser-key="control_list_entries">
+	<td class="govuk-table__cell lite-mobile-hide" data-customiser-key="control_list_entry">
 		<ol class="govuk-list destinations__list app-cles__list">
             {% for cle in case.goods_summary.cles %}
 				<li class="app-cles__item">
@@ -181,7 +181,7 @@
 	</td>
 
 	{# Report summaries #}
-	<td class="govuk-table__cell lite-mobile-hide" data-customiser-key="report_summaries">
+	<td class="govuk-table__cell lite-mobile-hide" data-customiser-key="report_summary">
 		<ol class="govuk-list destinations__list app-report-summaries__list">
 			{% for report_summary in case.goods_summary.report_summaries %}
 				<li class="app-report_summaries__item">
@@ -192,7 +192,7 @@
 	</td>
 
 	{# Regimes #}
-	<td class="govuk-table__cell lite-mobile-hide" data-customiser-key="regimes">
+	<td class="govuk-table__cell lite-mobile-hide" data-customiser-key="regime">
         <ol class="govuk-list destinations__list app-regimes__list">
 			{% for regime in case.goods_summary.regimes %}
 				<li class="app-regimes__item">

--- a/caseworker/templates/queues/cases.html
+++ b/caseworker/templates/queues/cases.html
@@ -92,9 +92,9 @@
 	    	    			<th class="govuk-table__header app-table__header--skeleton" data-customiser-key="case_allocation" scope="col">Case allocation</th>
 	    	    			<th class="govuk-table__header app-table__header--skeleton" data-customiser-key="case_updates" scope="col">Case updates</th>
 	    	    			<th class="govuk-table__header app-table__header--skeleton" data-customiser-key="products" scope="col">Products</th>
-	    	    			<th class="govuk-table__header app-table__header--skeleton" data-customiser-key="control_list_entries" scope="col">Control list entry</th>
-	    	    			<th class="govuk-table__header app-table__header--skeleton" data-customiser-key="report_summaries" scope="col">Report summary</th>
-	    	    			<th class="govuk-table__header app-table__header--skeleton" data-customiser-key="regimes" scope="col">Regime</th>
+	    	    			<th class="govuk-table__header app-table__header--skeleton" data-customiser-key="control_list_entry" scope="col">Control list entry</th>
+	    	    			<th class="govuk-table__header app-table__header--skeleton" data-customiser-key="report_summary" scope="col">Report summary</th>
+	    	    			<th class="govuk-table__header app-table__header--skeleton" data-customiser-key="regime" scope="col">Regime</th>
 	    	    			<th class="govuk-table__header app-table__header--skeleton" data-customiser-key="total_value" scope="col">Total value</th>
 	    	    			<th class="govuk-table__header app-table__header--skeleton" data-customiser-key="queries" scope="col">Queries</th>
 	    	    			<th class="govuk-table__header app-table__header--skeleton" data-customiser-key="denial_matches" scope="col">Denial matches</th>


### PR DESCRIPTION
### Aim

Fixes a bug in the queue view where Regime/Control list entry/Report summary columns would not be properly managed by the customiser component.  This was due to a rename of the keys during the original PR which was not applied everywhere properly.
