### PR TITLE
Show step names when outputting e2e report

### DIFF
--- a/makefile
+++ b/makefile
@@ -97,11 +97,11 @@ stop-exporter:
 
 caseworker-e2e-selenium-test:
 	@echo "*** Requires starting the caseworker stack, which can be started running: 'make start-caseworker' ***"
-	$(docker-e2e-caseworker) exec caseworker bash -c '$(wait-for-caseworker) && pipenv run pytest --headless ./ui_tests/caseworker'
+	$(docker-e2e-caseworker) exec caseworker bash -c '$(wait-for-caseworker) && pipenv run pytest --headless -vv --gherkin-terminal-reporter ./ui_tests/caseworker'
 
 exporter-e2e-selenium-test:
 	@echo "*** Requires starting the exporter stack, which can be started running: 'make start-exporter' ***"
-	$(docker-e2e-exporter) exec exporter bash -c '$(wait-for-exporter) && pipenv run pytest --headless ./ui_tests/exporter'
+	$(docker-e2e-exporter) exec exporter bash -c '$(wait-for-exporter) && pipenv run pytest --headless -vv --gherkin-terminal-reporter ./ui_tests/exporter'
 
 build-exporter:
 	$(docker-e2e-exporter) build


### PR DESCRIPTION
### Aim

Prints out the full report, including step names and error step, when running e2e tests

[LTD-3852](https://uktrade.atlassian.net/browse/LTD-3852)


[LTD-3852]: https://uktrade.atlassian.net/browse/LTD-3852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ