### PR TITLE
Fix flaky E2E tests

### DIFF
--- a/caseworker/templates/users/profile.html
+++ b/caseworker/templates/users/profile.html
@@ -78,7 +78,7 @@
 				{% lcs 'users.UserProfile.SummaryList.TEAM' %}
 			</dt>
 			<dd class="govuk-summary-list__value">
-				<a href="{% url 'teams:team' data.user.team.id %}" class="govuk-link govuk-link--no-visited-state">{{ data.user.team.name }}</a>
+				<a href="{% url 'teams:team' data.user.team.id %}" id="user-team-name" class="govuk-link govuk-link--no-visited-state">{{ data.user.team.name }}</a>
 			</dd>
 			<dd class="govuk-summary-list__actions">
 				<a id="link-edit-team" href="{% url 'users:edit' data.user.id %}#team" class="govuk-link govuk-link--no-visited-state">
@@ -107,7 +107,7 @@
 			<dt class="govuk-summary-list__key">
 				{% lcs 'users.UserProfile.SummaryList.DEFAULT_QUEUE' %}
 			</dt>
-			<dd class="govuk-summary-list__value">
+			<dd class="govuk-summary-list__value" id="user-default-queue">
 				{{ data.user.default_queue.name }}
 			</dd>
 			<dd class="govuk-summary-list__actions">

--- a/ui_tests/caseworker/conftest.py
+++ b/ui_tests/caseworker/conftest.py
@@ -331,6 +331,11 @@ def go_to_team_edit_page(driver, team, queue):  # noqa
     teams_page.select_team_from_dropdown(team)
     teams_page.select_default_queue_from_dropdown(queue)
     functions.click_submit(driver)
+    # Ensure we return to the profile page
+    WebDriverWait(driver, 30).until(expected_conditions.presence_of_element_located((By.ID, "link-edit-team")))
+    # Check that the team/queue change was applied successfully
+    assert driver.find_element(by=By.ID, value="user-team-name").text == team
+    assert driver.find_element(by=By.ID, value="user-default-queue").text == queue
 
 
 @when("I go to my case list")  # noqa


### PR DESCRIPTION
### Aim

Various "give advice" E2E tests would occasionally fail in a weird spot after trying to click on a previously created case.  After some thorough debugging it seemed like the preceeding step to change team/queue was occasionally not being applied fully; so that the test would be looking for the case on the wrong queue.

This change firms up the "change team and queue" step so that it waits for the submission to complete and asserts that the team/queue was changed correctly.
