### PR TITLE
LTD-3705-mentions-grouping 

### DIFF
--- a/caseworker/activities/templates/activities/notes-and-timeline.html
+++ b/caseworker/activities/templates/activities/notes-and-timeline.html
@@ -48,7 +48,7 @@
             <nav class="notes-and-timeline-nav">
                 <ul class="notes-and-timeline-nav__list notes-and-timeline-nav__mentions">
                     <li class="notes-and-timeline-nav__list-item{% if "mentions" in filtering_by %} notes-and-timeline-nav__list-item--selected{% endif %}">
-                        <a class="notes-and-timeline-nav__list-link" href="{% url 'cases:activities:notes-and-timeline' pk=case.id queue_pk=queue.id %}?mentions=True">
+                        <a class="notes-and-timeline-nav__list-link" href="{% url 'cases:activities:notes-and-timeline' pk=case.id queue_pk=queue.id %}?mentions=True&activity_type=created_case_note_with_mentions">
                             <span class="notes-and-timeline-nav__list-link-wrapper">
                                 Mentions
                             </span>
@@ -66,24 +66,6 @@
             </div>
             <div class="govuk-grid-row">
                 <div class="notes-and-timeline-timeline">
-                    {% if "mentions" in filtering_by %}
-                        {% regroup mentions by created_at|to_datetime|date:"d F Y" as mentions_list %}
-                        {% for mentions_by_date in mentions_list %}
-                             <div class="notes-and-timeline-timeline__day-group">
-                                 <h2 class="notes-and-timeline-timeline__day-group-heading">{{ mentions_by_date.grouper }}</h2>
-
-                                     {% for mention in mentions_by_date.list %}
-                                     <div class="notes-and-timeline-timeline__day-group-item">
-                                            {% if mention.case_note_user.team %}<span class="app-activity__item__user">{{ mention.case_note_user.team.name }}:</span> {% endif %}{{ mention.case_note_user.first_name }} {{ mention.case_note_user.last_name }}
-                                            sent a case note to {{ mention.user.first_name }} {{ mention.user.last_name }} ({{mention.user.team.name}}){% if mention.is_urgent %} <p class="warning-text mentions__urgent">URGENT</p> {% endif %}
-                                            <div class="notes-and-timeline-timeline__day-group-note">
-                                                {{ mention.case_note_text|linebreaks }}
-                                            </div>
-                                     </div>
-                                 {% endfor %}
-                             </div>
-                        {% endfor %}
-                    {% else %}
                         {% regroup activities by created_at|to_datetime|date:"d F Y" as activity_list %}
                         {% for activities_by_date in activity_list %}
                             <div class="notes-and-timeline-timeline__day-group">
@@ -113,7 +95,6 @@
                                 {% endfor %}
                             </div>
                         {% endfor %}
-                    {% endif%}
                 </div>
             </div>
         </div>

--- a/caseworker/activities/views.py
+++ b/caseworker/activities/views.py
@@ -94,12 +94,6 @@ class NotesAndTimeline(LoginRequiredMixin, CaseTabsMixin, CaseworkerMixin, FormV
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        if "mentions" in list(self.request.GET.keys()):
-            # add to context the list of CaseNotes with mentions.
-            context.update({"mentions": self.mentions})
-        else:
-            activities = get_activity(self.request, self.case_id, activity_filters=self.request.GET)
-            context.update({"activities": activities})
         return {
             **context,
             "case": self.case,
@@ -108,6 +102,7 @@ class NotesAndTimeline(LoginRequiredMixin, CaseTabsMixin, CaseworkerMixin, FormV
             "team_filters": self.get_team_filters(),
             "tabs": self.get_standard_application_tabs(),
             "current_tab": "cases:activities:notes-and-timeline",
+            "activities": get_activity(self.request, self.case_id, activity_filters=self.request.GET),
             "FEATURE_MENTIONS_ENABLED": settings.FEATURE_MENTIONS_ENABLED,
         }
 

--- a/unit_tests/caseworker/activities/test_views.py
+++ b/unit_tests/caseworker/activities/test_views.py
@@ -288,6 +288,27 @@ def test_notes_and_timelines_post_valid(
         assertTemplateUsed(response, template_used)
 
 
+def test_notes_and_timelines_filter_by_mentions(
+    authorized_client,
+    notes_and_timelines_url,
+    mock_standard_case_activity_system_user,
+    requests_mock,
+    mock_gov_users,
+    mock_case_note_mentions,
+):
+    requests_mock.get(
+        client._build_absolute_uri(f"/gov-users/"),
+        json={
+            "results": mock_gov_users,
+        },
+    )
+
+    authorized_client.get(f"{notes_and_timelines_url}?mentions=True&activity_type=created_case_note_with_mentions")
+    assert mock_standard_case_activity_system_user.last_request.qs["activity_type"] == [
+        "created_case_note_with_mentions"
+    ]
+
+
 def test_notes_and_timelines_mentions_urgent(
     authorized_client,
     requests_mock,
@@ -301,20 +322,6 @@ def test_notes_and_timelines_mentions_urgent(
 
     soup = BeautifulSoup(response.content, "html.parser")
     assert soup.find(class_="warning-text mentions__urgent")
-
-
-def test_notes_and_timelines_mentions(
-    authorized_client, notes_and_timelines_url, mock_case_note_mentions, mentions_data, requests_mock, mock_gov_users
-):
-    requests_mock.get(
-        client._build_absolute_uri(f"/gov-users/"),
-        json={
-            "results": mock_gov_users,
-        },
-    )
-    response = authorized_client.get(f"{notes_and_timelines_url}?mentions=True")
-    assert response.context["mentions"][0]["id"] == mentions_data["results"][0]["id"]
-    assert not response.context.get("activities")
 
 
 def test_notes_and_timelines_mentions_template(


### PR DESCRIPTION
This turns the routing tab in N&T into a filter for activity. 
Since this displays the correct text as per N&T and no live mentions data is required. 
https://uktrade.atlassian.net/browse/LTD-3705