### PR TITLE
LTD-4026: Update help text to clarify the functionality to screen reader users

### DIFF
--- a/caseworker/queues/forms.py
+++ b/caseworker/queues/forms.py
@@ -102,7 +102,7 @@ class EnforcementXMLImportForm(forms.Form):
 class CaseAssignmentsCaseOfficerForm(BaseForm):
     class Layout:
         TITLE = "Who do you want to allocate as Licensing Unit case officer ?"
-        SUBTITLE = "Manages the case until the application outcome (the exporter will see this name until the case officer is changed)"
+        SUBTITLE = "Manages the case until the application outcome (the exporter will see this name until the case officer is changed) – typing into the text input will automatically filter results on the page"  # noqa
         SUBMIT_BUTTON_TEXT = "Save and continue"
 
     users = forms.ChoiceField(


### PR DESCRIPTION
### Aim

When assigning LU case officer typing into the input field filters the options available for the users to select. This is not very clear for screen reader users so as per suggested solution update help text so that it clear for them before they start interacting with the input field.

[LTD-4026](https://uktrade.atlassian.net/browse/LTD-4026)


[LTD-4026]: https://uktrade.atlassian.net/browse/LTD-4026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ