### PR TITLE
[LTD-3884] Ensure csrfmiddlewaretoken is not visible after queue view form submission

### DIFF
--- a/caseworker/templates/queues/case-filters.html
+++ b/caseworker/templates/queues/case-filters.html
@@ -1,7 +1,7 @@
 {% load svg static %}
 {% load crispy_forms_tags %}
 
-<form method="get">
+<form method="post">
     <div id="case-filters" class="case-filters">
         <div class="case-filter-fields">
             {% crispy form %}

--- a/unit_tests/caseworker/queues/views/test_cases.py
+++ b/unit_tests/caseworker/queues/views/test_cases.py
@@ -174,6 +174,20 @@ def test_cases_home_page_view_context(authorized_client):
     assert response.status_code == 200
 
 
+def test_cases_home_page_post_redirect(authorized_client):
+    url = reverse("queues:cases")
+    response = authorized_client.post(url, follow=False)
+    assert response.url == "/queues/"
+    assert response.status_code == 302
+
+
+def test_cases_home_page_post_redirect_strips_csrftoken(authorized_client):
+    url = reverse("queues:cases")
+    response = authorized_client.post(url, {"csrfmiddlewaretoken": "foobar", "other_param": "bar"}, follow=False)
+    assert response.url == "/queues/?other_param=bar"
+    assert response.status_code == 302
+
+
 def test_cases_home_page_nca_applicable_search(authorized_client, mock_cases_search):
     url = reverse("queues:cases") + "?is_nca_applicable=True"
     authorized_client.get(url)


### PR DESCRIPTION
### Aim

Ensure that queue view filters submissions are always POST.  Add POST handling to view and redirect to GET with `csrfmiddlewaretoken` stripped out.


[LTD-3884](https://uktrade.atlassian.net/browse/LTD-3884)


[LTD-3884]: https://uktrade.atlassian.net/browse/LTD-3884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ