### PR TITLE
[LTD-4056] View to send generated letters

### DIFF
--- a/caseworker/cases/services.py
+++ b/caseworker/cases/services.py
@@ -315,6 +315,11 @@ def get_generated_document(request, pk, dpk):
     return data.json(), data.status_code
 
 
+def send_generated_document(request, pk, document_pk):
+    response = client.post(request, f"/cases/{pk}/generated-documents/{document_pk}/send/")
+    return response
+
+
 def get_destination(request, pk):
     data = client.get(request, f"/cases/destinations/{pk}")
     return data.json()

--- a/caseworker/cases/urls.py
+++ b/caseworker/cases/urls.py
@@ -101,6 +101,11 @@ urlpatterns = [
         generate_document.CreateDocument.as_view(),
         name="generate_document_create",
     ),
+    path(
+        "generate-document/<uuid:document_pk>/send/",
+        generate_document.SendExistingDocument.as_view(),
+        name="generate_document_send",
+    ),
     path("case-officer/", main.CaseOfficer.as_view(), name="case_officer"),
     path("review-date/", main.NextReviewDate.as_view(), name="review_date"),
     path(

--- a/caseworker/cases/views/generate_document.py
+++ b/caseworker/cases/views/generate_document.py
@@ -1,9 +1,10 @@
 from http import HTTPStatus
 from urllib.parse import quote
 
+from django.contrib import messages
 from django.shortcuts import redirect, render
-from django.urls import reverse_lazy
-from django.views.generic import TemplateView
+from django.urls import reverse_lazy, reverse
+from django.views.generic import TemplateView, View
 
 from caseworker.cases.forms.generate_document import (
     select_template_form,
@@ -13,6 +14,7 @@ from caseworker.cases.forms.generate_document import (
 from caseworker.cases.helpers.helpers import generate_document_error_page
 from caseworker.cases.services import (
     post_generated_document,
+    send_generated_document,
     get_generated_document_preview,
     get_generated_document,
     get_case,
@@ -166,6 +168,22 @@ class CreateDocument(LoginRequiredMixin, TemplateView):
             return redirect(
                 reverse_lazy("cases:case", kwargs={"queue_pk": queue_pk, "pk": str(pk), "tab": "documents"})
             )
+
+
+class SendExistingDocument(LoginRequiredMixin, View):
+    def post(self, request, queue_pk, pk, document_pk):
+        response = send_generated_document(request, pk, document_pk)
+        case = get_case(request, pk)
+        if response.ok:
+            messages.success(
+                self.request, f"Document sent to {case['data']['organisation']['name']}, {case['reference_code']}"
+            )
+        else:
+            messages.error(
+                self.request,
+                f"An error occurred when sending the document. Please try again later",
+            )
+        return redirect(reverse("queues:cases", kwargs={"queue_pk": queue_pk}))
 
 
 class CreateDocumentFinalAdvice(LoginRequiredMixin, TemplateView):

--- a/unit_tests/caseworker/cases/views/test_generate_document.py
+++ b/unit_tests/caseworker/cases/views/test_generate_document.py
@@ -1,0 +1,96 @@
+import pytest
+
+from django.urls import reverse
+
+from core import client
+
+
+@pytest.fixture(autouse=True)
+def setup(
+    mock_case,
+    mock_queue,
+    mock_cases_search,
+    mock_cases_search_head,
+    mock_control_list_entries,
+    mock_regime_entries,
+    mock_countries,
+    mock_queues_list,
+    mock_empty_bookmarks,
+):
+    return
+
+
+@pytest.fixture
+def data_generated_document_id():
+    return "2e0b4d2c-3a4b-4b00-8e5d-dac7fc285059"
+
+
+@pytest.fixture
+def send_document_url(data_standard_case, data_generated_document_id):
+    case_id = data_standard_case["case"]["id"]
+    return client._build_absolute_uri(f"/cases/{case_id}/generated-documents/{data_generated_document_id}/send/")
+
+
+@pytest.fixture
+def mock_send_generated_document(requests_mock, send_document_url, mock_gov_user):
+    return requests_mock.post(url=send_document_url, json={"notification_sent": False})
+
+
+def test_send_existing_document(
+    authorized_client,
+    requests_mock,
+    data_standard_case,
+    send_document_url,
+    queue_pk,
+    data_generated_document_id,
+):
+    mock_send_generated_document_api_error = requests_mock.post(url=send_document_url, json={}, status_code=404)
+    url = reverse(
+        "cases:generate_document_send",
+        kwargs={
+            "queue_pk": queue_pk,
+            "pk": data_standard_case["case"]["id"],
+            "document_pk": data_generated_document_id,
+        },
+    )
+    response = authorized_client.post(url, follow=True)
+    assert response.status_code == 200
+    messages = [str(msg) for msg in response.context["messages"]]
+    expected_message = f"An error occurred when sending the document. Please try again later"
+    assert response.redirect_chain[-1][0] == f"/queues/{queue_pk}/"
+    assert messages == [expected_message]
+    assert mock_send_generated_document_api_error.called
+    assert (
+        mock_send_generated_document_api_error.last_request.path
+        == f"/cases/{data_standard_case['case']['id']}/generated-documents/{data_generated_document_id}/send/"
+    )
+    assert mock_send_generated_document_api_error.last_request.json() == {}
+
+
+def test_send_existing_document_ok(
+    authorized_client,
+    data_standard_case,
+    queue_pk,
+    mock_send_generated_document,
+    data_generated_document_id,
+):
+    url = reverse(
+        "cases:generate_document_send",
+        kwargs={
+            "queue_pk": queue_pk,
+            "pk": data_standard_case["case"]["id"],
+            "document_pk": data_generated_document_id,
+        },
+    )
+    response = authorized_client.post(url, follow=True)
+    assert response.status_code == 200
+    messages = [str(msg) for msg in response.context["messages"]]
+    expected_message = f"Document sent to {data_standard_case['case']['data']['organisation']['name']}, {data_standard_case['case']['reference_code']}"
+    assert response.redirect_chain[-1][0] == f"/queues/{queue_pk}/"
+    assert messages == [expected_message]
+    assert mock_send_generated_document.called
+    assert (
+        mock_send_generated_document.last_request.path
+        == f"/cases/{data_standard_case['case']['id']}/generated-documents/{data_generated_document_id}/send/"
+    )
+    assert mock_send_generated_document.last_request.json() == {}

--- a/unit_tests/caseworker/conftest.py
+++ b/unit_tests/caseworker/conftest.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 import re
 import os
 import uuid
+from urllib import parse
 
 import pytest
 from dotenv import load_dotenv
@@ -2278,3 +2279,16 @@ def all_cles():
             "parent": "29d1f6de-b14b-4c92-b79b-c42124789ce3",
         },
     ]
+
+
+@pytest.fixture
+def mock_cases_search(requests_mock, data_cases_search, queue_pk):
+    encoded_params = parse.urlencode({"page": 1, "flags": []}, doseq=True)
+    url = client._build_absolute_uri(f"/cases/?queue_id={queue_pk}&{encoded_params}")
+    return requests_mock.get(url=url, json=data_cases_search)
+
+
+@pytest.fixture
+def mock_cases_search_head(requests_mock):
+    url = client._build_absolute_uri(f"/cases/")
+    yield requests_mock.head(url=re.compile(f"{url}.*"), headers={"resource-count": "350"})

--- a/unit_tests/caseworker/queues/views/test_cases.py
+++ b/unit_tests/caseworker/queues/views/test_cases.py
@@ -38,13 +38,6 @@ def setup(
 
 
 @pytest.fixture
-def mock_cases_search(requests_mock, data_cases_search, queue_pk):
-    encoded_params = parse.urlencode({"page": 1, "flags": []}, doseq=True)
-    url = client._build_absolute_uri(f"/cases/?queue_id={queue_pk}&{encoded_params}")
-    return requests_mock.get(url=url, json=data_cases_search)
-
-
-@pytest.fixture
 def mock_cases_search_team_queue(requests_mock, data_cases_search):
     encoded_params = parse.urlencode({"page": 1, "flags": []}, doseq=True)
     url = client._build_absolute_uri(f"/cases/?queue_id={queue_pk}&{encoded_params}")
@@ -120,12 +113,6 @@ def mock_team_cases_search(requests_mock, data_cases_search):
     data_cases_search["results"]["filters"]["is_system_queue"] = False
     url = client._build_absolute_uri(f"/cases/")
     yield requests_mock.get(url=url, json=data_cases_search)
-
-
-@pytest.fixture
-def mock_cases_search_head(requests_mock):
-    url = client._build_absolute_uri(f"/cases/")
-    yield requests_mock.head(url=re.compile(f"{url}.*"), headers={"resource-count": "350"})
 
 
 def test_cases_home_page_view_context(authorized_client):

--- a/unit_tests/caseworker/queues/views/test_queues_case_assignments.py
+++ b/unit_tests/caseworker/queues/views/test_queues_case_assignments.py
@@ -36,13 +36,6 @@ def setup(
 
 
 @pytest.fixture
-def mock_cases_search(requests_mock, data_cases_search, queue_pk):
-    encoded_params = parse.urlencode({"page": 1, "flags": []}, doseq=True)
-    url = client._build_absolute_uri(f"/cases/?queue_id={queue_pk}&{encoded_params}")
-    return requests_mock.get(url=url, json=data_cases_search)
-
-
-@pytest.fixture
 def mock_team_queue(requests_mock, data_queue):
     data_queue["is_system_queue"] = False
     url = client._build_absolute_uri("/queues/")


### PR DESCRIPTION
### Aim

This change adds a new view to the caseworker frontend which calls the new API endpoint for sending generated documents to exporters (https://github.com/uktrade/lite-api/pull/1531)

This is not yet visible/callable by lite users; it will be wired up when we are ready to release the inform letter functionality.

[LTD-4056](https://uktrade.atlassian.net/browse/LTD-4056)


[LTD-4056]: https://uktrade.atlassian.net/browse/LTD-4056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ