### PR TITLE
Ltd 4061 dac selected state

### DIFF
--- a/caseworker/assets/javascripts/tau.js
+++ b/caseworker/assets/javascripts/tau.js
@@ -1,4 +1,4 @@
-import SelectAll, { SELECT_ALL_BUTTON_TEXT } from "core/select-all";
+import SelectAll from "core/select-all";
 import ExpandAll, { SHOW_ALL_BUTTON_TEXT } from "core/expand-all";
 import CheckboxClassToggler from "core/checkbox-class-toggler";
 import DisablingButton from "core/disabling-button";
@@ -11,17 +11,38 @@ import initARS from "./tau/ars";
 import initRegimes from "./tau/regimes";
 import ShowHideNcscField from "./tau/show-hide-ncsc-field";
 
+const SELECT_ALL_BUTTON_TEXT = "Select all";
+const DESELECT_ALL_BUTTON_TEXT = "Deselect all";
+
 const initSelectAll = (goods) => {
   const selectAllButton = document.createElement("button");
-  selectAllButton.innerText = SELECT_ALL_BUTTON_TEXT;
   selectAllButton.classList.add(
     "lite-button--link",
     "assessment-form__select-all"
   );
 
-  const checkboxes = goods.querySelectorAll("[name=goods]");
+  let isAllSelected = null;
 
-  new SelectAll(selectAllButton, checkboxes).init();
+  const checkboxes = goods.querySelectorAll("[name=goods]");
+  const selectAll = new SelectAll(checkboxes, (_isAllSelected) => {
+    isAllSelected = _isAllSelected;
+    if (isAllSelected) {
+      selectAllButton.innerText = DESELECT_ALL_BUTTON_TEXT;
+    } else {
+      selectAllButton.innerText = SELECT_ALL_BUTTON_TEXT;
+    }
+  });
+  selectAll.init();
+
+  selectAllButton.addEventListener("click", (evt) => {
+    evt.preventDefault();
+    evt.stopPropagation();
+    if (isAllSelected) {
+      selectAll.deselectAll();
+    } else {
+      selectAll.selectAll();
+    }
+  });
 
   return selectAllButton;
 };

--- a/core/assets/javascripts/__tests__/select-all.test.js
+++ b/core/assets/javascripts/__tests__/select-all.test.js
@@ -17,21 +17,21 @@ const createElements = () => {
     </div>
   `;
 
-  const _selectAllButton = document.querySelector(".select-all-button");
   const _checkboxes = document.querySelectorAll("[type=checkbox]");
+  const _selectAllButton = document.querySelector(".select-all-button");
 
-  return [_selectAllButton, _checkboxes];
+  return [_checkboxes, _selectAllButton];
 };
 
 const createComponent = () => {
-  [selectAllButton, checkboxes] = createElements();
-  return new SelectAll(selectAllButton, checkboxes).init();
+  [checkboxes, selectAllButton] = createElements();
+  return new SelectAll(checkboxes, selectAllButton).init();
 };
 
 test("Checkboxes set before init sets button text", () => {
-  [selectAllButton, checkboxes] = createElements();
+  [checkboxes, selectAllButton] = createElements();
   checkboxes.forEach((checkbox) => (checkbox.checked = true));
-  new SelectAll(selectAllButton, checkboxes).init();
+  new SelectAll(checkboxes, selectAllButton).init();
   expect(selectAllButton).toHaveTextContent("Deselect all");
 });
 

--- a/core/assets/javascripts/select-all.js
+++ b/core/assets/javascripts/select-all.js
@@ -2,9 +2,9 @@ export const SELECT_ALL_BUTTON_TEXT = "Select all";
 export const DESELECT_ALL_BUTTON_TEXT = "Deselect all";
 
 class SelectAll {
-  constructor($selectAllButton, $checkboxes) {
-    this.$selectAllButton = $selectAllButton;
+  constructor($checkboxes, $selectAllButton) {
     this.$checkboxes = $checkboxes;
+    this.$selectAllButton = $selectAllButton;
 
     this.isAllSelected = false;
   }

--- a/core/assets/javascripts/select-all.js
+++ b/core/assets/javascripts/select-all.js
@@ -2,33 +2,18 @@ export const SELECT_ALL_BUTTON_TEXT = "Select all";
 export const DESELECT_ALL_BUTTON_TEXT = "Deselect all";
 
 class SelectAll {
-  constructor($checkboxes, $selectAllButton) {
+  constructor($checkboxes, allSelectedCallback) {
     this.$checkboxes = $checkboxes;
-    this.$selectAllButton = $selectAllButton;
+    this.allSelectedCallback = allSelectedCallback;
 
-    this.isAllSelected = false;
+    this.isAllSelected = null;
   }
 
   init() {
-    this.$selectAllButton.addEventListener("click", (evt) =>
-      this.handleSelectAllButtonClick(evt)
-    );
     for (const $checkbox of this.$checkboxes) {
       $checkbox.addEventListener("input", () => this.setSelectAll());
     }
     this.setSelectAll();
-  }
-
-  handleSelectAllButtonClick(evt) {
-    evt.preventDefault();
-    this.setCheckboxesChecked(!this.isAllSelected);
-  }
-
-  setCheckboxesChecked(checked) {
-    for (const $checkbox of this.$checkboxes) {
-      $checkbox.checked = checked;
-      $checkbox.dispatchEvent(new Event("input"));
-    }
   }
 
   getNumChecked() {
@@ -40,12 +25,24 @@ class SelectAll {
   }
 
   setSelectAll() {
-    if (this.getNumChecked() === this.$checkboxes.length) {
-      this.$selectAllButton.textContent = DESELECT_ALL_BUTTON_TEXT;
-      this.isAllSelected = true;
-    } else {
-      this.$selectAllButton.textContent = SELECT_ALL_BUTTON_TEXT;
-      this.isAllSelected = false;
+    const isAllSelected = this.getNumChecked() === this.$checkboxes.length;
+    if (this.isAllSelected !== isAllSelected) {
+      this.allSelectedCallback(isAllSelected);
+      this.isAllSelected = isAllSelected;
+    }
+  }
+
+  selectAll() {
+    for (const $checkbox of this.$checkboxes) {
+      $checkbox.checked = true;
+      $checkbox.dispatchEvent(new Event("input"));
+    }
+  }
+
+  deselectAll() {
+    for (const $checkbox of this.$checkboxes) {
+      $checkbox.checked = false;
+      $checkbox.dispatchEvent(new Event("input"));
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build_caseworker": "parcel build ./caseworker/assets/javascripts/{main,head,bookmarks,cookie-policy-form,search-cases,search-products,beis,tau,tau-edit,case-filters,refusal-review-consolidate}.js --dist-dir caseworker/assets/built --public-url /assets/",
     "watch_exporter": "parcel watch --port 8400 ./exporter/assets/javascripts/{main,head}.js ./exporter/assets/javascripts/cookie-policy-form.js --dist-dir exporter/assets/built --public-url /assets/",
     "watch_caseworker": "parcel watch --port 8401 ./caseworker/assets/javascripts/{main,head,bookmarks,cookie-policy-form,search-cases,search-products,beis,tau,tau-edit,case-filters,refusal-review-consolidate}.js --dist-dir caseworker/assets/built --public-url /assets/",
-    "watch": "concurrently 'npm run watch_exporter' 'npm run watch_caseworker'",
+    "watch": "rm -rf .parcel-cache && concurrently 'npm run watch_exporter' 'npm run watch_caseworker'",
     "build": "npm install --no-save && npm run build_all",
     "build_all": "export NODE_ENV=production && concurrently 'npm run build_exporter' 'npm run build_caseworker'",
     "heroku-postbuild": "npm run build && rm -r node_modules",


### PR DESCRIPTION
### Aim

This is the first step to having the "Select all" checkboxes on the queue page be toggled via a checkbox input as opposed to a button pretending to be a checkbox.

I'm taking this as an opportunity to reuse the component we already have that select checkboxes, although currently it assumes that there will be a button that handles this interaction whereas we want it to be a checkbox for the queue.

This initial pull request makes the SelectAll component only aware of checkboxes so that it can interact with other components when required.
