### PR TITLE
LTD-4059: Mark cookie banner heading correctly

### DIFF
--- a/core/cookies/templates/cookies/banner.html
+++ b/core/cookies/templates/cookies/banner.html
@@ -3,7 +3,7 @@
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
                 <p class="app-cookie-banner__message">
-                    <span class="govuk-heading-m">Cookies on LITE</span>
+                    <h2 class="govuk-heading-m">Cookies on LITE</h2>
                     <p class="govuk-body">
                         We use some essential cookies to make this service work.
                     </p>


### PR DESCRIPTION
### Aim

It is a heading but not marked as such so screen readers cannot pick this up correctly

[LTD-4059](https://uktrade.atlassian.net/browse/LTD-4059)


[LTD-4059]: https://uktrade.atlassian.net/browse/LTD-4059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ