### PR TITLE
LTD-4049 Fix page title for queue view when selected tab is changed

### DIFF
--- a/caseworker/queues/views/cases.py
+++ b/caseworker/queues/views/cases.py
@@ -321,6 +321,9 @@ class Cases(LoginRequiredMixin, CaseDataMixin, FormView):
         all_params = set(self.request.GET.keys())
         return len(all_params - params_to_ignore) > 0
 
+    def get_selected_tab(self):
+        return self.request.GET.get("selected_tab", CasesListPage.Tabs.ALL_CASES)
+
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
 
@@ -352,6 +355,7 @@ class Cases(LoginRequiredMixin, CaseDataMixin, FormView):
                 "enforcement_check": Permission.ENFORCEMENT_CHECK.value in get_user_permissions(self.request),
                 "updated_cases_banner_queue_id": UPDATED_CASES_QUEUE_ID,
                 "show_updated_cases_banner": show_updated_cases_banner,
+                "selected_tab": self.get_selected_tab(),
                 "tab_data": self._tab_data(),
                 "bookmarks": bookmarks,
                 "return_to": self.get_return_url(),

--- a/caseworker/templates/layouts/base.html
+++ b/caseworker/templates/layouts/base.html
@@ -7,15 +7,7 @@
 
 <head>
 	<meta charset="utf-8" />
-	<title>
-		{% block title %}
-			{% if title %}
-				{{ title }}
-			{% else %}
-				{% missing_title %}
-			{% endif %}
-		{% endblock %} - {% lcs 'Common.SERVICE_NAME' %}
-	</title>
+	<title>{% block title %}{% if title %}{{ title }}{% else %}{% missing_title %}{% endif %}{% endblock %} - {% lcs 'Common.SERVICE_NAME' %}</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 	<meta name="theme-color" content="#0b0c0c" />
 

--- a/caseworker/templates/queues/cases.html
+++ b/caseworker/templates/queues/cases.html
@@ -5,9 +5,7 @@
 
 {% block back_link %}{% endblock %}
 
-{% block title %}
-	{{ queue.name }}
-{% endblock %}
+{% block title %}{% if selected_tab == "my_cases" %}{{ queue.name }} - My cases{% elif selected_tab == "open_queries" %}{{ queue.name }} - Open queries{% else %}{{ queue.name }}{% endif %}{% endblock %}
 
 {% block messages %}
 	{{ block.super }}

--- a/unit_tests/caseworker/queues/views/test_cases.py
+++ b/unit_tests/caseworker/queues/views/test_cases.py
@@ -182,6 +182,22 @@ def test_cases_home_page_view_context(authorized_client):
 
 
 @pytest.mark.parametrize(
+    ("query_string", "expected_title"),
+    [
+        ("", "All cases - LITE Internal"),
+        ("?selected_tab=all_cases", "All cases - LITE Internal"),
+        ("?selected_tab=my_cases", "All cases - My cases - LITE Internal"),
+        ("?selected_tab=open_queries", "All cases - Open queries - LITE Internal"),
+    ],
+)
+def test_cases_page_has_correct_title(authorized_client, query_string, expected_title):
+    response = authorized_client.get(reverse("queues:cases") + query_string)
+    soup = BeautifulSoup(response.content, "html.parser")
+    title = soup.title.string.strip()
+    assert title == expected_title
+
+
+@pytest.mark.parametrize(
     "url_suffix",
     [
         "",


### PR DESCRIPTION
### Aim

This is one of the DAC accessibility changes for the Page Titled requirement

[LTD-4049](https://uktrade.atlassian.net/browse/LTD-4049)


[LTD-4049]: https://uktrade.atlassian.net/browse/LTD-4049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ