### PR TITLE
Set a href value for queue menu link

### DIFF
--- a/caseworker/assets/javascripts/queues-menu.js
+++ b/caseworker/assets/javascripts/queues-menu.js
@@ -20,7 +20,7 @@ export default function initQueuesMenu() {
     }
   });
 
-  $("#link-queue").removeAttr("href");
+  $("#link-queue").attr("href", "#");
 
   // deliberately written in vanilla JS not jquery
   const queuesMenu = document.getElementById("queues");


### PR DESCRIPTION
### Aim

This is to make sure that the queue link is accessible via a keyboard and a blank href stops keyboard input.

[LTD-4109](https://uktrade.atlassian.net/browse/LTD-4109)
