### PR TITLE
Re-instate erroneously removed javascript

### DIFF
--- a/core/assets/javascripts/filter-bar.js
+++ b/core/assets/javascripts/filter-bar.js
@@ -1,0 +1,38 @@
+function tryShowFilterBar() {
+  $(".lite-filter-bar").each(function () {
+    var $filters = $(this).parent();
+    $filters.hide();
+    $filters.prev().find("#show-filters-link").show();
+    $filters.prev().find("#hide-filters-link").hide();
+
+    $(this)
+      .find("input, select")
+      .each(function () {
+        if (
+          $(this).val() != "" &&
+          $(this).val() != "Select" &&
+          $(this).val() != "blank" &&
+          $(this).attr("type") != "hidden" &&
+          ($(this).attr("type") != "checkbox" ||
+            ($(this).attr("type") == "checkbox" && $(this).attr("checked")))
+        ) {
+          $filters.show();
+          $filters.prev().find("#show-filters-link").hide();
+          $filters.prev().find("#hide-filters-link").show();
+          $(this).parents(".govuk-details").attr("open", "");
+        }
+      });
+  });
+}
+
+tryShowFilterBar();
+
+$(".lite-filter-toggle-link")
+  .unbind()
+  .click(function () {
+    var $filters = $(this).parent().next();
+    $filters.toggle();
+    $(this).parent().find("> *").toggle();
+
+    return false;
+  });


### PR DESCRIPTION
### Aim

Re-instates the filter-bar javascript so that filters are hidden by default on a number of pages.  This was removed in error during saved filters work.

[LTD-3900](https://uktrade.atlassian.net/browse/LTD-3900)


[LTD-3900]: https://uktrade.atlassian.net/browse/LTD-3900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ