### PR TITLE
 LTD-4129-inform-letter-status-decision-docs 

### DIFF
--- a/caseworker/advice/templates/advice/decision_documents.html
+++ b/caseworker/advice/templates/advice/decision_documents.html
@@ -39,7 +39,7 @@
 			</strong>
 		  </td>
 		  <td class="govuk-table__cell">
-		    <a href={% if data.value == 'Inform letter' %} "{% url 'cases:select-inform-template' queue_id case.id %}" {% else %}  "{% url 'cases:finalise_document_template' queue_id case.id decision %}" {% endif %} class="govuk-button" data-module="govuk-button" id="generate-document-{{ decision }}">
+		    <a href={% if data.value == 'Inform' %} "{% url 'cases:select-inform-template' queue_id case.id %}" {% else %}  "{% url 'cases:finalise_document_template' queue_id case.id decision %}" {% endif %} class="govuk-button" data-module="govuk-button" id="generate-document-{{ decision }}">
 			  Create {{data.value}}
 		    </a>
 		  </td>

--- a/caseworker/advice/views.py
+++ b/caseworker/advice/views.py
@@ -11,7 +11,7 @@ from requests.exceptions import HTTPError
 from caseworker.advice import forms, services, constants
 from caseworker.advice.forms import BEISTriggerListAssessmentForm, BEISTriggerListAssessmentEditForm
 from caseworker.cases.helpers.case import CaseworkerMixin
-from caseworker.cases.services import get_case
+from caseworker.cases.services import get_case, get_final_decision_documents
 from caseworker.cases.views.main import CaseTabsMixin
 from caseworker.core.helpers import get_organisation_documents
 from caseworker.core.services import get_denial_reasons, group_denial_reasons
@@ -766,14 +766,10 @@ class ViewConsolidatedAdviceView(AdviceView, FormView):
             finalise_case = not (lu_countersign_required or rejected_lu_countersignature)
 
         refusal_note = [advice for advice in consolidated_advice if advice["is_refusal_note"]]
+
         # Only show decision documents inform letter if we have a refuse
-
-        decisions = {}
-
-        for advice in self.case["advice"]:
-            if advice["type"]["key"] == "refuse":
-                decisions = {"inform_letter": {"value": "Inform letter"}}
-                break
+        decisions, _ = get_final_decision_documents(self.request, self.case.id)
+        decision_documents = {key: value for key, value in decisions.get("documents", {}).items() if key == "inform"}
 
         return {
             **super().get_context(**kwargs),
@@ -783,7 +779,7 @@ class ViewConsolidatedAdviceView(AdviceView, FormView):
             "lu_countersign_required": lu_countersign_required,
             "finalise_case": finalise_case,
             "case": self.case,
-            "decisions": decisions,
+            "decisions": decision_documents,
             "queue_id": self.queue_id,
             "refusal_note": refusal_note,
         }

--- a/caseworker/cases/views/finalisation/letters.py
+++ b/caseworker/cases/views/finalisation/letters.py
@@ -82,6 +82,7 @@ class EditLetterText(BaseLetter):
 
     def form_valid(self, form):
         self.kwargs["tpk"] = self.template_id
+        self.kwargs["decision_key"] = "inform"
         case_id = str(self.kwargs["pk"])
         addressee = self.kwargs.get("addressee", "")
         text = str(form.cleaned_data["text"])
@@ -96,5 +97,13 @@ class EditLetterText(BaseLetter):
         return render(
             self.request,
             "generated-documents/preview.html",
-            {"preview": preview["preview"], "text": text, "addressee": addressee, "kwargs": self.kwargs},
+            {
+                "preview": preview["preview"],
+                "text": text,
+                "addressee": addressee,
+                "kwargs": self.kwargs,
+                "return_url": reverse(
+                    "cases:consolidate_view", kwargs={"queue_pk": self.kwargs["queue_pk"], "pk": case_id}
+                ),
+            },
         )

--- a/caseworker/cases/views/generate_document.py
+++ b/caseworker/cases/views/generate_document.py
@@ -197,5 +197,7 @@ class CreateDocumentFinalAdvice(LoginRequiredMixin, TemplateView):
         )
         if status_code != HTTPStatus.CREATED:
             return generate_document_error_page()
-        else:
-            return redirect(reverse_lazy("cases:finalise_documents", kwargs={"queue_pk": queue_pk, "pk": pk}))
+        if request.POST.get("return_url"):
+            return redirect(request.POST["return_url"])
+
+        return redirect(reverse_lazy("cases:finalise_documents", kwargs={"queue_pk": queue_pk, "pk": pk}))

--- a/caseworker/templates/generated-documents/preview.html
+++ b/caseworker/templates/generated-documents/preview.html
@@ -14,6 +14,9 @@
 				{% endif %}
 				{% csrf_token %}
 				<input name="text" type="hidden" value="{{ text }}">
+				{% if return_url %}
+					<input name="return_url" type="hidden" value="{{ return_url }}">
+                {% endif %}
 				<input name="addressee" type="hidden" value="{{ addressee }}">
 				<button class="govuk-button" type="submit">{% lcs 'letter_templates.LetterTemplatesPage.PickTemplate.BUTTON' %}</button>
 				</form>

--- a/unit_tests/caseworker/advice/views/test_consolidate.py
+++ b/unit_tests/caseworker/advice/views/test_consolidate.py
@@ -1127,10 +1127,10 @@ def test_finalise_button_shown_correctly_for_lu_countersigning_scenarios(
 
 @pytest.mark.parametrize(
     "decision_document",
-    (
-        ({"documents": {"inform_letter": {"hello": "world"}}}),
-        ({"documents": {"refusal": {}, "approval": {}, "inform_letter": {"hello": "world"}}},),
-    ),
+    [
+        {"documents": {"inform": {"value": "Inform"}}},
+        {"documents": {"refuse": {"value": "Refuse"}, "inform": {"value": "Inform"}}},
+    ],
 )
 def test_decision_document_present(
     requests_mock,
@@ -1152,7 +1152,7 @@ def test_decision_document_present(
     response = authorized_client.get(view_consolidate_outcome_url)
     assert response.status_code == 200
 
-    assert response.context["decisions"] == {"inform_letter": {"value": "Inform letter"}}
+    assert response.context["decisions"] == {"inform": {"value": "Inform"}}
 
     soup = BeautifulSoup(response.content, "html.parser")
     table = soup.find("table", attrs={"name": "decision_document"})


### PR DESCRIPTION
As part of https://github.com/uktrade/lite-api/pull/1545
We have added a new advice type 'Inform' 

This advice type is now used to drive the inform letter similar to how the other decision documents work 