### PR TITLE
LTD-2022: Fix contrast of back links

### DIFF
--- a/caseworker/assets/styles/overrides/_back-link.scss
+++ b/caseworker/assets/styles/overrides/_back-link.scss
@@ -7,6 +7,10 @@
 		&::before {
 			border-color: currentColor;
 		}
+
+		&:focus {
+			color: govuk-colour("black")!important;
+		}
 	}
 
 	&::before {


### PR DESCRIPTION
## Change description

Back links are currently displayed in white color against a dark background. When they are cllicked the focus color is yellow and it makes it difficult to read as the text is white. To improve the contrast the text color is changed to black when the link is in focus.

[LTD-2022](https://uktrade.atlassian.net/browse/LTD-2022)
