### PR TITLE
[LTD-3975] Re-activate LU refusal UI test after API update

### DIFF
--- a/ui_tests/caseworker/features/give_advice.feature
+++ b/ui_tests/caseworker/features/give_advice.feature
@@ -277,7 +277,7 @@ Feature: I want to record my user advice and any comments and conditions relatin
     And I see the case is not assigned to any queues
 
 
-  @skip @lu_refuse_advice
+  @lu_refuse_advice
   Scenario: LU refuse advice journey
     # Setup
     Given I sign in to SSO or am signed into SSO


### PR DESCRIPTION
### Aim
Now API is updated (https://github.com/uktrade/lite-api/pull/1534), lu refuse advice UI test can be re-enabled.

[LTD-3975](https://uktrade.atlassian.net/browse/LTD-3975)
