### PR TITLE
Update the number of builds required to report code coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,7 @@
+codecov:
+  notify:
+    after_n_builds: 3
+
 coverage:
   status:
     project:


### PR DESCRIPTION
This is to ensure that codecov has collected the three expected coverage reports before it reports

In some cases it will report early which will show a significant dip in coverage against a PR

This change waits until there are three uploads which correspond to:

  - exporter unit tests
  - caseworker unit tests
  - core unit tests
