### PR TITLE
[LTD-3798] Applicant filters

### DIFF
--- a/caseworker/assets/javascripts/case-filters.js
+++ b/caseworker/assets/javascripts/case-filters.js
@@ -133,6 +133,15 @@ const initCountryAutocompleteField = () => {
     .then((countries) => initAutoCompleteField("country", countries, "id"));
 };
 
+const initOrganisationSiteCountryAutocompleteField = () => {
+  fetch("/api/countries/")
+    .then((response) => response.json())
+    .then((results) => results["countries"])
+    .then((countries) =>
+      initAutoCompleteField("organisation_site_country", countries, "id")
+    );
+};
+
 const initRegimeEntryAutocompleteField = () => {
   fetch("/api/regime-entries/")
     .then((response) => response.json())
@@ -143,6 +152,7 @@ const initRegimeEntryAutocompleteField = () => {
 
 const initCaseFilters = () => {
   initCountryAutocompleteField();
+  initOrganisationSiteCountryAutocompleteField();
   initRegimeEntryAutocompleteField();
   accessibleAutocomplete.enhanceSelectElement({
     defaultValue: "",

--- a/caseworker/assets/javascripts/case-filters.js
+++ b/caseworker/assets/javascripts/case-filters.js
@@ -133,15 +133,6 @@ const initCountryAutocompleteField = () => {
     .then((countries) => initAutoCompleteField("country", countries, "id"));
 };
 
-const initOrganisationSiteCountryAutocompleteField = () => {
-  fetch("/api/countries/")
-    .then((response) => response.json())
-    .then((results) => results["countries"])
-    .then((countries) =>
-      initAutoCompleteField("organisation_site_country", countries, "id")
-    );
-};
-
 const initRegimeEntryAutocompleteField = () => {
   fetch("/api/regime-entries/")
     .then((response) => response.json())
@@ -152,7 +143,6 @@ const initRegimeEntryAutocompleteField = () => {
 
 const initCaseFilters = () => {
   initCountryAutocompleteField();
-  initOrganisationSiteCountryAutocompleteField();
   initRegimeEntryAutocompleteField();
   accessibleAutocomplete.enhanceSelectElement({
     defaultValue: "",

--- a/caseworker/queues/views/forms.py
+++ b/caseworker/queues/views/forms.py
@@ -40,9 +40,10 @@ class CasesFiltersForm(forms.Form):
         label="Site name",
         required=False,
     )
-    organisation_site_country = forms.CharField(
-        label="Organisation country",
+    goods_starting_point = forms.ChoiceField(
+        label="Shipping from",
         required=False,
+        choices=(("", ""), ("GB", "Great Britain"), ("NI", "Northern Ireland")),
     )
     party_name = forms.CharField(
         label="Party name",
@@ -238,7 +239,7 @@ class CasesFiltersForm(forms.Form):
                     "Applicant",
                     Field.text("organisation_name"),
                     Field.text("exporter_site_name"),
-                    Field.text("organisation_site_country"),
+                    Field.select("goods_starting_point"),
                 ),
                 AccordionSection(
                     "Parties",

--- a/caseworker/queues/views/forms.py
+++ b/caseworker/queues/views/forms.py
@@ -37,7 +37,7 @@ class CasesFiltersForm(forms.Form):
         required=False,
     )
     exporter_site_name = forms.CharField(
-        label="Exporter site name",
+        label="Site name",
         required=False,
     )
     organisation_site_country = forms.CharField(

--- a/caseworker/queues/views/forms.py
+++ b/caseworker/queues/views/forms.py
@@ -40,8 +40,8 @@ class CasesFiltersForm(forms.Form):
         label="Exporter site name",
         required=False,
     )
-    exporter_site_address = forms.CharField(
-        label="Exporter site address",
+    organisation_site_country = forms.CharField(
+        label="Organisation country",
         required=False,
     )
     party_name = forms.CharField(
@@ -236,10 +236,9 @@ class CasesFiltersForm(forms.Form):
                 ),
                 AccordionSection(
                     "Applicant",
-                    Field.text("exporter_application_reference"),
                     Field.text("organisation_name"),
                     Field.text("exporter_site_name"),
-                    Field.text("exporter_site_address"),
+                    Field.text("organisation_site_country"),
                 ),
                 AccordionSection(
                     "Parties",

--- a/unit_tests/caseworker/queues/views/test_cases.py
+++ b/unit_tests/caseworker/queues/views/test_cases.py
@@ -179,6 +179,23 @@ def test_cases_home_page_control_list_entries_search(authorized_client, mock_cas
     }
 
 
+def test_cases_home_page_organisation_site_country_search(authorized_client, mock_cases_search):
+    url = reverse("queues:cases")
+    response = authorized_client.get(url)
+    html = BeautifulSoup(response.content, "html.parser")
+    control_list_entry_filter_input = html.find(id="id_organisation_site_country")
+    assert control_list_entry_filter_input.attrs["type"] == "text"
+    assert control_list_entry_filter_input.attrs["name"] == "organisation_site_country"
+
+    url = reverse("queues:cases") + "?organisation_site_country=NL"
+    response = authorized_client.get(url)
+    assert response.status_code == 200
+    assert mock_cases_search.last_request.qs == {
+        **default_params,
+        "organisation_site_country": ["nl"],
+    }
+
+
 def test_cases_home_page_trigger_list_search(authorized_client, mock_cases_search):
     url = reverse("queues:cases") + "?is_trigger_list=True"
     authorized_client.get(url)

--- a/unit_tests/caseworker/queues/views/test_cases.py
+++ b/unit_tests/caseworker/queues/views/test_cases.py
@@ -179,20 +179,19 @@ def test_cases_home_page_control_list_entries_search(authorized_client, mock_cas
     }
 
 
-def test_cases_home_page_organisation_site_country_search(authorized_client, mock_cases_search):
+def test_cases_home_page_goods_starting_point_search(authorized_client, mock_cases_search):
     url = reverse("queues:cases")
     response = authorized_client.get(url)
     html = BeautifulSoup(response.content, "html.parser")
-    control_list_entry_filter_input = html.find(id="id_organisation_site_country")
-    assert control_list_entry_filter_input.attrs["type"] == "text"
-    assert control_list_entry_filter_input.attrs["name"] == "organisation_site_country"
+    control_list_entry_filter_input = html.find(id="id_goods_starting_point")
+    assert control_list_entry_filter_input.attrs["name"] == "goods_starting_point"
 
-    url = reverse("queues:cases") + "?organisation_site_country=NL"
+    url = reverse("queues:cases") + "?goods_starting_point=NI"
     response = authorized_client.get(url)
     assert response.status_code == 200
     assert mock_cases_search.last_request.qs == {
         **default_params,
-        "organisation_site_country": ["nl"],
+        "goods_starting_point": ["ni"],
     }
 
 


### PR DESCRIPTION
### Aim

Improve "Applicant" queue view filters accordion as follows;
- Drop "exporter site address" filter field.
- ~~Add "Organisation country" filter field (autocomplete); which depends on the following backend PR https://github.com/uktrade/lite-api/pull/1476~~
- Add "Shipping from" select field; maps to `goods_starting_point` on backend PR https://github.com/uktrade/lite-api/pull/1476
- Rename other applicant field labels.

[LTD-3798](https://uktrade.atlassian.net/browse/LTD-3798)


[LTD-3798]: https://uktrade.atlassian.net/browse/LTD-3798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ