### PR TITLE
Ensure failed get_queue() call does not prevent user logins

### DIFF
--- a/caseworker/queues/middleware.py
+++ b/caseworker/queues/middleware.py
@@ -11,4 +11,7 @@ class RequestQueueMiddleware:
 
     def process_view(self, request, view_func, view_args, view_kwargs):
         if view_kwargs.get("queue_pk"):
-            request.queue = get_queue(request, view_kwargs["queue_pk"])
+            try:
+                request.queue = get_queue(request, view_kwargs["queue_pk"])
+            except Exception:
+                return

--- a/caseworker/queues/middleware.py
+++ b/caseworker/queues/middleware.py
@@ -10,8 +10,7 @@ class RequestQueueMiddleware:
         return response
 
     def process_view(self, request, view_func, view_args, view_kwargs):
+        if "lite_api_user_id" not in request.session:
+            return
         if view_kwargs.get("queue_pk"):
-            try:
-                request.queue = get_queue(request, view_kwargs["queue_pk"])
-            except Exception:
-                return
+            request.queue = get_queue(request, view_kwargs["queue_pk"])

--- a/unit_tests/caseworker/queues/test_middleware.py
+++ b/unit_tests/caseworker/queues/test_middleware.py
@@ -10,6 +10,7 @@ from caseworker.queues.middleware import RequestQueueMiddleware
 def test_request_queue_middleware_process_view_queue_pk_in_kwargs(mock_get_queue):
     mock_get_queue.return_value = {"id": "some_queue"}
     request = HttpRequest()
+    request.session = {"lite_api_user_id": "fake-user-id"}
     RequestQueueMiddleware(mock.Mock()).process_view(request, None, None, {"queue_pk": "test-queue-id"})
     mock_get_queue.assert_called_with(request, "test-queue-id")
     assert request.queue == mock_get_queue.return_value
@@ -19,6 +20,7 @@ def test_request_queue_middleware_process_view_queue_pk_in_kwargs(mock_get_queue
 def test_request_queue_middleware_process_view_queue_pk_missing(mock_get_queue):
     mock_get_queue.return_value = {"id": "some_queue"}
     request = HttpRequest()
+    request.session = {"lite_api_user_id": "fake-user-id"}
     RequestQueueMiddleware(mock.Mock()).process_view(request, None, None, {})
     mock_get_queue.assert_not_called()
     assert not hasattr(request, "queue")
@@ -26,8 +28,9 @@ def test_request_queue_middleware_process_view_queue_pk_missing(mock_get_queue):
 
 @mock.patch("caseworker.queues.middleware.get_queue")
 def test_request_queue_middleware_process_view_queue_request_403s(mock_get_queue):
-    mock_get_queue.side_effect = HTTPError("Client error: 403")
+    mock_get_queue.return_value = {"id": "some_queue"}
     request = HttpRequest()
-    RequestQueueMiddleware(mock.Mock()).process_view(request, None, None, {})
+    request.session = {}
+    RequestQueueMiddleware(mock.Mock()).process_view(request, None, None, {"queue_pk": "test-queue-id"})
     mock_get_queue.assert_not_called()
     assert not hasattr(request, "queue")


### PR DESCRIPTION
### Aim

Hotfix to resolve issue where logged out users would get a 500 error page when going to a queue page e.g. /queues/00000000-0000-0000-0000-000000000001/

Prior to this fix, the middleware would not handle an exception raised by `get_queue()` when the requesting user was logged out.

[LTD-](https://uktrade.atlassian.net/browse/LTD-)
