### PR TITLE
[LTD-3827] Add max total value filter to queue view

### DIFF
--- a/caseworker/bookmarks/services.py
+++ b/caseworker/bookmarks/services.py
@@ -1,6 +1,7 @@
 import logging
 from collections import OrderedDict
 from datetime import datetime, date
+from decimal import Decimal
 from urllib.parse import urlencode
 
 from caseworker.users.services import get_gov_user
@@ -175,11 +176,16 @@ def enrich_filter_for_saving(data, raw_filters):
 
     filters = {k: data[k] for k in data.keys() if data[k] and k not in keys_to_remove}
 
+    # Ensure that Decimal values are cast to string ready for json serialization
+    for key, value in filters.items():
+        if isinstance(value, Decimal):
+            filters[key] = str(value)
+
     # Add in _id_ prefixed data to preserve country and regime names. This is to prevent
     # unnecessary lookup when we display the bookmarks later, as the description and
     # url display need different values for these filters (status, gov_user etc)
     # the former needing the display value and the latter an id.
-    for key in raw_filters:
+    for key, value in raw_filters.items():
         if key.startswith("_id_") and key[4:] in filters:
             filters[key] = raw_filters[key]
 

--- a/caseworker/queues/views/forms.py
+++ b/caseworker/queues/views/forms.py
@@ -53,6 +53,10 @@ class CasesFiltersForm(forms.Form):
         label="Goods related description",
         required=False,
     )
+    max_total_value = forms.DecimalField(
+        label="Max total value (£)",
+        required=False,
+    )
     country = forms.CharField(
         label="Country",
         required=False,
@@ -212,6 +216,7 @@ class CasesFiltersForm(forms.Form):
                     Field.select("control_list_entry", id="control_list_entry"),
                     Field.text("regime_entry"),
                     Field.text("goods_related_description"),
+                    Field("max_total_value", css_class="govuk-input"),
                     Field("is_trigger_list"),
                     Field("is_nca_applicable"),
                 ),

--- a/unit_tests/caseworker/bookmarks/test_services.py
+++ b/unit_tests/caseworker/bookmarks/test_services.py
@@ -1,4 +1,5 @@
 import uuid
+from decimal import Decimal
 
 import pytest
 
@@ -195,6 +196,14 @@ def test_enrich_bookmark_for_display_filters_out_errors(filter_data, flags):
                 "regime": "2594daef-8156-4e78-b4c4-e25f6cdbd203",
                 "_id_regime": "Wassenaar Arrangement Sensitive",
             },
+        ),
+        (
+            "Test decimal value converted properly",
+            {"max_total_value": Decimal(200)},
+            {
+                "max_total_value": Decimal(200),
+            },
+            {"max_total_value": "200"},
         ),
     ],
 )

--- a/unit_tests/caseworker/bookmarks/test_services.py
+++ b/unit_tests/caseworker/bookmarks/test_services.py
@@ -118,6 +118,11 @@ def test_description_from_filter(filter_data, bookmark_filter, expected_descript
             "Min sla days remaining: 15",
             "min_sla_days_remaining=15",
         ),
+        (
+            {"max_total_value": "200.0"},
+            "Max total value: 200.0",
+            "max_total_value=200.0",
+        ),
     ],
 )
 def test_enrich_bookmark_for_display(

--- a/unit_tests/caseworker/queues/views/test_cases.py
+++ b/unit_tests/caseworker/queues/views/test_cases.py
@@ -149,6 +149,7 @@ def test_cases_home_page_view_context(authorized_client):
         "goods_starting_point",
         "party_name",
         "goods_related_description",
+        "max_total_value",
         "country",
         "control_list_entry",
         "regime_entry",
@@ -261,6 +262,23 @@ def test_cases_home_page_control_list_entries_search(authorized_client, mock_cas
     assert mock_cases_search.last_request.qs == {
         **default_params,
         "control_list_entry": ["ml1"],
+    }
+
+
+def test_cases_home_page_max_total_value_search(authorized_client, mock_cases_search):
+    url = reverse("queues:cases")
+    response = authorized_client.get(url)
+    html = BeautifulSoup(response.content, "html.parser")
+    control_list_entry_filter_input = html.find(id="id_max_total_value")
+    assert control_list_entry_filter_input.attrs["type"] == "number"
+    assert control_list_entry_filter_input.attrs["name"] == "max_total_value"
+
+    url = reverse("queues:cases") + "?max_total_value=300"
+    response = authorized_client.get(url)
+    assert response.status_code == 200
+    assert mock_cases_search.last_request.qs == {
+        **default_params,
+        "max_total_value": ["300"],
     }
 
 


### PR DESCRIPTION
### Aim

Add ability for caseworkers to filter queue view cases by those which have a total value below the "Max total value" filter value.

[LTD-3827](https://uktrade.atlassian.net/browse/LTD-3827)


[LTD-3827]: https://uktrade.atlassian.net/browse/LTD-3827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ