### PR TITLE
[LTD-3676] Rationalise approval screen

### DIFF
--- a/caseworker/advice/forms.py
+++ b/caseworker/advice/forms.py
@@ -127,6 +127,7 @@ class GiveApprovalAdviceForm(forms.Form):
                 "instructions_to_exporter",
                 "footnote_details",
                 legend="Add a licence condition, instruction to exporter or footnote",
+                summary_css_class="supplemental-approval-fields",
             ),
             Submit("submit", "Submit recommendation"),
         )

--- a/caseworker/queues/views/forms.py
+++ b/caseworker/queues/views/forms.py
@@ -6,13 +6,10 @@ from crispy_forms_gds.layout import Layout, Field, Fieldset, HTML, Submit
 
 from core.forms.utils import coerce_str_to_bool
 from core.forms.widgets import CheckboxInputSmall
+from core.forms.layouts import ExpandingFieldset
 from caseworker.flags.services import get_flags
 
 SLA_DAYS_RANGE = 99
-
-
-class AdvancedFiltersFieldset(Fieldset):
-    template = "queues/advanced_filters_fieldset.html"
 
 
 class CasesFiltersForm(forms.Form):
@@ -200,7 +197,7 @@ class CasesFiltersForm(forms.Form):
                 *basic_filters,
                 css_class="basic-filter-fields",
             ),
-            AdvancedFiltersFieldset(
+            ExpandingFieldset(
                 Field.text("exporter_application_reference"),
                 Field.text("organisation_name"),
                 Field.text("exporter_site_name"),
@@ -226,6 +223,7 @@ class CasesFiltersForm(forms.Form):
                 Field("is_trigger_list"),
                 legend="Advanced filters",
                 css_class="advanced-group",
+                text_div_css_class="advanced-filter-fields",
             ),
             Fieldset(
                 Submit("submit", "Apply filters", css_id="button-apply-filters"),

--- a/core/forms/layouts.py
+++ b/core/forms/layouts.py
@@ -143,6 +143,7 @@ class Prefixed(Field):
 class ExpandingFieldset(Fieldset):
     template = "forms/expanding_fieldset.html"
 
-    def __init__(self, *args, text_div_css_class=None, **kwargs):
+    def __init__(self, *args, text_div_css_class=None, summary_css_class=None, **kwargs):
         self.text_div_css_class = text_div_css_class
+        self.summary_css_class = summary_css_class
         super().__init__(*args, **kwargs)

--- a/core/forms/layouts.py
+++ b/core/forms/layouts.py
@@ -1,7 +1,7 @@
 from crispy_forms.layout import TemplateNameMixin
 from crispy_forms.utils import render_field, TEMPLATE_PACK
 
-from crispy_forms_gds.layout import Field, HTML
+from crispy_forms_gds.layout import Field, HTML, Fieldset
 
 from django.template.loader import render_to_string
 
@@ -138,3 +138,11 @@ class ConditionalCheckbox(TemplateNameMixin):
 class Prefixed(Field):
     def __init__(self, prefix, field, **kwargs):
         super().__init__(field, context={"prefix": prefix}, template="%s/layout/prefixed_field.html", **kwargs)
+
+
+class ExpandingFieldset(Fieldset):
+    template = "forms/expanding_fieldset.html"
+
+    def __init__(self, *args, text_div_css_class=None, **kwargs):
+        self.text_div_css_class = text_div_css_class
+        super().__init__(*args, **kwargs)

--- a/core/forms/templates/forms/expanding_fieldset.html
+++ b/core/forms/templates/forms/expanding_fieldset.html
@@ -3,7 +3,7 @@
     {{ fieldset.flat_attrs|safe }}>
     {% if legend %}
         <details class="govuk-details" data-module="govuk-details">
-            <summary class="govuk-details__summary">
+            <summary class="govuk-details__summary {{fieldset.summary_css_class}}">
             <span class="govuk-details__summary-text">{{ legend|safe }}</span>
             </summary>
             <div class="govuk-details__text {{fieldset.text_div_css_class}}">

--- a/core/forms/templates/forms/expanding_fieldset.html
+++ b/core/forms/templates/forms/expanding_fieldset.html
@@ -6,7 +6,7 @@
             <summary class="govuk-details__summary">
             <span class="govuk-details__summary-text">{{ legend|safe }}</span>
             </summary>
-            <div class="govuk-details__text advanced-filter-fields">
+            <div class="govuk-details__text {{fieldset.text_div_css_class}}">
                 {{ fields|safe }}
             </div>
         </details>

--- a/ui_tests/caseworker/conftest.py
+++ b/ui_tests/caseworker/conftest.py
@@ -200,6 +200,11 @@ def submit_form(driver):  # noqa
     WebDriverWait(driver, 45).until(expected_conditions.staleness_of(old_page))
 
 
+@when(parsers.parse('I click element with css selector "{css_selector}"'))
+def click_text(driver, css_selector):  # noqa
+    driver.find_element(by=By.CSS_SELECTOR, value=css_selector).click()
+
+
 @when(parsers.parse('I click "{button_text}"'))
 def click_button_with_text(driver, button_text):  # noqa
     WebDriverWait(driver, 20).until(

--- a/ui_tests/caseworker/conftest.py
+++ b/ui_tests/caseworker/conftest.py
@@ -200,9 +200,10 @@ def submit_form(driver):  # noqa
     WebDriverWait(driver, 45).until(expected_conditions.staleness_of(old_page))
 
 
-@when(parsers.parse('I click element with css selector "{css_selector}"'))
-def click_text(driver, css_selector):  # noqa
-    driver.find_element(by=By.CSS_SELECTOR, value=css_selector).click()
+@when(parsers.parse('I click the text "{text}"'))
+def click_text(driver, text):  # noqa
+    xpath = f"//*[text()[contains(.,'{text}')]]"
+    driver.find_element(by=By.XPATH, value=xpath).click()
 
 
 @when(parsers.parse('I click "{button_text}"'))

--- a/ui_tests/caseworker/features/give_advice.feature
+++ b/ui_tests/caseworker/features/give_advice.feature
@@ -21,6 +21,10 @@ Feature: I want to record my user advice and any comments and conditions relatin
     And I click continue
     And I select countries "GB, UA"
     And I enter "Hello World" as the reasons for approving
+    And I click element with css selector "summary.supplemental-approval-fields"
+    And I enter "licence condition" as the licence condition
+    And I enter "instruction for exporter" as the instructions for the exporter
+    And I enter "reporting footnote" as the reporting footnote
     And I click submit recommendation
     Then I should see my recommendation for "Great Britain, Ukraine" with "Hello World"
     When I click move case forward
@@ -84,6 +88,7 @@ Feature: I want to record my user advice and any comments and conditions relatin
     And I click approve all
     And I click continue
     And I enter "reason for approving" as the reasons for approving
+    And I click element with css selector "summary.supplemental-approval-fields"
     And I enter "licence condition" as the licence condition
     And I enter "instruction for exporter" as the instructions for the exporter
     And I enter "reporting footnote" as the reporting footnote
@@ -140,6 +145,7 @@ Feature: I want to record my user advice and any comments and conditions relatin
     And I click approve all
     And I click continue
     And I enter "reason for approving" as the reasons for approving
+    And I click element with css selector "summary.supplemental-approval-fields"
     And I enter "licence condition" as the licence condition
     And I enter "instruction for exporter" as the instructions for the exporter
     And I enter "reporting footnote" as the reporting footnote
@@ -150,6 +156,7 @@ Feature: I want to record my user advice and any comments and conditions relatin
     And I see "reporting footnote" as the reporting footnote
     When I click "Edit recommendation"
     And I enter "reason for approving1" as the reasons for approving
+    And I click element with css selector "summary.supplemental-approval-fields"
     And I enter "licence condition1" as the licence condition
     And I enter "instruction for exporter1" as the instructions for the exporter
     And I enter "reporting footnote1" as the reporting footnote
@@ -176,6 +183,7 @@ Feature: I want to record my user advice and any comments and conditions relatin
     And I click approve all
     And I click continue
     And I enter "reason for approving" as the reasons for approving
+    And I click element with css selector "summary.supplemental-approval-fields"
     And I enter "licence condition" as the licence condition
     And I enter "instruction for exporter" as the instructions for the exporter
     And I enter "reporting footnote" as the reporting footnote

--- a/ui_tests/caseworker/features/give_advice.feature
+++ b/ui_tests/caseworker/features/give_advice.feature
@@ -21,7 +21,7 @@ Feature: I want to record my user advice and any comments and conditions relatin
     And I click continue
     And I select countries "GB, UA"
     And I enter "Hello World" as the reasons for approving
-    And I click element with css selector "summary.supplemental-approval-fields"
+    And I click the text "Add a licence condition, instruction to exporter or footnote"
     And I enter "licence condition" as the licence condition
     And I enter "instruction for exporter" as the instructions for the exporter
     And I enter "reporting footnote" as the reporting footnote
@@ -88,7 +88,7 @@ Feature: I want to record my user advice and any comments and conditions relatin
     And I click approve all
     And I click continue
     And I enter "reason for approving" as the reasons for approving
-    And I click element with css selector "summary.supplemental-approval-fields"
+    And I click the text "Add a licence condition, instruction to exporter or footnote"
     And I enter "licence condition" as the licence condition
     And I enter "instruction for exporter" as the instructions for the exporter
     And I enter "reporting footnote" as the reporting footnote
@@ -145,7 +145,7 @@ Feature: I want to record my user advice and any comments and conditions relatin
     And I click approve all
     And I click continue
     And I enter "reason for approving" as the reasons for approving
-    And I click element with css selector "summary.supplemental-approval-fields"
+    And I click the text "Add a licence condition, instruction to exporter or footnote"
     And I enter "licence condition" as the licence condition
     And I enter "instruction for exporter" as the instructions for the exporter
     And I enter "reporting footnote" as the reporting footnote
@@ -156,7 +156,7 @@ Feature: I want to record my user advice and any comments and conditions relatin
     And I see "reporting footnote" as the reporting footnote
     When I click "Edit recommendation"
     And I enter "reason for approving1" as the reasons for approving
-    And I click element with css selector "summary.supplemental-approval-fields"
+    And I click the text "Add a licence condition, instruction to exporter or footnote"
     And I enter "licence condition1" as the licence condition
     And I enter "instruction for exporter1" as the instructions for the exporter
     And I enter "reporting footnote1" as the reporting footnote
@@ -183,7 +183,7 @@ Feature: I want to record my user advice and any comments and conditions relatin
     And I click approve all
     And I click continue
     And I enter "reason for approving" as the reasons for approving
-    And I click element with css selector "summary.supplemental-approval-fields"
+    And I click the text "Add a licence condition, instruction to exporter or footnote"
     And I enter "licence condition" as the licence condition
     And I enter "instruction for exporter" as the instructions for the exporter
     And I enter "reporting footnote" as the reporting footnote


### PR DESCRIPTION
### Aim
This change hides some supplemental fields for the "Recommend an approval" page by placing them within a GDS "details" component.  This adheres to the designs in the Jira here; https://uktrade.atlassian.net/browse/LTD-3676

[LTD-3676](https://uktrade.atlassian.net/browse/LTD-3676)


[LTD-3676]: https://uktrade.atlassian.net/browse/LTD-3676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ