### PR TITLE
[LTD-3799] Parties filters

### DIFF
--- a/caseworker/queues/views/forms.py
+++ b/caseworker/queues/views/forms.py
@@ -81,6 +81,12 @@ class CasesFiltersForm(forms.Form):
         label="Finalised to date",
         required=False,
     )
+    exclude_denial_matches = forms.TypedChoiceField(
+        choices=[(True, "Exclude denial matches")],
+        label="",
+        widget=CheckboxInputSmall(),
+        required=False,
+    )
 
     def get_field_choices(self, filters_data, field):
         return [("", "Select")] + [(choice["key"], choice["value"]) for choice in filters_data.get(field, [])]
@@ -204,6 +210,7 @@ class CasesFiltersForm(forms.Form):
                     "Parties",
                     Field.text("country"),
                     Field.text("party_name"),
+                    Field("exclude_denial_matches"),
                 ),
                 css_id="accordion-1",
             ),

--- a/caseworker/queues/views/forms.py
+++ b/caseworker/queues/views/forms.py
@@ -94,8 +94,6 @@ class CasesFiltersForm(forms.Form):
             (choice["id"], choice["full_name"]) for choice in filters_data["gov_users"]
         ]
 
-        sla_days_choices = [("", "Select")] + [(i, i) for i in range(SLA_DAYS_RANGE)]
-        sla_sorted_choices = [("", "Select"), ("ascending", "Ascending"), ("descending", "Descending")]
         nca_choices = [(True, "Filter by Nuclear Cooperation Agreement")]
         trigger_list_guidelines_choices = [(True, "Filter by trigger list")]
         flags_choices = [(flag["id"], flag["name"]) for flag in all_flags]
@@ -124,41 +122,6 @@ class CasesFiltersForm(forms.Form):
             required=False,
         )
 
-        self.fields["team_advice_type"] = forms.ChoiceField(
-            label="Team advice type",
-            choices=advice_type_choices,
-            required=False,
-        )
-
-        self.fields["final_advice_type"] = forms.ChoiceField(
-            label="Final advice type",
-            choices=advice_type_choices,
-            required=False,
-        )
-
-        self.fields["max_sla_days_remaining"] = forms.ChoiceField(
-            label="Max SLA days remaining",
-            choices=sla_days_choices,
-            required=False,
-        )
-
-        self.fields["min_sla_days_remaining"] = forms.ChoiceField(
-            label="Min SLA days remaining",
-            choices=sla_days_choices,
-            required=False,
-        )
-
-        self.fields["sla_days_elapsed"] = forms.ChoiceField(
-            label="SLA days elapsed",
-            choices=sla_days_choices,
-            required=False,
-        )
-
-        self.fields["sla_days_elapsed_sort_order"] = forms.ChoiceField(
-            label="Sorted by SLA days",
-            choices=sla_sorted_choices,
-            required=False,
-        )
         self.fields["flags"] = forms.MultipleChoiceField(
             label="Flags",
             choices=flags_choices,
@@ -241,15 +204,6 @@ class CasesFiltersForm(forms.Form):
                     "Parties",
                     Field.text("country"),
                     Field.text("party_name"),
-                ),
-                AccordionSection(
-                    "Misc",
-                    Field.select("team_advice_type"),
-                    Field.select("final_advice_type"),
-                    Field.select("max_sla_days_remaining"),
-                    Field.select("min_sla_days_remaining"),
-                    Field.select("sla_days_elapsed"),
-                    Field.select("sla_days_elapsed_sort_order"),
                 ),
                 css_id="accordion-1",
             ),

--- a/caseworker/queues/views/forms.py
+++ b/caseworker/queues/views/forms.py
@@ -49,10 +49,6 @@ class CasesFiltersForm(forms.Form):
         label="Party name",
         required=False,
     )
-    party_address = forms.CharField(
-        label="Party address",
-        required=False,
-    )
     goods_related_description = forms.CharField(
         label="Goods related description",
         required=False,
@@ -243,9 +239,8 @@ class CasesFiltersForm(forms.Form):
                 ),
                 AccordionSection(
                     "Parties",
-                    Field.text("party_name"),
-                    Field.text("party_address"),
                     Field.text("country"),
+                    Field.text("party_name"),
                 ),
                 AccordionSection(
                     "Misc",

--- a/caseworker/queues/views/forms.py
+++ b/caseworker/queues/views/forms.py
@@ -87,6 +87,12 @@ class CasesFiltersForm(forms.Form):
         widget=CheckboxInputSmall(),
         required=False,
     )
+    exclude_sanction_matches = forms.TypedChoiceField(
+        choices=[(True, "Exclude sanction matches")],
+        label="",
+        widget=CheckboxInputSmall(),
+        required=False,
+    )
 
     def get_field_choices(self, filters_data, field):
         return [("", "Select")] + [(choice["key"], choice["value"]) for choice in filters_data.get(field, [])]
@@ -211,6 +217,7 @@ class CasesFiltersForm(forms.Form):
                     Field.text("country"),
                     Field.text("party_name"),
                     Field("exclude_denial_matches"),
+                    Field("exclude_sanction_matches"),
                 ),
                 css_id="accordion-1",
             ),

--- a/caseworker/queues/views/forms.py
+++ b/caseworker/queues/views/forms.py
@@ -101,7 +101,6 @@ class CasesFiltersForm(forms.Form):
         super().__init__(*args, **kwargs)
 
         case_status_choices = self.get_field_choices(filters_data, "statuses")
-        advice_type_choices = self.get_field_choices(filters_data, "advice_types")
         gov_user_choices = [("", "Select"), ("not_assigned", "Not assigned")] + [
             (choice["id"], choice["full_name"]) for choice in filters_data["gov_users"]
         ]

--- a/unit_tests/caseworker/queues/views/test_cases.py
+++ b/unit_tests/caseworker/queues/views/test_cases.py
@@ -237,6 +237,15 @@ def test_cases_home_page_regime_entry_search(authorized_client, mock_cases_searc
     }
 
 
+def test_cases_home_page_exlude_denial_matches_search(authorized_client, mock_cases_search):
+    url = reverse("queues:cases") + "?exclude_denial_matches=True"
+    authorized_client.get(url)
+    assert mock_cases_search.last_request.qs == {
+        **default_params,
+        "exclude_denial_matches": ["true"],
+    }
+
+
 def test_trigger_list_checkbox_visible_unchecked(authorized_client):
     response = authorized_client.get(reverse("core:index"))
     html = BeautifulSoup(response.content, "html.parser")

--- a/unit_tests/caseworker/queues/views/test_cases.py
+++ b/unit_tests/caseworker/queues/views/test_cases.py
@@ -122,7 +122,31 @@ def test_cases_home_page_view_context(authorized_client):
     ]
     response = authorized_client.get(reverse("queues:cases"))
     assert isinstance(response.context["form"], CasesFiltersForm)
-    assert len(response.context["form"].fields) == 30
+    assert [field_name for field_name, _ in response.context["form"].fields.items()] == [
+        "case_reference",
+        "export_type",
+        "exporter_application_reference",
+        "organisation_name",
+        "exporter_site_name",
+        "exporter_site_address",
+        "party_name",
+        "goods_related_description",
+        "country",
+        "control_list_entry",
+        "regime_entry",
+        "submitted_from",
+        "submitted_to",
+        "finalised_from",
+        "finalised_to",
+        "status",
+        "case_officer",
+        "assigned_user",
+        "flags",
+        "assigned_queues",
+        "is_nca_applicable",
+        "is_trigger_list",
+        "return_to",
+    ]
     for context_key in context_keys:
         assert response.context[context_key]
     assert response.status_code == 200

--- a/unit_tests/caseworker/queues/views/test_cases.py
+++ b/unit_tests/caseworker/queues/views/test_cases.py
@@ -128,7 +128,7 @@ def test_cases_home_page_view_context(authorized_client):
         "exporter_application_reference",
         "organisation_name",
         "exporter_site_name",
-        "exporter_site_address",
+        "goods_starting_point",
         "party_name",
         "goods_related_description",
         "country",
@@ -138,6 +138,8 @@ def test_cases_home_page_view_context(authorized_client):
         "submitted_to",
         "finalised_from",
         "finalised_to",
+        "exclude_denial_matches",
+        "exclude_sanction_matches",
         "status",
         "case_officer",
         "assigned_user",
@@ -237,12 +239,30 @@ def test_cases_home_page_regime_entry_search(authorized_client, mock_cases_searc
     }
 
 
-def test_cases_home_page_exlude_denial_matches_search(authorized_client, mock_cases_search):
+def test_cases_home_page_exclude_denial_matches_search(authorized_client, mock_cases_search):
     url = reverse("queues:cases") + "?exclude_denial_matches=True"
-    authorized_client.get(url)
+    response = authorized_client.get(url)
+
+    html = BeautifulSoup(response.content, "html.parser")
+    exclude_denial_matches_input = html.find(id="id_exclude_denial_matches_0")
+    assert exclude_denial_matches_input.attrs["name"] == "exclude_denial_matches"
+
     assert mock_cases_search.last_request.qs == {
         **default_params,
         "exclude_denial_matches": ["true"],
+    }
+
+
+def test_cases_home_page_exclude_sanction_matches_search(authorized_client, mock_cases_search):
+    url = reverse("queues:cases") + "?exclude_sanction_matches=True"
+    response = authorized_client.get(url)
+    html = BeautifulSoup(response.content, "html.parser")
+    exclude_sanction_matches_input = html.find(id="id_exclude_sanction_matches_0")
+    assert exclude_sanction_matches_input.attrs["name"] == "exclude_sanction_matches"
+
+    assert mock_cases_search.last_request.qs == {
+        **default_params,
+        "exclude_sanction_matches": ["true"],
     }
 
 


### PR DESCRIPTION
### Aim

This change achieves the following;
- Removes unnecessary "Misc" section from queue view filters.
- Rationalises "Party" section in queue view filters (including adding ability to exclude cases with sanction/denial matches)

[LTD-3799](https://uktrade.atlassian.net/browse/LTD-3799)


[LTD-3799]: https://uktrade.atlassian.net/browse/LTD-3799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ