### PR TITLE
[LTD-3857] Ensure assigned queues filter is only applied for system queue searches

### DIFF
--- a/caseworker/queues/views/cases.py
+++ b/caseworker/queues/views/cases.py
@@ -97,6 +97,12 @@ class CaseDataMixin:
         # but it can be overriden by a checkbox on the frontend
         is_hidden_by_form = self.request.GET.get("hidden", False)
         params["hidden"] = self._set_is_hidden(params["selected_tab"], is_hidden_by_form)
+        # Ideally we would do some proper form validation and this value would be removed
+        # as part of that, until then we remove assigned_queues from the params
+        # because this should not be filtered on unless the queue is a system queue
+        if params.get("assigned_queues") and not self._is_system_queue():
+            del params["assigned_queues"]
+
         # No need to send return_to parameter in server calls
         if params.get("return_to"):
             del params["return_to"]

--- a/unit_tests/caseworker/queues/views/test_cases.py
+++ b/unit_tests/caseworker/queues/views/test_cases.py
@@ -47,6 +47,26 @@ def mock_cases_search(requests_mock, data_cases_search, queue_pk):
 
 
 @pytest.fixture
+def mock_cases_search_team_queue(requests_mock, data_cases_search):
+    encoded_params = parse.urlencode({"page": 1, "flags": []}, doseq=True)
+    url = client._build_absolute_uri(f"/cases/?queue_id={queue_pk}&{encoded_params}")
+    return requests_mock.get(url=url, json=data_cases_search)
+
+
+@pytest.fixture
+def mock_team_queue(requests_mock):
+    data = {
+        "id": queue_pk,
+        "alias": None,
+        "name": "Some team",
+        "is_system_queue": False,
+        "countersigning_queue": None,
+    }
+    url = client._build_absolute_uri("/queues/")
+    return requests_mock.get(url=re.compile(f"{url}.*/"), json=data_queue)
+
+
+@pytest.fixture
 def mock_cases_search_page_2(requests_mock, data_cases_search, queue_pk):
     encoded_params = parse.urlencode({"page": 2, "flags": []}, doseq=True)
     url = client._build_absolute_uri(f"/cases/?queue_id={queue_pk}&{encoded_params}")
@@ -168,6 +188,27 @@ def test_cases_home_page_return_to_excluded_from_api(authorized_client, mock_cas
     authorized_client.get(url)
     assert mock_cases_search.last_request.qs == {
         **default_params,
+    }
+
+
+def test_cases_home_page_assigned_queues(authorized_client, mock_cases_search):
+    url = reverse("queues:cases") + "?assigned_queues=foo"
+    authorized_client.get(url)
+    assert mock_cases_search.last_request.qs == {
+        **default_params,
+        "assigned_queues": ["foo"],
+    }
+
+
+def test_cases_queue_page_assigned_queues(authorized_client, mock_cases_search_team_queue, mock_team_queue):
+    url = reverse("queues:cases", kwargs={"queue_pk": queue_pk}) + "?assigned_queues=foo"
+    authorized_client.get(url)
+    # Assert that assigned_queues is not sent through to the search API request
+    assert mock_cases_search_team_queue.last_request.qs == {
+        "page": ["1"],
+        "queue_id": [queue_pk],
+        "selected_tab": ["all_cases"],
+        "hidden": ["false"],
     }
 
 


### PR DESCRIPTION
### Aim

Ensure that `assigned_queues` filter is stripped out for searches on user team queues; this should only be possible for system queue searches.  The form does not show this field for system queues, but it was possible for a user to search by it on non-system queues by using a saved filter.  This has now been remedied.

[LTD-3857](https://uktrade.atlassian.net/browse/LTD-3857)


[LTD-3857]: https://uktrade.atlassian.net/browse/LTD-3857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ