### PR TITLE
Replace selenium submit clicks with JS

### DIFF
--- a/ui_tests/caseworker/conftest.py
+++ b/ui_tests/caseworker/conftest.py
@@ -916,7 +916,7 @@ def fill_report_summary_select_regime_none_and_submit(driver, prefix, subject): 
 @when("I click submit recommendation")  # noqa
 @when("I click save and publish to exporter")  # noqa
 def submit_form(driver):  # noqa
-    Shared(driver).click_submit()
+    functions.click_submit(driver)
 
 
 @then(parsers.parse('I select the CLE "{control_code}"'))

--- a/ui_tests/caseworker/pages/application_page.py
+++ b/ui_tests/caseworker/pages/application_page.py
@@ -100,9 +100,7 @@ class ApplicationPage(BasePage):
                 (By.CSS_SELECTOR, f"#{self.BUTTON_POST_NOTE_ID}:not([disabled])")
             )
         )
-        old_page = self.driver.find_element(by=By.TAG_NAME, value="html")
-        self.driver.find_element(by=By.ID, value=self.BUTTON_POST_NOTE_ID).click()
-        WebDriverWait(self.driver, 45).until(expected_conditions.staleness_of(old_page))
+        functions.click_submit(self.driver)
 
     def click_cancel_btn(self):
         WebDriverWait(self.driver, 30).until(


### PR DESCRIPTION
### Aim

This fixes flakiness in clicking the submit button during the case notes test and advice tests.  It swaps out selenium driver's `click()` for a javascript "scroll to"/"click"
