### PR TITLE
[LTD-3673] Quick summary "allocate and approve" button

### DIFF
--- a/caseworker/advice/rules.py
+++ b/caseworker/advice/rules.py
@@ -62,4 +62,4 @@ def can_user_make_recommendation(request, case):
 
 
 rules.add_rule("can_user_make_recommendation", is_user_allocated & can_user_make_recommendation)
-rules.add_rule("can_user_make_recommendation_when_allocated", can_user_make_recommendation)
+rules.add_rule("can_user_allocate_and_approve", can_user_make_recommendation)

--- a/caseworker/advice/rules.py
+++ b/caseworker/advice/rules.py
@@ -37,7 +37,7 @@ def can_beis_make_recommendation(user, case, queue_alias):
 @rules.predicate
 def can_user_make_recommendation(request, case):
     queue = request.queue
-    user = request.user
+    user = request.lite_user
     team = user["team"]["alias"]
     queue_alias = queue["alias"]
     existing_advice = services.get_my_advice(case.advice, user["id"])
@@ -59,3 +59,4 @@ def can_user_make_recommendation(request, case):
 
 
 rules.add_rule("can_user_make_recommendation", is_user_allocated & can_user_make_recommendation)
+rules.add_rule("can_user_make_recommendation_when_allocated", can_user_make_recommendation)

--- a/caseworker/advice/rules.py
+++ b/caseworker/advice/rules.py
@@ -36,8 +36,11 @@ def can_beis_make_recommendation(user, case, queue_alias):
 
 @rules.predicate
 def can_user_make_recommendation(request, case):
-    queue = request.queue
-    user = request.lite_user
+    try:
+        queue = request.queue
+        user = request.lite_user
+    except AttributeError:
+        return False
     team = user["team"]["alias"]
     queue_alias = queue["alias"]
     existing_advice = services.get_my_advice(case.advice, user["id"])

--- a/caseworker/advice/rules.py
+++ b/caseworker/advice/rules.py
@@ -1,0 +1,61 @@
+import rules
+
+from caseworker.core.rules import is_user_allocated
+from caseworker.advice import services
+
+
+def can_fcdo_make_recommendation(user, case, queue_alias):
+    if queue_alias not in (
+        services.FCDO_CASES_TO_REVIEW_QUEUE,
+        services.FCDO_CPACC_CASES_TO_REVIEW_QUEUE,
+    ):
+        return False
+    return len(services.unadvised_countries(user, case)) > 0
+
+
+def can_mod_make_recommendation(user, case, queue_alias):
+    return queue_alias in services.MOD_CONSOLIDATE_QUEUES
+
+
+def can_ncsc_make_recommendation(user, case, queue_alias):
+    return queue_alias == services.NCSC_CASES_TO_REVIEW
+
+
+def can_beis_make_recommendation(user, case, queue_alias):
+    if queue_alias not in (
+        services.BEIS_CHEMICAL_CASES_TO_REVIEW,
+        services.BEIS_NUCLEAR_CASES_TO_REVIEW,
+    ):
+        return False
+
+    if queue_alias == services.BEIS_NUCLEAR_CASES_TO_REVIEW:
+        return len(services.unassessed_trigger_list_goods(case)) == 0
+
+    return True
+
+
+@rules.predicate
+def can_user_make_recommendation(request, case):
+    queue = request.queue
+    user = request.user
+    team = user["team"]["alias"]
+    queue_alias = queue["alias"]
+    existing_advice = services.get_my_advice(case.advice, user["id"])
+
+    # Existing advice, so this must be edited
+    if existing_advice:
+        return False
+
+    if team == services.FCDO_TEAM:
+        return can_fcdo_make_recommendation(user, case, queue_alias)
+    if team in services.MOD_CONSOLIDATE_TEAMS:
+        return can_mod_make_recommendation(user, case, queue_alias)
+    if team in services.BEIS_TEAMS:
+        return can_beis_make_recommendation(user, case, queue_alias)
+    if team == services.NCSC_TEAM:
+        return can_ncsc_make_recommendation(user, case, queue_alias)
+
+    return False
+
+
+rules.add_rule("can_user_make_recommendation", is_user_allocated & can_user_make_recommendation)

--- a/caseworker/advice/services.py
+++ b/caseworker/advice/services.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from requests.exceptions import HTTPError
 
 from core import client
-from caseworker.advice.constants import AdviceLevel
+from caseworker.advice import constants
 
 # Queues
 BEIS_CHEMICAL_CASES_TO_REVIEW = "BEIS_CHEMICAL_CASES_TO_REVIEW"
@@ -101,7 +101,7 @@ def filter_current_user_advice(all_advice, user_id):
     return [
         advice
         for advice in all_advice
-        if advice["level"] == AdviceLevel.USER
+        if advice["level"] == constants.AdviceLevel.USER
         and advice["type"]["key"] in ["approve", "proviso", "refuse"]
         and (advice["user"]["id"] == user_id)
     ]
@@ -179,11 +179,10 @@ def group_advice_by_team(advice):
 
 
 def get_advice_to_countersign(advice, caseworker):
-    advice_levels_to_countersign = [AdviceLevel.USER]
+    advice_levels_to_countersign = [constants.AdviceLevel.USER]
 
     if caseworker["team"]["alias"] == LICENSING_UNIT_TEAM:
-        advice_levels_to_countersign = [AdviceLevel.FINAL]
-
+        advice_levels_to_countersign = [constants.AdviceLevel.FINAL]
     advice_by_team = filter_advice_by_users_team(advice, caseworker)
     user_advice = filter_advice_by_level(advice_by_team, advice_levels_to_countersign)
     grouped_user_advice = group_advice_by_user(user_advice)
@@ -244,10 +243,10 @@ def get_advice_to_consolidate(advice, user_team_alias):
     """
     if user_team_alias == LICENSING_UNIT_TEAM:
         # LU needs to review the consolidated advice given by MOD which is at team level
-        user_team_advice = filter_advice_by_level(advice, [AdviceLevel.USER, AdviceLevel.TEAM])
+        user_team_advice = filter_advice_by_level(advice, [constants.AdviceLevel.USER, constants.AdviceLevel.TEAM])
         advice_from_teams = filter_advice_by_teams(user_team_advice, LU_CONSOLIDATE_TEAMS)
     elif user_team_alias == MOD_ECJU_TEAM:
-        user_advice = filter_advice_by_level(advice, [AdviceLevel.USER])
+        user_advice = filter_advice_by_level(advice, [constants.AdviceLevel.USER])
         advice_from_teams = filter_advice_by_teams(user_advice, MOD_CONSOLIDATE_TEAMS)
     else:
         raise Exception(f"Consolidate/combine operation not allowed for team {user_team_alias}")
@@ -510,7 +509,6 @@ def get_advice_tab_context(case, caseworker, queue_id):
         "url": "cases:advice_view",
         # Booleans that determine button visibility
         "buttons": {
-            "make_recommendation": False,
             "edit_recommendation": False,
             "clear_recommendation": False,
             "review_and_countersign": False,
@@ -531,10 +529,7 @@ def get_advice_tab_context(case, caseworker, queue_id):
         ):
             existing_advice = get_my_advice(case.advice, caseworker["id"])
 
-            if not existing_advice:
-                # An individual giving advice on a case for the first time
-                context["buttons"]["make_recommendation"] = True
-            else:
+            if existing_advice:
                 # An individual accessing a case again after having given advice
                 context["url"] = "cases:view_my_advice"
                 context["buttons"]["edit_recommendation"] = True
@@ -543,7 +538,6 @@ def get_advice_tab_context(case, caseworker, queue_id):
 
             # BEIS Nuclear need to assess products first before giving recommendation
             if team_alias == BEIS_NUCLEAR and queue_alias == BEIS_NUCLEAR_CASES_TO_REVIEW and not existing_advice:
-                context["buttons"]["make_recommendation"] = len(unassessed_trigger_list_goods(case)) == 0
                 context["buttons"]["assess_trigger_list_products"] = len(unassessed_trigger_list_goods(case)) > 0
 
         elif queue_alias == FCDO_COUNTERSIGNING_QUEUE or queue_alias == BEIS_NUCLEAR_COUNTERSIGNING:
@@ -591,3 +585,21 @@ def get_advice_tab_context(case, caseworker, queue_id):
                 context["buttons"]["move_case_forward"] = True
 
     return context
+
+
+def unadvised_countries(caseworker, case):
+    """Returns a dict of countries for which advice has not been given by the current user's team."""
+    dest_types = constants.DESTINATION_TYPES
+    advised_on = {
+        # Map of destinations advised on -> team that gave the advice
+        advice.get(dest_type): advice["user"]["team"]["id"]
+        for dest_type in dest_types
+        for advice in case.advice
+        if advice.get(dest_type) is not None
+    }
+    return {
+        dest["country"]["id"]: dest["country"]["name"]
+        for dest in case.destinations
+        # Don't include destinations already advised on by the current user's team
+        if (dest["id"], caseworker["team"]["id"]) not in advised_on.items()
+    }

--- a/caseworker/advice/templates/advice/view-advice.html
+++ b/caseworker/advice/templates/advice/view-advice.html
@@ -29,9 +29,9 @@
     {% endfor %}
 
     {% if not consolidated_advice %}
-        {% test_rule 'can_user_review_and_countersign' current_user case as can_user_review_and_countersign %}
-        {% test_rule 'can_user_review_and_combine' current_user case as can_user_review_and_combine %}
-        {% test_rule 'can_user_make_recommendation' current_user case as can_user_make_recommendation %}
+        {% test_rule 'can_user_review_and_countersign' request case as can_user_review_and_countersign %}
+        {% test_rule 'can_user_review_and_combine' request case as can_user_review_and_combine %}
+        {% test_rule 'can_user_make_recommendation' request case as can_user_make_recommendation %}
         {% if countersign and buttons.review_and_countersign and can_user_review_and_countersign %}
             {% if is_lu_countersigning %}
                 <a id="review-and-countersign-decision-button" draggable="false" class="govuk-button govuk-button--primary" href="{% url 'cases:countersign_decision_review' queue_pk case.id %}">Review and countersign</a>
@@ -41,7 +41,7 @@
         {% elif consolidate and buttons.review_and_combine and can_user_review_and_combine %}
             <a id="review-and-combine-button" draggable="false" class="govuk-button govuk-button--primary" href="{% url 'cases:consolidate_review' queue_pk case.id %}">Review and combine</a>
         {% else %}
-            {% if can_advise and buttons.make_recommendation and can_user_make_recommendation %}
+            {% if can_user_make_recommendation %}
                 <a id="make-recommendation-button" draggable="false" class="govuk-button govuk-button--primary" href="{% url 'cases:select_advice' queue_pk case.id %}">Make recommendation</a>
                 {% if assessed_trigger_list_goods %}
                     {% include "advice/assessed_products.html" with assessed_trigger_list_goods=assessed_trigger_list_goods %}

--- a/caseworker/advice/templates/advice/view_my_advice.html
+++ b/caseworker/advice/templates/advice/view_my_advice.html
@@ -52,7 +52,7 @@
             </div>
             <div class="govuk-grid-column-one-quarter">
               {% if my_advice and advice_completed and buttons.move_case_forward %}
-                {% test_rule 'can_user_move_case_forward' current_user case as can_user_move_case_forward %}
+                {% test_rule 'can_user_move_case_forward' request case as can_user_move_case_forward %}
                     {% if can_user_move_case_forward %}
                         {% crispy form %}
                     {% endif %}

--- a/caseworker/cases/helpers/case.py
+++ b/caseworker/cases/helpers/case.py
@@ -3,6 +3,7 @@ from dateutil.parser import parse
 from decimal import Decimal
 
 from django.shortcuts import render
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
 from django.views.generic import TemplateView
@@ -110,9 +111,22 @@ class CaseworkerMixin:
                 }
             )
         )
+        allocate_and_approve_form = (
+            None
+            if self.queue["is_system_queue"]
+            else CaseAssignmentsAllocateToMeForm(
+                initial={
+                    "queue_id": self.queue_id,
+                    "user_id": self.caseworker["id"],
+                    "case_id": self.case_id,
+                    "return_to": reverse("cases:approve_all", kwargs={"queue_pk": self.queue_id, "pk": self.case_id}),
+                }
+            )
+        )
         return {
             **context,
             "allocate_to_me_form": allocate_to_me_form,
+            "allocate_and_approve_form": allocate_and_approve_form,
         }
 
 

--- a/caseworker/core/context_processors.py
+++ b/caseworker/core/context_processors.py
@@ -18,22 +18,22 @@ from caseworker.users.services import get_gov_user
 from caseworker.core.constants import ALL_CASES_QUEUE_ID
 
 
-def current_queue(request):
+def current_queue_and_user(request):
+    extra_context = {}
     kwargs = getattr(request.resolver_match, "kwargs", {})
+    queue = None
     if "queue_pk" in kwargs and "disable_queue_lookup" not in kwargs:
         queue_pk = request.resolver_match.kwargs["queue_pk"]
         queue = get_queue(request, queue_pk)
-        return {"queue": queue}
+    extra_context["queue"] = queue
 
-    return {}
-
-
-def current_user(request):
     current_user = None
     if "lite_api_user_id" in request.session:
         user, _ = get_gov_user(request, str(request.session["lite_api_user_id"]))
         current_user = user.get("user", None)
-    return {"current_user": current_user}
+    extra_context["current_user"] = current_user
+
+    return extra_context
 
 
 def export_vars(request):

--- a/caseworker/core/rules.py
+++ b/caseworker/core/rules.py
@@ -2,7 +2,7 @@ import rules
 
 
 @rules.predicate
-def is_user_case_adviser(request, case):
+def is_user_case_officer(request, case):
     try:
         user = request.lite_user
     except AttributeError:
@@ -25,7 +25,7 @@ def is_user_assigned(request, case):
     return False
 
 
-is_user_allocated = is_user_case_adviser | is_user_assigned
+is_user_allocated = is_user_case_officer | is_user_assigned
 
 rules.add_rule("can_user_change_case", is_user_allocated)
 rules.add_rule("can_user_move_case_forward", is_user_allocated)

--- a/caseworker/core/rules.py
+++ b/caseworker/core/rules.py
@@ -2,13 +2,15 @@ import rules
 
 
 @rules.predicate
-def is_user_case_adviser(user, case):
+def is_user_case_adviser(request, case):
+    user = request.user
     case_officer = case["case_officer"]
     return case_officer is not None and user and user["id"] == case_officer.get("id")
 
 
 @rules.predicate
-def is_user_assigned(user, case):
+def is_user_assigned(request, case):
+    user = request.user
     if user and case["assigned_users"]:
         # Loop through all queues to check if user is assigned
         for _, assigned_users in case["assigned_users"].items():
@@ -23,7 +25,6 @@ rules.add_rule("can_user_change_case", is_user_allocated)
 rules.add_rule("can_user_move_case_forward", is_user_allocated)
 rules.add_rule("can_user_review_and_countersign", is_user_allocated)
 rules.add_rule("can_user_review_and_combine", is_user_allocated)
-rules.add_rule("can_user_make_recommendation", is_user_allocated)
 rules.add_rule("can_user_assess_products", is_user_allocated)
 rules.add_rule("can_user_add_an_ejcu_query", is_user_allocated)
 rules.add_rule("can_user_attach_document", rules.always_allow)

--- a/caseworker/core/rules.py
+++ b/caseworker/core/rules.py
@@ -3,14 +3,14 @@ import rules
 
 @rules.predicate
 def is_user_case_adviser(request, case):
-    user = request.user
+    user = request.lite_user
     case_officer = case["case_officer"]
     return case_officer is not None and user and user["id"] == case_officer.get("id")
 
 
 @rules.predicate
 def is_user_assigned(request, case):
-    user = request.user
+    user = request.lite_user
     if user and case["assigned_users"]:
         # Loop through all queues to check if user is assigned
         for _, assigned_users in case["assigned_users"].items():

--- a/caseworker/core/rules.py
+++ b/caseworker/core/rules.py
@@ -3,14 +3,20 @@ import rules
 
 @rules.predicate
 def is_user_case_adviser(request, case):
-    user = request.lite_user
+    try:
+        user = request.lite_user
+    except AttributeError:
+        return False
     case_officer = case["case_officer"]
     return case_officer is not None and user and user["id"] == case_officer.get("id")
 
 
 @rules.predicate
 def is_user_assigned(request, case):
-    user = request.lite_user
+    try:
+        user = request.lite_user
+    except AttributeError:
+        return False
     if user and case["assigned_users"]:
         # Loop through all queues to check if user is assigned
         for _, assigned_users in case["assigned_users"].items():

--- a/caseworker/queues/middleware.py
+++ b/caseworker/queues/middleware.py
@@ -11,4 +11,4 @@ class RequestQueueMiddleware:
 
     def process_view(self, request, view_func, view_args, view_kwargs):
         if view_kwargs.get("queue_pk"):
-            request.queue = get_queue(view_kwargs["queue_pk"])
+            request.queue = get_queue(request, view_kwargs["queue_pk"])

--- a/caseworker/queues/middleware.py
+++ b/caseworker/queues/middleware.py
@@ -1,0 +1,14 @@
+from caseworker.queues.services import get_queue
+
+
+class RequestQueueMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        return response
+
+    def process_view(self, request, view_func, view_args, view_kwargs):
+        if view_kwargs.get("queue_pk"):
+            request.queue = get_queue(view_kwargs["queue_pk"])

--- a/caseworker/queues/services.py
+++ b/caseworker/queues/services.py
@@ -54,8 +54,12 @@ def post_queues(request, json):
 
 
 def get_queue(request, pk):
-    data = client.get(request, "/queues/" + str(pk))
-    return data.json()
+    if hasattr(request, "queue") and request.queue.get("id") == pk:
+        return request.queue
+
+    response = client.get(request, "/queues/" + str(pk))
+    response.raise_for_status()
+    return response.json()
 
 
 def get_cases_search_data(request, queue_pk, params):

--- a/caseworker/tau/templates/tau/edit.html
+++ b/caseworker/tau/templates/tau/edit.html
@@ -22,7 +22,7 @@
                 <form id="tau-form" method="POST">
                     <h1 class="govuk-heading-m tau__headline">Assessing {{good.good.name}}</h1>
                     {% crispy form %}
-                    {% test_rule 'can_user_assess_products' current_user case as can_user_assess_products %}
+                    {% test_rule 'can_user_assess_products' request case as can_user_assess_products %}
                     {% if can_user_assess_products %}
                         <input type="submit" name="submit" value="Save" class="govuk-button" id="submit-id-submit" />
                     {% endif %}

--- a/caseworker/tau/templates/tau/home.html
+++ b/caseworker/tau/templates/tau/home.html
@@ -24,7 +24,7 @@
                     {% endif %}
                 </div>
                 <!-- Move case forward form -->
-                {% test_rule 'can_user_move_case_forward' current_user case as can_user_move_case_forward %}
+                {% test_rule 'can_user_move_case_forward' request case as can_user_move_case_forward %}
                 {% if can_user_move_case_forward  %}
                     <div class="govuk-grid-column-one-third">
                         {% if not unassessed_goods and is_tau and not is_all_cases_queue %}
@@ -51,7 +51,7 @@
                         <div class="govuk-grid-column-one-third assessment-form__second-column">
                             <h1 class="govuk-heading-m assessment-form__headline"></h1>
                             {% crispy form %}
-                            {% test_rule 'can_user_assess_products' current_user case as can_user_assess_products %}
+                            {% test_rule 'can_user_assess_products' request case as can_user_assess_products %}
                             {% if can_user_assess_products %}
                                 <input type="submit" name="submit" value="Save and continue" class="govuk-button" id="submit-id-submit" />
                             {% endif %}
@@ -66,7 +66,7 @@
                     <div class="govuk-grid-column-full">
                         <table id="assessed-products" class="govuk-table">
                             <h2 class="govuk-heading-m">Assessed products</h2>
-                            {% test_rule 'can_user_assess_products' current_user case as can_user_assess_products %}
+                            {% test_rule 'can_user_assess_products' request case as can_user_assess_products %}
                             {% if can_user_assess_products %}
                                 <a id="clear-assessments-button" href="{% url 'cases:tau:clear_assessments' queue_pk=queue_id pk=case.id %}" class="govuk-button govuk-button--secondary" data-module="govuk-button">Clear assessments</a>
                             {% endif %}

--- a/caseworker/templates/case/slices/summary.html
+++ b/caseworker/templates/case/slices/summary.html
@@ -1,5 +1,5 @@
 {% load rules %}
-{% test_rule 'can_user_change_case' current_user case as can_user_change_case %}
+{% test_rule 'can_user_change_case' request case as can_user_change_case %}
 
 <dl class="app-case__summary-list">
 	{% if case.case_type.reference.key == "comp_v" %}

--- a/caseworker/templates/case/tabs/additional-contacts.html
+++ b/caseworker/templates/case/tabs/additional-contacts.html
@@ -2,7 +2,7 @@
 
 <div class="lite-buttons-row">
 	{% make_list queue.id case.id as button_params %}
-	{% test_rule 'can_user_add_contact' current_user case as can_user_add_contact %}
+	{% test_rule 'can_user_add_contact' request case as can_user_add_contact %}
 	{% if can_user_add_contact %}
 		{% govuk_link_button id='add-a-contact' text='cases.CasePage.AdditionalContactsTab.ADD_A_CONTACT_BUTTON' url='cases:add_additional_contact' url_param=button_params %}
 	{% endif %}

--- a/caseworker/templates/case/tabs/documents.html
+++ b/caseworker/templates/case/tabs/documents.html
@@ -1,13 +1,13 @@
 {% load rules svg %}
 
 <div class="lite-buttons-row">
-	{% test_rule 'can_user_attach_document' current_user case as can_user_attach_document %}
+	{% test_rule 'can_user_attach_document' request case as can_user_attach_document %}
 	{% if can_user_attach_document %}
 		<a id="button-attach-document" role="button" draggable="false" class="govuk-button" href="{% url 'cases:attach_documents' queue.id case.id %}">
 			{% lcs 'cases.CasePage.DocumentsTab.ATTACH_DOCUMENT_BUTTON' %}
 		</a>
 	{% endif %}
-	{% test_rule 'can_user_generate_document' current_user case as can_user_generate_document %}
+	{% test_rule 'can_user_generate_document' request case as can_user_generate_document %}
 	{% if can_user_generate_document %}
 		<a id="button-generate-document" role="button" draggable="false" class="govuk-button" href="{% url 'cases:generate_document' queue.id case.id %}">
 			{% lcs 'cases.CasePage.DocumentsTab.GENERATE_DOCUMENT_BUTTON' %}

--- a/caseworker/templates/case/tabs/ecju-queries.html
+++ b/caseworker/templates/case/tabs/ecju-queries.html
@@ -2,7 +2,7 @@
 
 <div class="lite-buttons-row">
 	{% make_list queue.id case.id as button_params %}
-	{% test_rule 'can_user_add_an_ejcu_query' current_user case as can_user_add_an_ejcu_query %}
+	{% test_rule 'can_user_add_an_ejcu_query' request case as can_user_add_an_ejcu_query %}
 	{% if can_user_add_an_ejcu_query %}
 		{% govuk_link_button id='new-query' text='cases.EcjuQueries.AddQuery.ADD_BUTTON_LABEL' url='cases:new_ecju_query' url_param=button_params query_params="?query_type=ecju_query"%}
 	{% endif %}

--- a/caseworker/templates/case/tabs/quick-summary.html
+++ b/caseworker/templates/case/tabs/quick-summary.html
@@ -243,8 +243,8 @@
     </tbody>
 </table>
 
-{% test_rule 'can_user_make_recommendation_when_allocated' request case as can_user_make_recommendation_when_allocated %}
-{% if allocate_and_approve_form and can_user_make_recommendation_when_allocated %}
+{% test_rule 'can_user_allocate_and_approve' request case as can_user_allocate_and_approve %}
+{% if allocate_and_approve_form and can_user_allocate_and_approve %}
     <form action="{% url 'queues:case_assignment_assign_to_me' queue.id %}" method="post"
       class="app-case-warning-banner__action-form">
     {% csrf_token %}

--- a/caseworker/templates/case/tabs/quick-summary.html
+++ b/caseworker/templates/case/tabs/quick-summary.html
@@ -1,4 +1,4 @@
-{% load static advice_tags %}
+{% load static advice_tags crispy_forms_tags rules %}
 {% load humanize %}
 
 <h2 class="govuk-heading-m">Quick Summary</h2>
@@ -242,3 +242,13 @@
         </tr>
     </tbody>
 </table>
+
+{% test_rule 'can_user_make_recommendation_when_allocated' request case as can_user_make_recommendation_when_allocated %}
+{% if allocate_and_approve_form and can_user_make_recommendation_when_allocated %}
+    <form action="{% url 'queues:case_assignment_assign_to_me' queue.id %}" method="post"
+      class="app-case-warning-banner__action-form">
+    {% csrf_token %}
+    {{ allocate_and_approve_form|crispy }}
+    <button type="submit" name="status" id="allocate-and-approve-button" class="govuk-button govuk-button--primary">Allocate to me and approve</button>
+    </form>
+{% endif %}

--- a/caseworker/templates/layouts/case.html
+++ b/caseworker/templates/layouts/case.html
@@ -116,7 +116,7 @@
 				</div>
 			{% endif %}
 		</div>
-		{% test_rule 'can_user_change_case' current_user case as can_user_change_case %}
+		{% test_rule 'can_user_change_case' request case as can_user_change_case %}
 		{% if not can_user_change_case %}
 			<div id="allocation-warning" class="app-case-warning-banner">
 				<span class="app-case-warning-banner__icon" aria-hidden="true">!</span>
@@ -156,7 +156,7 @@
 							{% endif %}
 							{% govuk_link_button id='rerun-routing-rules' text='cases.ApplicationPage.Actions.RERUN_ROUTING_RULES' url='cases:rerun_routing_rules' url_param=button_params query_params='?return_to='|add:CURRENT_PATH classes='govuk-button--secondary' %}
 							{% if can_set_done and case.case_type.reference.key != "comp_c" %}
-							{% test_rule 'can_user_move_case_forward' current_user case as can_user_move_case_forward %}
+							{% test_rule 'can_user_move_case_forward' request case as can_user_move_case_forward %}
                                 {% if can_user_move_case_forward %}
 									{% govuk_link_button id='done' text='cases.ApplicationPage.DONE_WITH_CASE' url='cases:done' url_param=button_params classes='govuk-button--secondary' hidden=hide_im_done %}
 								{% endif %}

--- a/caseworker/users/middleware.py
+++ b/caseworker/users/middleware.py
@@ -1,0 +1,18 @@
+from caseworker.users.services import get_gov_user
+
+
+class RequestUserMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        return response
+
+    def process_view(self, request, view_func, view_args, view_kwargs):
+        if "lite_api_user_id" not in request.session:
+            return
+        response_data, status_code = get_gov_user(request, str(request.session["lite_api_user_id"]))
+        if not status_code == 200:
+            return
+        request.user = response_data.get("user", None)

--- a/caseworker/users/middleware.py
+++ b/caseworker/users/middleware.py
@@ -15,4 +15,4 @@ class RequestUserMiddleware:
         response_data, status_code = get_gov_user(request, str(request.session["lite_api_user_id"]))
         if not status_code == 200:
             return
-        request.user = response_data.get("user", None)
+        request.lite_user = response_data.get("user", None)

--- a/conf/caseworker.py
+++ b/conf/caseworker.py
@@ -25,6 +25,10 @@ INSTALLED_APPS += [
     "rules.apps.AutodiscoverRulesConfig",
 ]
 
+MIDDLEWARE += [
+    "caseworker.queues.middleware.RequestQueueMiddleware",
+]
+
 if MOCK_SSO_ACTIVATE_ENDPOINTS:
     INSTALLED_APPS += [
         "caseworker.mock_sso",

--- a/conf/caseworker.py
+++ b/conf/caseworker.py
@@ -50,11 +50,10 @@ TEMPLATES = [
                 "django.template.context_processors.debug",
                 "django.template.context_processors.request",
                 "django.contrib.messages.context_processors.messages",
-                "caseworker.core.context_processors.current_queue",
+                "caseworker.core.context_processors.current_queue_and_user",
                 "caseworker.core.context_processors.export_vars",
                 "caseworker.core.context_processors.lite_menu",
                 "caseworker.core.context_processors.new_mentions",
-                "caseworker.core.context_processors.current_user"
                 "caseworker.core.context_processors.is_all_cases_queue",
                 "caseworker.core.context_processors.feature_flags",
             ],

--- a/conf/caseworker.py
+++ b/conf/caseworker.py
@@ -27,6 +27,7 @@ INSTALLED_APPS += [
 
 MIDDLEWARE += [
     "caseworker.queues.middleware.RequestQueueMiddleware",
+    "caseworker.users.middleware.RequestUserMiddleware",
 ]
 
 if MOCK_SSO_ACTIVATE_ENDPOINTS:
@@ -53,7 +54,7 @@ TEMPLATES = [
                 "caseworker.core.context_processors.export_vars",
                 "caseworker.core.context_processors.lite_menu",
                 "caseworker.core.context_processors.new_mentions",
-                "caseworker.core.context_processors.current_user",
+                "caseworker.core.context_processors.current_user"
                 "caseworker.core.context_processors.is_all_cases_queue",
                 "caseworker.core.context_processors.feature_flags",
             ],

--- a/unit_tests/caseworker/advice/test_rules.py
+++ b/unit_tests/caseworker/advice/test_rules.py
@@ -46,7 +46,7 @@ def test_can_user_make_recommendation_request_missing_attributes(mock_gov_user, 
     case = Case(data_standard_case["case"])
     request = None
 
-    assert not rules.test_rule("can_user_make_recommendation", request, case)
+    assert not advice_rules.can_user_make_recommendation(request, case)
 
 
 def test_can_user_make_recommendation_user_not_allocated(mock_gov_user, data_fake_queue, data_standard_case):
@@ -180,10 +180,10 @@ def test_can_user_make_recommendation_user_allocated_ncsc_queue_mismatch(
     assert not rules.test_rule("can_user_make_recommendation", request, data_assigned_case)
 
 
-def test_can_user_make_recommendation_when_allocated(mock_gov_user, data_fake_queue, data_standard_case):
-    # User satisfies `can_user_make_recommendation_when_allocated` criteria, but is not yet allocated
+def test_can_user_allocate_and_approve(mock_gov_user, data_fake_queue, data_standard_case):
+    # User satisfies `can_user_allocate_and_approve` criteria, but is not yet allocated
     case = Case(data_standard_case["case"])
     mock_gov_user["user"]["team"]["alias"] = services.NCSC_TEAM
     data_fake_queue["alias"] = services.NCSC_CASES_TO_REVIEW
     request = get_mock_request(mock_gov_user["user"], data_fake_queue)
-    assert rules.test_rule("can_user_make_recommendation_when_allocated", request, case)
+    assert rules.test_rule("can_user_allocate_and_approve", request, case)

--- a/unit_tests/caseworker/advice/test_rules.py
+++ b/unit_tests/caseworker/advice/test_rules.py
@@ -178,3 +178,12 @@ def test_can_user_make_recommendation_user_allocated_ncsc_queue_mismatch(
     data_fake_queue["alias"] = "mismatched-queue"
     request = get_mock_request(mock_gov_user["user"], data_fake_queue)
     assert not rules.test_rule("can_user_make_recommendation", request, data_assigned_case)
+
+
+def test_can_user_make_recommendation_when_allocated(mock_gov_user, data_fake_queue, data_standard_case):
+    # User satisfies `can_user_make_recommendation_when_allocated` criteria, but is not yet allocated
+    case = Case(data_standard_case["case"])
+    mock_gov_user["user"]["team"]["alias"] = services.NCSC_TEAM
+    data_fake_queue["alias"] = services.NCSC_CASES_TO_REVIEW
+    request = get_mock_request(mock_gov_user["user"], data_fake_queue)
+    assert rules.test_rule("can_user_make_recommendation_when_allocated", request, case)

--- a/unit_tests/caseworker/advice/test_rules.py
+++ b/unit_tests/caseworker/advice/test_rules.py
@@ -42,6 +42,13 @@ def get_mock_request(user, queue):
     return request
 
 
+def test_can_user_make_recommendation_request_missing_attributes(mock_gov_user, data_fake_queue, data_standard_case):
+    case = Case(data_standard_case["case"])
+    request = None
+
+    assert not rules.test_rule("can_user_make_recommendation", request, case)
+
+
 def test_can_user_make_recommendation_user_not_allocated(mock_gov_user, data_fake_queue, data_standard_case):
     case = Case(data_standard_case["case"])
     request = get_mock_request(mock_gov_user["user"], data_fake_queue)

--- a/unit_tests/caseworker/advice/test_rules.py
+++ b/unit_tests/caseworker/advice/test_rules.py
@@ -1,0 +1,173 @@
+from unittest import mock
+
+import pytest
+import rules
+
+from django.http import HttpRequest
+
+from caseworker.advice import rules as advice_rules
+from caseworker.advice import services
+from caseworker.cases.objects import Case
+
+
+mock_gov_user_id = "2a43805b-c082-47e7-9188-c8b3e1a83cb0"  # /PS-IGNORE
+
+
+@pytest.fixture
+def data_fake_queue():
+    return {
+        "id": "00000000-0000-0000-0000-000000000001",
+        "alias": "fake",
+        "name": "Fake queue",
+        "is_system_queue": False,
+        "countersigning_queue": None,
+    }
+
+
+@pytest.fixture
+def data_assigned_case(data_standard_case):
+    case = Case(data_standard_case["case"])
+    case.assigned_users = {
+        "fake queue": [
+            {"id": mock_gov_user_id},
+        ]
+    }
+    return case
+
+
+def get_mock_request(user, queue):
+    request = HttpRequest()
+    request.user = user
+    request.queue = queue
+    return request
+
+
+def test_can_user_make_recommendation_user_not_allocated(mock_gov_user, data_fake_queue, data_standard_case):
+    case = Case(data_standard_case["case"])
+    request = get_mock_request(mock_gov_user["user"], data_fake_queue)
+
+    assert not rules.test_rule("can_user_make_recommendation", request, case)
+
+
+@mock.patch("caseworker.advice.rules.services.get_my_advice")
+def test_can_user_make_recommendation_user_allocated_existing_advice(
+    mock_get_my_advice, mock_gov_user, data_fake_queue, data_assigned_case
+):
+    mock_get_my_advice.return_value = True
+    request = get_mock_request(mock_gov_user["user"], data_fake_queue)
+    assert not rules.test_rule("can_user_make_recommendation", request, data_assigned_case)
+
+
+@pytest.mark.parametrize(
+    "queue_alias",
+    (
+        services.FCDO_CASES_TO_REVIEW_QUEUE,
+        services.FCDO_CPACC_CASES_TO_REVIEW_QUEUE,
+    ),
+)
+def test_can_user_make_recommendation_user_allocated_fcdo_allow(
+    queue_alias, mock_gov_user, data_fake_queue, data_assigned_case
+):
+    mock_gov_user["user"]["team"]["alias"] = services.FCDO_TEAM
+    data_fake_queue["alias"] = queue_alias
+    request = get_mock_request(mock_gov_user["user"], data_fake_queue)
+    assert rules.test_rule("can_user_make_recommendation", request, data_assigned_case)
+
+
+def test_can_user_make_recommendation_user_allocated_fcdo_queue_mismatch(
+    mock_gov_user, data_fake_queue, data_assigned_case
+):
+    mock_gov_user["user"]["team"]["alias"] = services.FCDO_TEAM
+    data_fake_queue["alias"] = "some_queue"
+    request = get_mock_request(mock_gov_user["user"], data_fake_queue)
+    assert not rules.test_rule("can_user_make_recommendation", request, data_assigned_case)
+
+
+@mock.patch("caseworker.advice.rules.services.unadvised_countries")
+def test_can_user_make_recommendation_user_allocated_fcdo_all_countries_advised(
+    mock_unadvised_countries, mock_gov_user, data_fake_queue, data_assigned_case
+):
+    mock_unadvised_countries.return_value = [1, 2]
+    mock_gov_user["user"]["team"]["alias"] = services.FCDO_TEAM
+    data_fake_queue["alias"] = services.FCDO_CASES_TO_REVIEW_QUEUE
+    request = get_mock_request(mock_gov_user["user"], data_fake_queue)
+    assert rules.test_rule("can_user_make_recommendation", request, data_assigned_case)
+
+
+@pytest.mark.parametrize(
+    "queue_alias",
+    services.MOD_CONSOLIDATE_QUEUES,
+)
+def test_can_user_make_recommendation_user_allocated_mod_allow(
+    queue_alias, mock_gov_user, data_fake_queue, data_assigned_case
+):
+    mock_gov_user["user"]["team"]["alias"] = services.MOD_CONSOLIDATE_TEAMS[0]
+    data_fake_queue["alias"] = queue_alias
+    request = get_mock_request(mock_gov_user["user"], data_fake_queue)
+    assert rules.test_rule("can_user_make_recommendation", request, data_assigned_case)
+
+
+def test_can_user_make_recommendation_user_allocated_mod_queue_mismatch(
+    mock_gov_user, data_fake_queue, data_assigned_case
+):
+    mock_gov_user["user"]["team"]["alias"] = services.MOD_CONSOLIDATE_TEAMS[0]
+    data_fake_queue["alias"] = "some-mismatched-queue"
+    request = get_mock_request(mock_gov_user["user"], data_fake_queue)
+    assert not rules.test_rule("can_user_make_recommendation", request, data_assigned_case)
+
+
+def test_can_user_make_recommendation_user_allocated_beis_chemical_allow(
+    mock_gov_user, data_fake_queue, data_assigned_case
+):
+    mock_gov_user["user"]["team"]["alias"] = services.BEIS_TEAMS[0]
+    data_fake_queue["alias"] = services.BEIS_CHEMICAL_CASES_TO_REVIEW
+    request = get_mock_request(mock_gov_user["user"], data_fake_queue)
+    assert rules.test_rule("can_user_make_recommendation", request, data_assigned_case)
+
+
+def test_can_user_make_recommendation_user_allocated_beis_queue_mismatch(
+    mock_gov_user, data_fake_queue, data_assigned_case
+):
+    mock_gov_user["user"]["team"]["alias"] = services.BEIS_TEAMS[0]
+    data_fake_queue["alias"] = "some-mismatched-queue"
+    request = get_mock_request(mock_gov_user["user"], data_fake_queue)
+    assert not rules.test_rule("can_user_make_recommendation", request, data_assigned_case)
+
+
+@pytest.mark.parametrize(
+    "unassessed_trigger_list_goods_result, expected_permission_result",
+    (
+        ([], True),
+        ([1], False),
+    ),
+)
+@mock.patch("caseworker.advice.rules.services.unassessed_trigger_list_goods")
+def test_can_user_make_recommendation_user_allocated_beis_nuclear_trigger_list_goods(
+    mock_unassessed_trigger_list_goods,
+    unassessed_trigger_list_goods_result,
+    expected_permission_result,
+    mock_gov_user,
+    data_fake_queue,
+    data_assigned_case,
+):
+    mock_unassessed_trigger_list_goods.return_value = unassessed_trigger_list_goods_result
+    mock_gov_user["user"]["team"]["alias"] = services.BEIS_TEAMS[0]
+    data_fake_queue["alias"] = services.BEIS_NUCLEAR_CASES_TO_REVIEW
+    request = get_mock_request(mock_gov_user["user"], data_fake_queue)
+    assert rules.test_rule("can_user_make_recommendation", request, data_assigned_case) == expected_permission_result
+
+
+def test_can_user_make_recommendation_user_allocated_ncsc_allow(mock_gov_user, data_fake_queue, data_assigned_case):
+    mock_gov_user["user"]["team"]["alias"] = services.NCSC_TEAM
+    data_fake_queue["alias"] = services.NCSC_CASES_TO_REVIEW
+    request = get_mock_request(mock_gov_user["user"], data_fake_queue)
+    assert rules.test_rule("can_user_make_recommendation", request, data_assigned_case)
+
+
+def test_can_user_make_recommendation_user_allocated_ncsc_queue_mismatch(
+    mock_gov_user, data_fake_queue, data_assigned_case
+):
+    mock_gov_user["user"]["team"]["alias"] = services.NCSC_TEAM
+    data_fake_queue["alias"] = "mismatched-queue"
+    request = get_mock_request(mock_gov_user["user"], data_fake_queue)
+    assert not rules.test_rule("can_user_make_recommendation", request, data_assigned_case)

--- a/unit_tests/caseworker/advice/test_rules.py
+++ b/unit_tests/caseworker/advice/test_rules.py
@@ -37,7 +37,7 @@ def data_assigned_case(data_standard_case):
 
 def get_mock_request(user, queue):
     request = HttpRequest()
-    request.user = user
+    request.lite_user = user
     request.queue = queue
     return request
 

--- a/unit_tests/caseworker/advice/views/test_advice_view.py
+++ b/unit_tests/caseworker/advice/views/test_advice_view.py
@@ -15,6 +15,19 @@ def setup(
 
 
 @pytest.fixture
+def mock_beis_nuclear_queue(requests_mock):
+    data = {
+        "id": "00000000-0000-0000-0000-000000000001",
+        "alias": "BEIS_NUCLEAR_CASES_TO_REVIEW",
+        "name": "BEIS Nuclear",
+        "is_system_queue": True,
+        "countersigning_queue": None,
+    }
+    url = client._build_absolute_uri("/queues/566fd526-bd6d-40c1-94bd-60d10c967cf7/")
+    return requests_mock.get(url=url, json=data)
+
+
+@pytest.fixture
 def url(data_standard_case):
     return reverse(
         "cases:advice_view",
@@ -57,6 +70,7 @@ def test_advice_view_shows_no_assessed_trigger_list_goods_if_some_are_not_assess
     data_standard_case_with_potential_trigger_list_product,
     mock_gov_beis_nuclear_user,
     mock_application,
+    mock_beis_nuclear_queue,
     mock_gov_user,
     assign_user_to_case,
 ):
@@ -85,6 +99,7 @@ def test_advice_view_shows_assessed_trigger_list_goods_if_all_are_assessed(
     url,
     data_standard_case_with_all_trigger_list_products_assessed,
     mock_gov_beis_nuclear_user,
+    mock_beis_nuclear_queue,
     mock_application,
     mock_gov_user,
     assign_user_to_case,

--- a/unit_tests/caseworker/core/test_rules.py
+++ b/unit_tests/caseworker/core/test_rules.py
@@ -56,8 +56,22 @@ def test_is_user_assigned(data, mock_gov_user, expected_result):
     assert caseworker_rules.is_user_assigned(get_mock_request(mock_gov_user["user"]), assigned_users) == expected_result
 
 
+def test_is_user_assigned_request_missing_attribute():
+    assigned_users = {
+        "assigned_users": {
+            "fake queue": [
+                {"id": mock_gov_user_id},
+            ],
+            "fake queue 2": [
+                {"id": "12345zyz"},
+            ],
+        },
+    }
+    assert not caseworker_rules.is_user_assigned(None, assigned_users)
+
+
 def test_is_user_case_officer_none():
-    assert caseworker_rules.is_user_case_officer(get_mock_request(None), {"case_officer": None}) is False
+    assert not caseworker_rules.is_user_case_officer(get_mock_request(None), {"case_officer": None})
 
 
 @pytest.mark.parametrize(
@@ -70,6 +84,10 @@ def test_is_user_case_officer_none():
 )
 def test_is_user_case_officer(data, mock_gov_user, expected_result):
     assert caseworker_rules.is_user_case_officer(get_mock_request(mock_gov_user["user"]), data) == expected_result
+
+
+def test_is_user_case_officer_request_missing_attribute():
+    assert caseworker_rules.is_user_case_officer(None, {"case_officer": {"id": mock_gov_user_id}}) is False
 
 
 @pytest.mark.parametrize(

--- a/unit_tests/caseworker/core/test_rules.py
+++ b/unit_tests/caseworker/core/test_rules.py
@@ -1,10 +1,18 @@
 import pytest
 import rules
 
+from django.http import HttpRequest
+
 from caseworker.core import rules as caseworker_rules
 
 
 mock_gov_user_id = "2a43805b-c082-47e7-9188-c8b3e1a83cb0"  # /PS-IGNORE
+
+
+def get_mock_request(user):
+    request = HttpRequest()
+    request.user = user
+    return request
 
 
 @pytest.mark.parametrize(
@@ -45,11 +53,11 @@ mock_gov_user_id = "2a43805b-c082-47e7-9188-c8b3e1a83cb0"  # /PS-IGNORE
 )
 def test_is_user_assigned(data, mock_gov_user, expected_result):
     assigned_users = {"assigned_users": data}
-    assert caseworker_rules.is_user_assigned(mock_gov_user["user"], assigned_users) == expected_result
+    assert caseworker_rules.is_user_assigned(get_mock_request(mock_gov_user["user"]), assigned_users) == expected_result
 
 
 def test_is_user_case_officer_none():
-    assert caseworker_rules.is_user_case_adviser(None, {"case_officer": None}) is False
+    assert caseworker_rules.is_user_case_adviser(get_mock_request(None), {"case_officer": None}) is False
 
 
 @pytest.mark.parametrize(
@@ -61,7 +69,7 @@ def test_is_user_case_officer_none():
     ),
 )
 def test_is_user_case_officer(data, mock_gov_user, expected_result):
-    assert caseworker_rules.is_user_case_adviser(mock_gov_user["user"], data) == expected_result
+    assert caseworker_rules.is_user_case_adviser(get_mock_request(mock_gov_user["user"]), data) == expected_result
 
 
 @pytest.mark.parametrize(
@@ -119,13 +127,12 @@ def test_user_assignment_based_rules(data, mock_gov_user, expected_result):
         "can_user_move_case_forward",
         "can_user_review_and_countersign",
         "can_user_review_and_combine",
-        "can_user_make_recommendation",
         "can_user_assess_products",
         "can_user_add_an_ejcu_query",
         "can_user_generate_document",
         "can_user_add_contact",
     ):
-        assert rules.test_rule(rule_name, mock_gov_user["user"], data) == expected_result
+        assert rules.test_rule(rule_name, get_mock_request(mock_gov_user["user"]), data) == expected_result
 
 
 @pytest.mark.parametrize(
@@ -174,4 +181,4 @@ def test_user_assignment_based_rules(data, mock_gov_user, expected_result):
     ),
 )
 def test_can_user_attach_document(data, mock_gov_user):
-    assert rules.test_rule("can_user_attach_document", mock_gov_user["user"], data)
+    assert rules.test_rule("can_user_attach_document", get_mock_request(mock_gov_user["user"]), data)

--- a/unit_tests/caseworker/core/test_rules.py
+++ b/unit_tests/caseworker/core/test_rules.py
@@ -57,7 +57,7 @@ def test_is_user_assigned(data, mock_gov_user, expected_result):
 
 
 def test_is_user_case_officer_none():
-    assert caseworker_rules.is_user_case_adviser(get_mock_request(None), {"case_officer": None}) is False
+    assert caseworker_rules.is_user_case_officer(get_mock_request(None), {"case_officer": None}) is False
 
 
 @pytest.mark.parametrize(
@@ -69,7 +69,7 @@ def test_is_user_case_officer_none():
     ),
 )
 def test_is_user_case_officer(data, mock_gov_user, expected_result):
-    assert caseworker_rules.is_user_case_adviser(get_mock_request(mock_gov_user["user"]), data) == expected_result
+    assert caseworker_rules.is_user_case_officer(get_mock_request(mock_gov_user["user"]), data) == expected_result
 
 
 @pytest.mark.parametrize(

--- a/unit_tests/caseworker/core/test_rules.py
+++ b/unit_tests/caseworker/core/test_rules.py
@@ -11,7 +11,7 @@ mock_gov_user_id = "2a43805b-c082-47e7-9188-c8b3e1a83cb0"  # /PS-IGNORE
 
 def get_mock_request(user):
     request = HttpRequest()
-    request.user = user
+    request.lite_user = user
     return request
 
 

--- a/unit_tests/caseworker/external_data/test_views.py
+++ b/unit_tests/caseworker/external_data/test_views.py
@@ -123,9 +123,9 @@ def test_denial_revoke_submit(authorized_client, mock_denial_detail, mock_denial
     # when the denial revoke form is submitted
     response = authorized_client.post(url, {"comment": "abc"})
 
-    # then the denial is revoked
-    assert requests_mock.request_history[0].json() == {"is_revoked": True, "is_revoked_comment": "abc"}
-
     # and the user is redirected back to denial detail
     assert response.status_code == 302
     assert response.url == reverse("external_data:denial-detail", kwargs={"pk": denial_pk})
+
+    # then the denial is revoked
+    assert mock_denial_patch.last_request.json() == {"is_revoked": True, "is_revoked_comment": "abc"}

--- a/unit_tests/caseworker/queues/test_middleware.py
+++ b/unit_tests/caseworker/queues/test_middleware.py
@@ -1,0 +1,23 @@
+from unittest import mock
+
+from django.http import HttpRequest
+
+from caseworker.queues.middleware import RequestQueueMiddleware
+
+
+@mock.patch("caseworker.queues.middleware.get_queue")
+def test_request_queue_middleware_process_view_queue_pk_in_kwargs(mock_get_queue):
+    mock_get_queue.return_value = {"id": "some_queue"}
+    request = HttpRequest()
+    RequestQueueMiddleware(mock.Mock()).process_view(request, None, None, {"queue_pk": "test-queue-id"})
+    mock_get_queue.assert_called_with(request, "test-queue-id")
+    assert request.queue == mock_get_queue.return_value
+
+
+@mock.patch("caseworker.queues.middleware.get_queue")
+def test_request_queue_middleware_process_view_queue_pk_missing(mock_get_queue):
+    mock_get_queue.return_value = {"id": "some_queue"}
+    request = HttpRequest()
+    RequestQueueMiddleware(mock.Mock()).process_view(request, None, None, {})
+    mock_get_queue.assert_not_called()
+    assert not hasattr(request, "queue")

--- a/unit_tests/caseworker/users/test_middleware.py
+++ b/unit_tests/caseworker/users/test_middleware.py
@@ -11,7 +11,7 @@ def test_request_user_middleware_process_view_no_user_id_in_session(mock_get_gov
     request.session = {}
     RequestUserMiddleware(mock.Mock()).process_view(request, None, None, None)
     mock_get_gov_user.assert_not_called()
-    assert not hasattr(request, "user")
+    assert not hasattr(request, "lite_user")
 
 
 @mock.patch("caseworker.users.middleware.get_gov_user")
@@ -21,7 +21,7 @@ def test_request_queue_middleware_process_view_api_error(mock_get_gov_user):
     request.session = {"lite_api_user_id": "some-user-id"}
     RequestUserMiddleware(mock.Mock()).process_view(request, None, None, None)
     mock_get_gov_user.assert_called_with(request, "some-user-id")
-    assert not hasattr(request, "user")
+    assert not hasattr(request, "lite_user")
 
 
 @mock.patch("caseworker.users.middleware.get_gov_user")
@@ -31,4 +31,4 @@ def test_request_queue_middleware_process_view_success(mock_get_gov_user):
     request.session = {"lite_api_user_id": "some-user-id"}
     RequestUserMiddleware(mock.Mock()).process_view(request, None, None, None)
     mock_get_gov_user.assert_called_with(request, "some-user-id")
-    assert request.user == "some-user"
+    assert request.lite_user == "some-user"

--- a/unit_tests/caseworker/users/test_middleware.py
+++ b/unit_tests/caseworker/users/test_middleware.py
@@ -1,0 +1,34 @@
+from unittest import mock
+
+from django.http import HttpRequest
+
+from caseworker.users.middleware import RequestUserMiddleware
+
+
+@mock.patch("caseworker.users.middleware.get_gov_user")
+def test_request_user_middleware_process_view_no_user_id_in_session(mock_get_gov_user):
+    request = HttpRequest()
+    request.session = {}
+    RequestUserMiddleware(mock.Mock()).process_view(request, None, None, None)
+    mock_get_gov_user.assert_not_called()
+    assert not hasattr(request, "user")
+
+
+@mock.patch("caseworker.users.middleware.get_gov_user")
+def test_request_queue_middleware_process_view_api_error(mock_get_gov_user):
+    mock_get_gov_user.return_value = ({}, 500)
+    request = HttpRequest()
+    request.session = {"lite_api_user_id": "some-user-id"}
+    RequestUserMiddleware(mock.Mock()).process_view(request, None, None, None)
+    mock_get_gov_user.assert_called_with(request, "some-user-id")
+    assert not hasattr(request, "user")
+
+
+@mock.patch("caseworker.users.middleware.get_gov_user")
+def test_request_queue_middleware_process_view_success(mock_get_gov_user):
+    mock_get_gov_user.return_value = ({"user": "some-user"}, 200)
+    request = HttpRequest()
+    request.session = {"lite_api_user_id": "some-user-id"}
+    RequestUserMiddleware(mock.Mock()).process_view(request, None, None, None)
+    mock_get_gov_user.assert_called_with(request, "some-user-id")
+    assert request.user == "some-user"


### PR DESCRIPTION
### Aim

This PR adds a button "Allocate to me and approve" to the new quick summary tab on the case detail page.  The quick summary tab is still feature flagged.

In order to re-use the logic for showing/hiding the "Make recommendation" button, it was necessary to absorb this logic in to django rules.  This meant the following changes;
- Logic for showing "Make recommendation" on the "view advice" template has been reworked such that there is a single predicate `can_user_make_recommendation` using a django rule.
    - Previously, this logic was distributed throughout views/context helpers so the old logic has been extracted.
- It was necessary for the new rules function to be based on `user`, `case` AND `queue`.  Django rules functions can only take two arguments, so the decision was made to refactor all our existing rules functions to take `request` as the first argument (previously `user`).
    - `request` therefore needed a handle to both `user` and `queue` so two middlewares were added to populate these attributes.

[LTD-3673](https://uktrade.atlassian.net/browse/LTD-3673)


[LTD-3673]: https://uktrade.atlassian.net/browse/LTD-3673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ