### PR TITLE
LTD-4068: Add accessible name for the button that expands list of flags

### DIFF
--- a/caseworker/assets/javascripts/list-expander.js
+++ b/caseworker/assets/javascripts/list-expander.js
@@ -34,7 +34,10 @@ class ListExpander {
     );
     this.$expandButton = this.$el.querySelector(".expander__expand-button");
     this.$expandButton.innerHTML =
-      this.visibleElems + ` of ` + this.liElems.length;
+      `<span class="govuk-visually-hidden">expand additional list of flags</span>` +
+      this.visibleElems +
+      ` of ` +
+      this.liElems.length;
     this.$expandButton.addEventListener("click", (evt) =>
       this.handleExpandButtonClick(evt)
     );


### PR DESCRIPTION
### Aim

As per recommended solution a hidden span is added to explain the purpose of the button.

[LTD-LTD-4068](https://uktrade.atlassian.net/browse/LTD-LTD-4068)
