### PR TITLE
LTD-3696-Condition-bug-fix

### DIFF
--- a/caseworker/advice/services.py
+++ b/caseworker/advice/services.py
@@ -368,6 +368,7 @@ def update_advice(request, case, caseworker, advice_type, data, level):
                 "id": advice["id"],
                 "text": data["approval_reasons"],
                 "proviso": data["proviso"],
+                "type": "proviso" if data["proviso"] else "approve",
             }
             for advice in consolidated_advice
         ]

--- a/unit_tests/caseworker/advice/views/test_consolidate_edit.py
+++ b/unit_tests/caseworker/advice/views/test_consolidate_edit.py
@@ -263,7 +263,6 @@ def test_edit_consolidated_advice_approve_by_lu_put(
     url,
     consolidated_advice,
 ):
-
     case_data = data_standard_case
     case_data["case"]["advice"] = consolidated_advice
 
@@ -279,11 +278,7 @@ def test_edit_consolidated_advice_approve_by_lu_put(
     history = requests_mock.request_history.pop()
     assert history.method == "PUT"
     assert history.json() == [
-        {
-            "id": advice["id"],
-            "text": data["approval_reasons"],
-            "proviso": data["proviso"],
-        }
+        {"id": advice["id"], "text": data["approval_reasons"], "proviso": data["proviso"], "type": "proviso"}
         for advice in consolidated_advice
     ]
 
@@ -333,7 +328,6 @@ def test_edit_consolidated_advice_by_LU_error_from_API(
     url,
     consolidated_advice,
 ):
-
     case_data = data_standard_case
     case_data["case"]["advice"] = consolidated_advice
 


### PR DESCRIPTION
### Aim
(LU) edited their recommendation and added conditions later on. Initially there was no conditions. These conditions were originally added by some other team (MoD) so they edited their final advice and added these conditions later.

If you add conditions then the advice type becomes PROVISO but in this case it is still as APPROVE which is why they are not showing up in the document


### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/LTD-3696
- [x] Jira ticket has the correct status.