### PR TITLE
LTD-4042: Consider NLR products when LU edits their recommendation

### DIFF
--- a/caseworker/advice/constants.py
+++ b/caseworker/advice/constants.py
@@ -19,3 +19,10 @@ class AdviceLevel:
     USER = "user"
     TEAM = "team"
     FINAL = "final"
+
+
+class AdviceType:
+    APPROVE = "approve"
+    PROVISO = "proviso"
+    REFUSE = "refuse"
+    NO_LICENCE_REQUIRED = "no_licence_required"

--- a/caseworker/advice/services.py
+++ b/caseworker/advice/services.py
@@ -4,6 +4,7 @@ from requests.exceptions import HTTPError
 
 from core import client
 from caseworker.advice import constants
+from caseworker.advice.constants import AdviceType
 
 # Queues
 BEIS_CHEMICAL_CASES_TO_REVIEW = "BEIS_CHEMICAL_CASES_TO_REVIEW"
@@ -360,21 +361,25 @@ def update_advice(request, case, caseworker, advice_type, data, level):
 
     team_advice = filter_advice_by_level(case.advice, ["final"])
     consolidated_advice = filter_advice_by_team(team_advice, user_team_alias)
-    licenceable_products_advice = [item for item in consolidated_advice if item["type"]["key"] != "no_licence_required"]
-    nlr_products_advice = [item for item in consolidated_advice if item["type"]["key"] == "no_licence_required"]
+    licenceable_products_advice = [
+        item for item in consolidated_advice if item["type"]["key"] != AdviceType.NO_LICENCE_REQUIRED
+    ]
+    nlr_products_advice = [
+        item for item in consolidated_advice if item["type"]["key"] == AdviceType.NO_LICENCE_REQUIRED
+    ]
 
     json = []
-    if advice_type == "approve" or advice_type == "proviso":
+    if advice_type in (AdviceType.APPROVE, AdviceType.PROVISO):
         json = [
             {
                 "id": advice["id"],
                 "text": data["approval_reasons"],
                 "proviso": data["proviso"],
-                "type": "proviso" if data["proviso"] else "approve",
+                "type": AdviceType.PROVISO if data["proviso"] else AdviceType.APPROVE,
             }
             for advice in licenceable_products_advice
         ]
-    elif advice_type == "refuse":
+    elif advice_type == AdviceType.REFUSE:
         json = [
             {
                 "id": advice["id"],


### PR DESCRIPTION
### Aim

Currently when LU edits their recommendation (final-level) then we are updating all products as either approve/refuse depending on their decision. This includes NLR products also which means if application has any NLR products they will also be recorded as approve/refuse after they edit recommendation.

This is a problem as it is final level advice because they are no longer treated as NLR and they will be added to the licence document also.

Fix this by filtering NLR products and recording the type as NLR correctly for all NLR products. We have existing tests so update them to include NLR products.

[LTD-4042](https://uktrade.atlassian.net/browse/LTD-4042)


[LTD-4042]: https://uktrade.atlassian.net/browse/LTD-4042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ