### PR TITLE
[LTD-3952] Denials match back button

### DIFF
--- a/caseworker/queues/views/cases.py
+++ b/caseworker/queues/views/cases.py
@@ -295,6 +295,13 @@ class Cases(LoginRequiredMixin, CaseDataMixin, FormView):
         sanitised_url = self._strip_param_from_url(url, "csrfmiddlewaretoken")
         return redirect(sanitised_url)
 
+    def is_filters_visible(self):
+        # when this view instantiates the form on submission, we can do better by using form.is_bound
+        # until then we must interrogate GET parameters
+        params_to_ignore = set(["selected_tab", "page"])
+        all_params = set(self.request.GET.keys())
+        return len(all_params - params_to_ignore) > 0
+
     def get_context_data(self, *args, **kwargs):
         try:
             updated_queue = [
@@ -313,6 +320,7 @@ class Cases(LoginRequiredMixin, CaseDataMixin, FormView):
             "sla_circumference": SLA_CIRCUMFERENCE,
             "data": self.data,
             "queue": self.queue,  # Used for showing current queue
+            "is_filters_visible": self.is_filters_visible(),
             "is_all_cases_queue": self.queue_pk == ALL_CASES_QUEUE_ID,
             "enforcement_check": Permission.ENFORCEMENT_CHECK.value in get_user_permissions(self.request),
             "updated_cases_banner_queue_id": UPDATED_CASES_QUEUE_ID,

--- a/caseworker/templates/external_data/denial-detail.html
+++ b/caseworker/templates/external_data/denial-detail.html
@@ -16,7 +16,7 @@
 
     <div class="govuk-!-margin-bottom-6">
         {% if queue_id and case_id %}
-            <a class="lite-back-link-button govuk-back-link" id="back-link" href="{% url 'cases:case' queue_id case_id %}">Back</a>
+            <a class="lite-back-link-button govuk-back-link" id="back-link" href="{% url 'cases:case' queue_pk=queue_id pk=case_id tab="details" %}">Back</a>
         {% else %}
             <a class="lite-back-link-button govuk-back-link" id="back-link" href="#">Back</a>
         {% endif %}

--- a/caseworker/templates/queues/cases.html
+++ b/caseworker/templates/queues/cases.html
@@ -61,7 +61,7 @@
 
     <div class="app-queue-view">
         <div class="app-queue-view__filters lite-mobile-hide">
-            <details class="govuk-details" {% if request.GET %}open{% endif %}>
+            <details class="govuk-details" {% if is_filters_visible %}open{% endif %}>
                 <summary class="govuk-details__summary" id="show-filters-link">
                   <span class="govuk-details__summary-text">
                     <span class="govuk-details__summary-text-closed">Show filters</span>

--- a/unit_tests/caseworker/queues/views/test_cases.py
+++ b/unit_tests/caseworker/queues/views/test_cases.py
@@ -179,6 +179,30 @@ def test_cases_home_page_view_context(authorized_client):
     assert response.status_code == 200
 
 
+@pytest.mark.parametrize(
+    "url_suffix",
+    [
+        "",
+        "?selected_tab=my_cases",
+    ],
+)
+def test_cases_home_page_view_context_is_filter_visible_hidden(authorized_client, url_suffix):
+    response = authorized_client.get(reverse("queues:cases") + url_suffix)
+    assert not response.context["is_filters_visible"]
+
+
+@pytest.mark.parametrize(
+    "url_suffix",
+    [
+        "?case_reference=bar",
+        "?a=b",
+    ],
+)
+def test_cases_home_page_view_context_is_filter_visible_visible(authorized_client, url_suffix):
+    response = authorized_client.get(reverse("queues:cases") + url_suffix)
+    assert response.context["is_filters_visible"]
+
+
 def test_cases_home_page_post_redirect(authorized_client):
     url = reverse("queues:cases")
     response = authorized_client.post(url, follow=False)


### PR DESCRIPTION
### Aim
Achieves two things;
- Ensures that the back button on the denial detail page returns to the case detail tab rather than the quick summary tab.
- Improves the logic for whether the filters sidebar is visible by default on the queue view page; this should only show if the caseworker has applied some filtering. Previously, it would show if any GET parameters were present; so a user would go to the second page and the filters sidebar would pop open. 

[LTD-3952](https://uktrade.atlassian.net/browse/LTD-3952)


[LTD-3952]: https://uktrade.atlassian.net/browse/LTD-3952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ