### PR TITLE
[LTD-3856] Ensure bookmark links retain current queue

### DIFF
--- a/caseworker/bookmarks/services.py
+++ b/caseworker/bookmarks/services.py
@@ -3,8 +3,6 @@ from collections import OrderedDict
 from datetime import datetime, date
 from urllib.parse import urlencode
 
-from django.urls import reverse
-
 from caseworker.users.services import get_gov_user
 from core import client
 

--- a/caseworker/bookmarks/services.py
+++ b/caseworker/bookmarks/services.py
@@ -11,7 +11,7 @@ from core import client
 logger = logging.getLogger(__name__)
 
 
-def fetch_bookmarks(request, filter_data, all_flags):
+def fetch_bookmarks(request, filter_data, all_flags, bookmark_base_url):
     response = client.get(request, "/bookmarks/")
     if response.status_code >= 300:
         # Not important enough to break the page, so return an empty set of bookmarks.
@@ -19,7 +19,9 @@ def fetch_bookmarks(request, filter_data, all_flags):
         return {"user": []}
 
     bookmarks = response.json()["user"]
-    enriched_bookmarks = [enrich_bookmark_for_display(bookmark, filter_data, all_flags) for bookmark in bookmarks]
+    enriched_bookmarks = [
+        enrich_bookmark_for_display(bookmark, filter_data, all_flags, bookmark_base_url) for bookmark in bookmarks
+    ]
     enriched_bookmarks = [bookmark for bookmark in enriched_bookmarks if bookmark is not None]
 
     return {"user": enriched_bookmarks}
@@ -57,13 +59,12 @@ def rename_bookmark(request, bookmark_id, name):
     return client.put(request, f"/bookmarks", data)
 
 
-def enrich_bookmark_for_display(bookmark, filter_data, all_flags):
+def enrich_bookmark_for_display(bookmark, filter_data, all_flags, bookmark_base_url):
     try:
         out = {**bookmark}
-        base_url = reverse("queues:cases")
         bookmark_filter = out["filter_json"]
         out["description"] = description_from_filter(bookmark_filter, filter_data, all_flags)
-        out["url"] = url_from_bookmark(base_url, bookmark_filter)
+        out["url"] = url_from_bookmark(bookmark_base_url, bookmark_filter)
 
         return out
     except Exception as ex:  # pylint: disable=broad-except

--- a/caseworker/queues/views/cases.py
+++ b/caseworker/queues/views/cases.py
@@ -275,7 +275,7 @@ class Cases(LoginRequiredMixin, CaseDataMixin, FormView):
         for case in self.data["results"]["cases"]:
             self.transform_case(case)
 
-        bookmarks = fetch_bookmarks(self.request, self.filters, self.all_flags)
+        bookmarks = fetch_bookmarks(self.request, self.filters, self.all_flags, self.request.path)
         context = {
             "sla_radius": SLA_RADIUS,
             "sla_circumference": SLA_CIRCUMFERENCE,

--- a/unit_tests/caseworker/bookmarks/test_services.py
+++ b/unit_tests/caseworker/bookmarks/test_services.py
@@ -94,7 +94,7 @@ def test_description_from_filter(filter_data, bookmark_filter, expected_descript
 def test_enrich_bookmark_for_display(filter_data, bookmark_filter, expected_description, expected_url_params, flags):
     bookmark = {"name": "Name", "description": "", "filter_json": bookmark_filter, "id": uuid.uuid4()}
 
-    enriched = enrich_bookmark_for_display(bookmark, filter_data, flags)
+    enriched = enrich_bookmark_for_display(bookmark, filter_data, flags, "/queues/")
 
     assert enriched["description"] == expected_description
     assert enriched["url"] == f"/queues/?{expected_url_params}"
@@ -109,7 +109,7 @@ def test_enrich_bookmark_for_display_returns_None_on_error(filter_data, flags):
     bookmark_filter = {"dodgy_filter_entry": ObjectToForceException()}
     bookmark = {"name": "Name", "description": "", "filter_json": bookmark_filter, "id": uuid.uuid4()}
 
-    enriched = enrich_bookmark_for_display(bookmark, filter_data, flags)
+    enriched = enrich_bookmark_for_display(bookmark, filter_data, flags, "/queues/")
 
     assert enriched is None
 

--- a/unit_tests/caseworker/bookmarks/test_services.py
+++ b/unit_tests/caseworker/bookmarks/test_services.py
@@ -100,6 +100,15 @@ def test_enrich_bookmark_for_display(filter_data, bookmark_filter, expected_desc
     assert enriched["url"] == f"/queues/?{expected_url_params}"
 
 
+def test_enrich_bookmark_for_display_custom_base_url(filter_data, flags):
+    bookmark = {"name": "Name", "description": "", "filter_json": {"is_trigger_list": True}, "id": uuid.uuid4()}
+
+    enriched = enrich_bookmark_for_display(bookmark, filter_data, flags, "/queues/abcd")
+
+    assert enriched["description"] == "Is trigger list: True"
+    assert enriched["url"] == f"/queues/abcd?is_trigger_list=True"
+
+
 class ObjectToForceException:
     def __str__(self):
         raise Exception("This object breaks when str() called")


### PR DESCRIPTION
### Aim

This change fixes a bug where user's were unable to use saved filters on anything other than their default queue.  Saved filter links now use a base URL of the current request path.


[LTD-3856](https://uktrade.atlassian.net/browse/LTD-3856)


[LTD-3856]: https://uktrade.atlassian.net/browse/LTD-3856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ