### PR TITLE
LTD-4027 Fix table markup

### DIFF
--- a/caseworker/tau/templates/tau/ammunition_table.html
+++ b/caseworker/tau/templates/tau/ammunition_table.html
@@ -7,7 +7,7 @@
         {% include "tau/includes/product_details.html" %}
         {% include "tau/includes/security_grading.html" %}
         <tr class="govuk-table__row">
-          <td class="govuk-table__header">What is the calibre of the product?</td>
+          <th class="govuk-table__header">What is the calibre of the product?</th>
           <td class="govuk-table__cell">{{ good.firearm_details.calibre }}</td>
         </tr>
 
@@ -16,12 +16,12 @@
         {% include "tau/includes/onward_exported.html" %}
 
         <tr class="govuk-table__row">
-          <td class="govuk-table__header">Does the product have a valid proof mark?</td>
+          <th class="govuk-table__header">Does the product have a valid proof mark?</th>
           <td class="govuk-table__cell">{{ firearm_details.has_proof_mark|yesno|title }}</td>
         </tr>
         {% if firearm_details.has_proof_mark is False %}
           <tr class="govuk-table__row">
-            <td class="govuk-table__header">Explain why the product doesn’t have a valid proof mark</td>
+            <th class="govuk-table__header">Explain why the product doesn’t have a valid proof mark</th>
             <td class="govuk-table__cell">{{ firearm_details.no_proof_mark_details }}</td>
           </tr>
         {% endif %}

--- a/caseworker/tau/templates/tau/components_for_ammunition_table.html
+++ b/caseworker/tau/templates/tau/components_for_ammunition_table.html
@@ -7,7 +7,7 @@
         {% include "tau/includes/product_details.html" %}
         {% include "tau/includes/security_grading.html" %}
         <tr class="govuk-table__row">
-          <td class="govuk-table__header">What is the calibre of the product?</td>
+          <th class="govuk-table__header">What is the calibre of the product?</th>
           <td class="govuk-table__cell">{{ good.firearm_details.calibre }}</td>
         </tr>
 
@@ -16,11 +16,11 @@
         {% include "tau/includes/onward_exported.html" %}
 
         <tr class="govuk-table__row">
-          <td class="govuk-table__header">Number of items</td>
+          <th class="govuk-table__header">Number of items</th>
           <td class="govuk-table__cell">{{ firearm_details.number_of_items }}</td>
         </tr>
         <tr class="govuk-table__row">
-          <td class="govuk-table__header">Total value</td>
+          <th class="govuk-table__header">Total value</th>
           <td class="govuk-table__cell">£{{ good_on_application.value|floatformat:2 }}</td>
         </tr>
 

--- a/caseworker/tau/templates/tau/firearms_accessory_table.html
+++ b/caseworker/tau/templates/tau/firearms_accessory_table.html
@@ -15,56 +15,56 @@
         </tr>
         {% else %}
         <tr class="govuk-table__row">
-          <td class="govuk-table__header">Explain why you are not able to upload a product document</td>
+          <th class="govuk-table__header">Explain why you are not able to upload a product document</th>
           <td class="govuk-table__cell">{{ good.no_document_comments }}</td>
         </tr>
         {% endif %}
         <tr class="govuk-table__row">
-          <td class="govuk-table__header">Select the type of firearm product</td>
+          <th class="govuk-table__header">Select the type of firearm product</th>
           <td class="govuk-table__cell">{{ good.firearm_details.type.value }}</td>
         </tr>
         <tr class="govuk-table__row">
-          <td class="govuk-table__header">Part number (optional)</td>
+          <th class="govuk-table__header">Part number (optional)</th>
           <td class="govuk-table__cell">{{ good.part_number }}</td>
         </tr>
         <tr class="govuk-table__row">
-          <td class="govuk-table__header">Does the product have a government security grading or classification?</td>
+          <th class="govuk-table__header">Does the product have a government security grading or classification?</th>
           <td class="govuk-table__cell">{{ good.is_pv_graded|title }}</td>
         </tr>
         {% if good.is_pv_graded == "yes" %}
           {% if good.pv_grading_details.prefix %}
             <tr class="govuk-table__row">
-              <td class="govuk-table__header">Enter a prefix (optional)</td>
+              <th class="govuk-table__header">Enter a prefix (optional)</th>
               <td class="govuk-table__cell">{{ good.pv_grading_details.prefix }}</td>
             </tr>
           {% endif %}
           <tr class="govuk-table__row">
-            <td class="govuk-table__header">What is the security grading or classification?</td>
+            <th class="govuk-table__header">What is the security grading or classification?</th>
             <td class="govuk-table__cell">{{ good.pv_grading_details.grading.value }}</td>
           </tr>
           {% if good.pv_grading_details.suffix %}
             <tr class="govuk-table__row">
-              <td class="govuk-table__header">Enter a suffix (optional)</td>
+              <th class="govuk-table__header">Enter a suffix (optional)</th>
               <td class="govuk-table__cell">{{ good.pv_grading_details.suffix }}</td>
             </tr>
           {% endif %}
           <tr class="govuk-table__row">
-            <td class="govuk-table__header">Name and address of the issuing authority</td>
+            <th class="govuk-table__header">Name and address of the issuing authority</th>
             <td class="govuk-table__cell">{{ good.pv_grading_details.issuing_authority|linebreaksbr }}</td>
           </tr>
           <tr class="govuk-table__row">
-            <td class="govuk-table__header">Reference</td>
+            <th class="govuk-table__header">Reference</th>
             <td class="govuk-table__cell">{{ good.pv_grading_details.reference }}</td>
           </tr>
           <tr class="govuk-table__row">
-            <td class="govuk-table__header">Date of issue</td>
+            <th class="govuk-table__header">Date of issue</th>
             <td class="govuk-table__cell">
               {{ good.pv_grading_details.date_of_issue|format_date }}
             </td>
           </tr>
         {% endif %}
         <tr class="govuk-table__row">
-          <td class="govuk-table__header">Is the product for military use?</td>
+          <th class="govuk-table__header">Is the product for military use?</th>
           <td class="govuk-table__cell">
             {{ good.is_military_use.value }}
             {% if good.is_military_use.key != "no" %}
@@ -73,7 +73,7 @@
           </td>
         </tr>
         <tr class="govuk-table__row">
-          <td class="govuk-table__header">Component</td>
+          <th class="govuk-table__header">Component</th>
           <td class="govuk-table__cell">
             {{ good.is_component.value }}
             {% if good.is_component.key != "no" %}
@@ -82,7 +82,7 @@
           </td>
         </tr>
         <tr class="govuk-table__row">
-          <td class="govuk-table__header">Information security features</td>
+          <th class="govuk-table__header">Information security features</th>
           <td class="govuk-table__cell">
             {{ good.uses_information_security|yesno|capfirst }}
             {% if good.uses_information_security %}
@@ -91,17 +91,17 @@
           </td>
         </tr>
         <tr class="govuk-table__row">
-          <td class="govuk-table__header">Will the product be onward exported to any additional countries?</td>
+          <th class="govuk-table__header">Will the product be onward exported to any additional countries?</th>
           <td class="govuk-table__cell">{{ case.destinations|is_ultimate_end_user|yesno|capfirst }}</td>
         </tr>
         <tr class="govuk-table__row">
-          <td class="govuk-table__header">Quantity</td>
+          <th class="govuk-table__header">Quantity</th>
           <td class="govuk-table__cell">
             {{ good_on_application.quantity|floatformat:"0" }} {{ good_on_application.unit.value }}
           </td>
         </tr>
         <tr class="govuk-table__row">
-          <td class="govuk-table__header">Total value</td>
+          <th class="govuk-table__header">Total value</th>
           <td class="govuk-table__cell">£{{ good_on_application.value }}</td>
         </tr>
       {% endwith %}

--- a/caseworker/tau/templates/tau/product_summary_table.html
+++ b/caseworker/tau/templates/tau/product_summary_table.html
@@ -12,7 +12,7 @@
                     </tr>
                     {% if document.description %}
                         <tr>
-                            <td class="govuk-table__header">Description (optional)</td>
+                            <th class="govuk-table__header">Description (optional)</th>
                             <td class="govuk-table__cell">
                                 {{ document.description }}
                             </td>
@@ -21,14 +21,14 @@
                 {% endfor %}
             {% else %}
                 <tr class="govuk-table__row">
-                    <td class="govuk-table__header">Explain why you are not able to upload a product document</td>
+                    <th class="govuk-table__header">Explain why you are not able to upload a product document</th>
                     <td class="govuk-table__cell">{{ good.no_document_comments }}</td>
                 </tr>
             {% endif %}
         {% endwith %}
         {% for id, value, label in summary %}
             <tr class="govuk-table__row" id="table-product-{{ forloop.counter }}-{{ id }}">
-                <td class="govuk-table__header">{{ label }}</td>
+                <th class="govuk-table__header">{{ label }}</th>
                 <td class="govuk-table__cell">{{ value }}</td>
             </tr>
         {% endfor %}

--- a/caseworker/tau/templates/tau/software_related_to_firearms_table.html
+++ b/caseworker/tau/templates/tau/software_related_to_firearms_table.html
@@ -7,26 +7,26 @@
       {% include "tau/includes/product_details.html" %}
       {% include "tau/includes/security_grading.html" %}
       <tr class="govuk-table__row">
-        <td class="govuk-table__header">Describe the purpose of the product</td>
+        <th class="govuk-table__header">Describe the purpose of the product</th>
         <td class="govuk-table__cell">{{ good.software_or_technology_details }}</td>
       </tr>
       <tr class="govuk-table__row">
-        <td class="govuk-table__header">Is the product for military use?</td>
+        <th class="govuk-table__header">Is the product for military use?</th>
         <td class="govuk-table__cell">{{ good.is_military_use.value }}</td>
       </tr>
       {% if good.is_military_use.key == "yes_modified" %}
         <tr class="govuk-table__row">
-         <td class="govuk-table__header">Provide details of the modifications?</td>
+         <th class="govuk-table__header">Provide details of the modifications?</th>
          <td class="govuk-table__cell">{{ good.modified_military_use_details }}</td>
         </tr>
       {% endif %}
       <tr class="govuk-table__row">
-        <td class="govuk-table__header">Does the product include security features to protect information?</td>
+        <th class="govuk-table__header">Does the product include security features to protect information?</th>
         <td class="govuk-table__cell">{{ good.uses_information_security|yesno|capfirst }}</td>
       </tr>
       {% if good.information_security_details %}
       <tr class="govuk-table__row">
-        <td class="govuk-table__header">Provide details of the information security features</td>
+        <th class="govuk-table__header">Provide details of the information security features</th>
         <td class="govuk-table__cell">{{ good.information_security_details }}</td>
       </tr>
       {% endif %}


### PR DESCRIPTION
### Aim

The `<th>` element should be used instead of `<td>` for table headers as screen readers use this.

[LTD-4027](https://uktrade.atlassian.net/browse/LTD-4027)


[LTD-4027]: https://uktrade.atlassian.net/browse/LTD-4027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ