### PR TITLE
LTD-4036: Correct typo for data-module field to focus on error summary

### DIFF
--- a/lite_forms/templates/forms-errors.html
+++ b/lite_forms/templates/forms-errors.html
@@ -1,4 +1,4 @@
-<div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
+<div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
 	<h2 class="govuk-error-summary__title" id="error-summary-title">
 		There is a problem
 	</h2>


### PR DESCRIPTION
### Change description

In case of form errors keyboard focus should be taken to the error summary but because of a typo to the value of data-module field it is incorrectly taken to other elements on the page. This causes issues for screen reader users as they are not made aware of the error(s).

[LTD-4036](https://uktrade.atlassian.net/browse/LTD-4036)


[LTD-4036]: https://uktrade.atlassian.net/browse/LTD-4036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ