### PR TITLE
LTD-4072: Add missing h2 for Applications tile

### DIFF
--- a/exporter/templates/core/hub.html
+++ b/exporter/templates/core/hub.html
@@ -76,9 +76,11 @@
 			{# Applications tile #}
 			{% if existing.applications %}
 				<div class="app-tile">
-					<a href="{% url 'applications:applications' %}" class="app-tile__heading" id="link-applications">
-						<p>{% lcs 'hub.Tiles.APPLICATIONS' %}</p>{% if notifications.notifications.application %}<span id="applications-notifications" class="lite-notification-bubble"><span class="govuk-visually-hidden"> (</span>{{ notifications.notifications.application }} <span class="govuk-visually-hidden">notifications)</span></span>{% endif %}
-					</a>
+					<h2 class="govuk-!-margin-top-0">
+						<a href="{% url 'applications:applications' %}" class="app-tile__heading" id="link-applications">
+							<p>{% lcs 'hub.Tiles.APPLICATIONS' %}</p>{% if notifications.notifications.application %}<span id="applications-notifications" class="lite-notification-bubble"><span class="govuk-visually-hidden"> (</span>{{ notifications.notifications.application }} <span class="govuk-visually-hidden">notifications)</span></span>{% endif %}
+						</a>
+					</h2>
 					<p class="app-tile__body">{% lcs 'hub.Tiles.Applications.CHECK_PROGRESS' %}</p>
 					<p class="app-tile__body">{% lcs 'hub.Tiles.Applications.EDIT_APPLICATIONS' %}</p>
 				</div>


### PR DESCRIPTION
### Aim

This was missed in previous iteration

[LTD-4072](https://uktrade.atlassian.net/browse/LTD-4072)


[LTD-4072]: https://uktrade.atlassian.net/browse/LTD-4072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ