### PR TITLE
Bump disk quota in manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -5,3 +5,4 @@ applications:
       - https://github.com/cloudfoundry/python-buildpack.git#v1.8.3
     health-check-type: http
     health-check-http-endpoint: /healthcheck/
+    disk_quota: 4096M


### PR DESCRIPTION
This is to allow the build process to run without failing

[LTD-4100](https://uktrade.atlassian.net/browse/LTD-4100)


[LTD-4100]: https://uktrade.atlassian.net/browse/LTD-4100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ