### PR TITLE
[LTD-3843] Ensure quick summary product names are numbered

### DIFF
--- a/caseworker/assets/styles/components/_cases.scss
+++ b/caseworker/assets/styles/components/_cases.scss
@@ -667,6 +667,11 @@ $case-header-text-colour: govuk-colour('white');
                 width: 15rem;
             }
 
+            ol#quick-summary__product-names {
+                padding-left: 1rem;
+                margin: 0;
+            }
+
             ul.app-flags {
                 white-space: nowrap;
                 flex-flow: wrap;

--- a/caseworker/templates/case/tabs/quick-summary.html
+++ b/caseworker/templates/case/tabs/quick-summary.html
@@ -141,9 +141,11 @@
                 <tr class="govuk-table__row app-table__row" data-customiser-key="product_names">
                     <th scope="row" class="govuk-table__header">Product names</th>
                     <td class="govuk-table__cell">
+                        <ol id="quick-summary__product-names">
                         {% for name in goods_summary.names %}
-                            {{name}}<br/>
+                            <li>{{name}}</li>
                         {% endfor %}
+                        </ol>
                     </td>
                 </tr>
                 <tr class="govuk-table__row app-table__row" data-customiser-key="total_value">


### PR DESCRIPTION
### Aim

Add numbering to product names on quick summary page; the ordering of products from the API is consistent across details/product assessment pages so these numbers tally.

[LTD-3843](https://uktrade.atlassian.net/browse/LTD-3843)


[LTD-3843]: https://uktrade.atlassian.net/browse/LTD-3843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ