### PR TITLE
Hide "edit destination flag" button

### DIFF
--- a/caseworker/templates/case/slices/destinations.html
+++ b/caseworker/templates/case/slices/destinations.html
@@ -7,9 +7,9 @@
 			<form action="{% url 'cases:assign_flags' queue.id case.id %}" method="get" data-enable-on-checkboxes="#table-destinations">
 				<div class="lite-buttons-row">
 					<button class="govuk-button" formaction="{% url 'cases:denials' queue_pk=queue.id pk=case.id %}">View related denials</button>
-					<button id="button-edit-destinations-flags" class="govuk-button govuk-button--secondary" data-module="govuk-button">
+					<!--<button id="button-edit-destinations-flags" class="govuk-button govuk-button--secondary" data-module="govuk-button">
 						{% lcs 'cases.ApplicationPage.EDIT_DESTINATION_FLAGS' %}
-					</button>
+					</button>-->
 				</div>
 		{% endif %}
 


### PR DESCRIPTION
### Aim

This is temporarily hiding this button to see if this solves the issue where the old countersigning method is used.
    
We believe that this button is only used to make changes to the flags so that LU countersigning kicks in, which is the old process.
    
At present we don't believe that this functionality is used for anything else but we are leaving the button commented out in case we need to bring this back quickly (or possibly someone can just edit the HTML via dev tools and use it if absolutely required).

[LTD-4011](https://uktrade.atlassian.net/browse/LTD-4011)


[LTD-4011]: https://uktrade.atlassian.net/browse/LTD-4011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ