### PR TITLE
[LTD-3792] Make activity entry presentation more DRY

### DIFF
--- a/caseworker/activities/templates/activities/includes/activity-entry-activity.html
+++ b/caseworker/activities/templates/activities/includes/activity-entry-activity.html
@@ -1,0 +1,8 @@
+{% if activity.verb == "created_case_note_with_mentions" %}
+    {{ activity.text|slice:":-1"}}
+    {{ activity.payload.mention_users|join:", " }}
+    in a case note.
+    {% if activity.payload.is_urgent %} <p class="govuk-tag govuk-tag--red">URGENT</p> {% endif %}
+{% else %}
+    {{ activity.text|linebreaksbr }}
+{% endif %}

--- a/caseworker/activities/templates/activities/includes/activity-entry-user.html
+++ b/caseworker/activities/templates/activities/includes/activity-entry-user.html
@@ -1,0 +1,7 @@
+{% with user=activity.user %}
+    {% if user.type == 'exporter' %}
+        <span class="app-activity__item__user">Applicant:</span> {{ user.first_name }} {{ user.last_name }}
+    {% else %}
+        {% if user.team %}<span class="app-activity__item__user">{{ user.team }}:</span> {% endif %}{{ user.first_name }} {{ user.last_name }}
+    {% endif %}
+{% endwith %}

--- a/caseworker/activities/templates/activities/notes-and-timeline.html
+++ b/caseworker/activities/templates/activities/notes-and-timeline.html
@@ -71,19 +71,9 @@
                                 {% for activity in activities_by_date.list %}
                                     {% with user=activity.user %}
                                         <div class="notes-and-timeline-timeline__day-group-item">
-                                            {% if user.type == 'exporter' %}
-                                                <span class="app-activity__item__user">Applicant:</span> {{ user.first_name }} {{ user.last_name }}
-                                            {% else %}
-                                                {% if user.team %}<span class="app-activity__item__user">{{ user.team }}:</span> {% endif %}{{ user.first_name }} {{ user.last_name }}
-                                            {% endif %}
-                                            {% if activity.verb == "created_case_note_with_mentions" %}
-                                                {{ activity.text|slice:":-1"}}
-                                                {{ activity.payload.mention_users|join:", " }}
-                                                in a case note.
-                                                {% if activity.payload.is_urgent %} <p class="govuk-tag govuk-tag--red">URGENT</p> {% endif %}
-                                            {% else %}
-                                                {{ activity.text|linebreaksbr }}
-                                             {% endif %}
+
+			                                {% include 'activities/includes/activity-entry-user.html' with activity=activity %}
+			                                {% include 'activities/includes/activity-entry-activity.html' with activity=activity %}
                                             {% if activity.additional_text %}
                                                 <div class="notes-and-timeline-timeline__day-group-note">
                                                     {{ activity.additional_text|linebreaks }}

--- a/caseworker/templates/case/tabs/quick-summary.html
+++ b/caseworker/templates/case/tabs/quick-summary.html
@@ -77,14 +77,10 @@
                     <td class="govuk-table__cell">
         				{% if case.latest_activity %}
         					<div>
-        						{% if case.latest_activity.user.type == 'exporter' %}
-        							Applicant {{ case.latest_activity.created_at|to_datetime|date:"d F Y" }}
-        						{% else %}
-        							{{ case.latest_activity.user.team }} {{ case.latest_activity.created_at|to_datetime|date:"d F Y" }}
-        						{% endif %}
+			                    {% include 'activities/includes/activity-entry-user.html' with activity=case.latest_activity %} {{ update.created_at|to_datetime|date:"d F Y" }}
         					</div>
         					<div>
-        						{{ case.latest_activity.user.first_name }} {{ case.latest_activity.user.last_name }} {{ case.latest_activity.text|linebreaksbr }}
+			                    {% include 'activities/includes/activity-entry-activity.html' with activity=case.latest_activity %}
         					</div>
         					{% if case.latest_activity.additional_text %}
         						<div class="app-updates__activity">

--- a/caseworker/templates/includes/case-row.html
+++ b/caseworker/templates/includes/case-row.html
@@ -138,14 +138,10 @@
 							{% endif %}
 						</div>
 						<div class="app-updates__department">
-							{% if update.user.type == 'exporter' %}
-								Applicant {{ update.created_at|to_datetime|date:"d F Y" }}
-							{% else %}
-								{{ update.user.team }} {{ update.created_at|to_datetime|date:"d F Y" }}
-							{% endif %}
+			                {% include 'activities/includes/activity-entry-user.html' with activity=update %} {{ update.created_at|to_datetime|date:"d F Y" }}
 						</div>
 						<div class="app-updates__activity">
-							{{ update.user.first_name }} {{ update.user.last_name }} {{ update.text|linebreaksbr }}
+			                {% include 'activities/includes/activity-entry-activity.html' with activity=update %}
 						</div>
 						{% if update.additional_text %}
 							<div class="app-updates__activity">


### PR DESCRIPTION
### Aim

Ensure that different locations where we display Notes+Timeline activity entries use the same templates so that we have less repetition sprinkled throughout the codebase.
This fixes an issue where custom mentions presentation of activity entries was not being used for the quick summary page/queue view page.

[LTD-3792](https://uktrade.atlassian.net/browse/LTD-3792)


[LTD-3792]: https://uktrade.atlassian.net/browse/LTD-3792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ