### PR TITLE
LTD-4115: Add option to start appeal if an application is refused

### DIFF
--- a/exporter/applications/rules.py
+++ b/exporter/applications/rules.py
@@ -1,11 +1,22 @@
 import rules
 
+from datetime import datetime
+
 from django.conf import settings
 
 
 @rules.predicate
-def is_appeal_feature_flag_set(request):
-    return settings.FEATURE_FLAG_APPEALS
+def is_appeal_feature_flag_set(request, application):
+    if not settings.FEATURE_FLAG_APPEALS:
+        return False
+
+    if application and (application.licence or not application.appeal_deadline):
+        return False
+
+    appeal_deadline_date_str = application.appeal_deadline.split("T")[0]
+    appeal_deadline = datetime.strptime(appeal_deadline_date_str, "%Y-%m-%d")
+
+    return datetime.today().date() <= appeal_deadline.date()
 
 
 rules.add_rule("can_user_appeal_case", is_appeal_feature_flag_set)

--- a/exporter/applications/views/common.py
+++ b/exporter/applications/views/common.py
@@ -390,7 +390,7 @@ class AppealApplication(LoginRequiredMixin, FormView):
         except HTTPError:
             raise Http404()
 
-        if not rules.test_rule("can_user_appeal_case", request):
+        if not rules.test_rule("can_user_appeal_case", request, self.application):
             raise Http404()
 
         return super().dispatch(request, **kwargs)

--- a/exporter/templates/applications/application.html
+++ b/exporter/templates/applications/application.html
@@ -39,7 +39,7 @@
 						</a>
 					{% endif %}
 					{# Using licence_duration to check that there is a licence to surrender #}
-					{% if application.licence.status.key != "surrendered" %}
+					{% if application.licence and application.licence.status.key != "surrendered" %}
 						<a href="{% url 'applications:surrender' application.id %}" id="button-surrender-application" class="govuk-button govuk-button--secondary">
 							{% lcs 'applications.ApplicationSummaryPage.Buttons.SURRENDER_APPLICATION_BUTTON' %}
 						</a>

--- a/exporter/templates/applications/application.html
+++ b/exporter/templates/applications/application.html
@@ -44,6 +44,11 @@
 							{% lcs 'applications.ApplicationSummaryPage.Buttons.SURRENDER_APPLICATION_BUTTON' %}
 						</a>
 					{% endif %}
+					{% if not application.licence and application.appeal_deadline %}
+						<a href="{% url 'applications:appeal' application.id %}" id="button-appeal-refusal" class="govuk-button govuk-button--secondary">
+							Appeal refusal decision
+						</a>
+					{% endif %}
 				{% endif %}
 			</div>
 		{% endif %}

--- a/exporter/templates/applications/application.html
+++ b/exporter/templates/applications/application.html
@@ -46,8 +46,8 @@
 							{% lcs 'applications.ApplicationSummaryPage.Buttons.SURRENDER_APPLICATION_BUTTON' %}
 						</a>
 					{% endif %}
-					{% test_rule 'can_user_appeal_case' request as can_user_appeal_case %}
-					{% if can_user_appeal_case and not application.licence and application.appeal_deadline %}
+					{% test_rule 'can_user_appeal_case' request application as can_user_appeal_case %}
+					{% if can_user_appeal_case %}
 						<a href="{% url 'applications:appeal' application.id %}" id="button-appeal-refusal" class="govuk-button govuk-button--secondary">
 							Appeal refusal decision
 						</a>

--- a/exporter/templates/applications/application.html
+++ b/exporter/templates/applications/application.html
@@ -1,5 +1,7 @@
 {% extends 'layouts/base.html' %}
 
+{% load rules %}
+
 {% block back_link %}
 	{% if summary_page %}
 		<a href="{% url 'applications:task_list' case_id %}" id="back-link" class="govuk-back-link">
@@ -44,7 +46,8 @@
 							{% lcs 'applications.ApplicationSummaryPage.Buttons.SURRENDER_APPLICATION_BUTTON' %}
 						</a>
 					{% endif %}
-					{% if not application.licence and application.appeal_deadline %}
+					{% test_rule 'can_user_appeal_case' request as can_user_appeal_case %}
+					{% if can_user_appeal_case and not application.licence and application.appeal_deadline %}
 						<a href="{% url 'applications:appeal' application.id %}" id="button-appeal-refusal" class="govuk-button govuk-button--secondary">
 							Appeal refusal decision
 						</a>

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -1000,6 +1000,7 @@ def data_standard_case(
                 "compliant_limitations_eu_ref": None,
                 "intended_end_use": "44",
                 "licence": None,
+                "appeal_deadline": "",
                 "is_shipped_waybill_or_lading": False,
                 "non_waybill_or_lading_route_details": "44",
                 "is_mod_security_approved": None,

--- a/unit_tests/exporter/applications/test_rules.py
+++ b/unit_tests/exporter/applications/test_rules.py
@@ -1,15 +1,35 @@
 import pytest
 import rules
 
+from datetime import datetime, timedelta
+
+from django.utils import timezone
+
+from exporter.core.objects import Application
+
 
 @pytest.mark.parametrize(
-    "flag_value, expected",
+    "flag_value, licence, days_until_deadline, expected",
     (
-        (True, True),
-        (False, False),
+        (False, None, None, False),
+        (True, {"reference_code": "GBSIEL/2023/0000001/P"}, None, False),
+        (True, None, -1, False),  # deadline is 1 day before today
+        (True, None, 0, True),  # today is the deadline
+        (True, None, 5, True),  # deadline is 5 days from today
     ),
 )
-def test_can_user_appeal_case_based_on_feature_flag(settings, flag_value, expected, rf):
+def test_can_user_appeal_case_based_on_feature_flag(
+    settings, rf, data_standard_case, flag_value, licence, days_until_deadline, expected
+):
     settings.FEATURE_FLAG_APPEALS = flag_value
+    data_standard_case["licence"] = licence
+    data_standard_case["appeal_deadline"] = ""
+
+    if days_until_deadline is not None:
+        appeal_deadline = timezone.localtime() + timedelta(days_until_deadline)
+        data_standard_case["appeal_deadline"] = appeal_deadline.isoformat()
+
+    application = Application(data_standard_case)
+
     request = rf.get("/")
-    assert rules.test_rule("can_user_appeal_case", request) is expected
+    assert rules.test_rule("can_user_appeal_case", request, application) is expected

--- a/unit_tests/exporter/applications/test_rules.py
+++ b/unit_tests/exporter/applications/test_rules.py
@@ -1,35 +1,51 @@
 import pytest
 import rules
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from django.utils import timezone
 
+from exporter.applications import rules as appeal_rules
 from exporter.core.objects import Application
 
 
+def test_can_user_appeal_case_rule_predicates(settings, rf, data_standard_case):
+    settings.FEATURE_FLAG_APPEALS = True
+    data_standard_case["case"]["data"]["appeal_deadline"] = ""
+
+    request = rf.get("/")
+    assert not appeal_rules.is_application_finalised(request, None)
+    assert not appeal_rules.is_application_refused(request, None)
+    assert not appeal_rules.appeal_within_deadline(request, None)
+
+    application = Application(data_standard_case["case"]["data"])
+    assert not appeal_rules.appeal_within_deadline(request, application)
+
+
 @pytest.mark.parametrize(
-    "flag_value, licence, days_until_deadline, expected",
+    "flag_value, status, licence, days_until_deadline, expected",
     (
-        (False, None, None, False),
-        (True, {"reference_code": "GBSIEL/2023/0000001/P"}, None, False),
-        (True, None, -1, False),  # deadline is 1 day before today
-        (True, None, 0, True),  # today is the deadline
-        (True, None, 5, True),  # deadline is 5 days from today
+        (False, "submitted", None, None, False),
+        (True, "under_final_review", {"reference_code": "GBSIEL/2023/0000001/P"}, None, False),
+        (True, "finalised", {"reference_code": "GBSIEL/2023/0000001/P"}, None, False),
+        (True, "finalised", None, -1, False),  # we are past deadline by 1 day
+        (True, "finalised", None, 0, True),  # today is the deadline
+        (True, "finalised", None, 5, True),  # deadline is 5 days from today
     ),
 )
 def test_can_user_appeal_case_based_on_feature_flag(
-    settings, rf, data_standard_case, flag_value, licence, days_until_deadline, expected
+    settings, rf, data_standard_case, flag_value, status, licence, days_until_deadline, expected
 ):
     settings.FEATURE_FLAG_APPEALS = flag_value
-    data_standard_case["licence"] = licence
-    data_standard_case["appeal_deadline"] = ""
+    data_standard_case["case"]["data"]["status"] = {"key": status, "value": status.title()}
+    data_standard_case["case"]["data"]["licence"] = licence
+    data_standard_case["case"]["data"]["appeal_deadline"] = ""
 
     if days_until_deadline is not None:
         appeal_deadline = timezone.localtime() + timedelta(days_until_deadline)
-        data_standard_case["appeal_deadline"] = appeal_deadline.isoformat()
+        data_standard_case["case"]["data"]["appeal_deadline"] = appeal_deadline.isoformat()
 
-    application = Application(data_standard_case)
+    application = Application(data_standard_case["case"]["data"])
 
     request = rf.get("/")
     assert rules.test_rule("can_user_appeal_case", request, application) is expected

--- a/unit_tests/exporter/applications/views/conftest.py
+++ b/unit_tests/exporter/applications/views/conftest.py
@@ -3,6 +3,7 @@ import pytest
 import uuid
 
 from django.urls import reverse
+from django.utils import timezone
 
 from core import client
 from core.constants import (
@@ -19,6 +20,14 @@ def application(data_standard_case):
 @pytest.fixture
 def mock_application_get(requests_mock, data_standard_case):
     application = data_standard_case["case"]["data"]
+    url = client._build_absolute_uri(f'/applications/{application["id"]}/')
+    return requests_mock.get(url=url, json=application)
+
+
+@pytest.fixture
+def mock_refused_application_get(requests_mock, data_standard_case):
+    application = data_standard_case["case"]["data"]
+    application = {**application, "licence": None, "appeal_deadline": timezone.localtime().isoformat()}
     url = client._build_absolute_uri(f'/applications/{application["id"]}/')
     return requests_mock.get(url=url, json=application)
 

--- a/unit_tests/exporter/applications/views/conftest.py
+++ b/unit_tests/exporter/applications/views/conftest.py
@@ -27,7 +27,12 @@ def mock_application_get(requests_mock, data_standard_case):
 @pytest.fixture
 def mock_refused_application_get(requests_mock, data_standard_case):
     application = data_standard_case["case"]["data"]
-    application = {**application, "licence": None, "appeal_deadline": timezone.localtime().isoformat()}
+    application = {
+        **application,
+        "status": {"key": "finalised", "value": "Finalised"},
+        "licence": None,
+        "appeal_deadline": timezone.localtime().isoformat(),
+    }
     url = client._build_absolute_uri(f'/applications/{application["id"]}/')
     return requests_mock.get(url=url, json=application)
 

--- a/unit_tests/exporter/applications/views/test_appeal.py
+++ b/unit_tests/exporter/applications/views/test_appeal.py
@@ -6,8 +6,12 @@ from pytest_django.asserts import assertContains, assertTemplateUsed
 from django.urls import reverse
 
 from core import client
-
 from exporter.applications.forms.appeal import AppealForm
+
+
+@pytest.fixture(autouse=True)
+def setup(mock_refused_application_get):
+    yield
 
 
 @pytest.fixture(autouse=True)
@@ -22,15 +26,7 @@ def invalid_application_pk():
 
 @pytest.fixture
 def application_pk(data_standard_case):
-    return data_standard_case["case"]["id"]
-
-
-@pytest.fixture(autouse=True)
-def mock_get_application(requests_mock, application_pk, data_standard_case):
-    requests_mock.get(
-        client._build_absolute_uri(f"/applications/{application_pk}/"),
-        json=data_standard_case["case"],
-    )
+    return data_standard_case["case"]["data"]["id"]
 
 
 @pytest.fixture(autouse=True)

--- a/unit_tests/exporter/applications/views/test_application_detail.py
+++ b/unit_tests/exporter/applications/views/test_application_detail.py
@@ -21,16 +21,22 @@ def test_edit_button(authorized_client, data_standard_case, mock_application_get
         assert soup.find(id="button-edit-application")
 
 
-def test_appeal_refusal_decision_button(authorized_client, data_standard_case, mock_refused_application_get):
+@pytest.mark.parametrize("feature_appeals_status", [True, False])
+def test_appeal_refusal_decision_button(
+    authorized_client, settings, data_standard_case, mock_refused_application_get, feature_appeals_status
+):
+    settings.FEATURE_FLAG_APPEALS = feature_appeals_status
     pk = data_standard_case["case"]["id"]
 
     application_url = reverse("applications:application", kwargs={"pk": pk})
     response = authorized_client.get(application_url)
     soup = BeautifulSoup(response.content, "html.parser")
-    assert soup.find(id="button-appeal-refusal")
+    assert not (not soup.find(id="button-appeal-refusal")) is feature_appeals_status
 
 
-def test_appeal_button_not_shown_for_successful_application(authorized_client, data_standard_case, mock_application_get):
+def test_appeal_button_not_shown_for_successful_application(
+    authorized_client, data_standard_case, mock_application_get
+):
     pk = data_standard_case["case"]["id"]
 
     application_url = reverse("applications:application", kwargs={"pk": pk})

--- a/unit_tests/exporter/applications/views/test_application_detail.py
+++ b/unit_tests/exporter/applications/views/test_application_detail.py
@@ -19,3 +19,21 @@ def test_edit_button(authorized_client, data_standard_case, mock_application_get
         assert not soup.find(id="button-edit-application")
     else:
         assert soup.find(id="button-edit-application")
+
+
+def test_appeal_refusal_decision_button(authorized_client, data_standard_case, mock_refused_application_get):
+    pk = data_standard_case["case"]["id"]
+
+    application_url = reverse("applications:application", kwargs={"pk": pk})
+    response = authorized_client.get(application_url)
+    soup = BeautifulSoup(response.content, "html.parser")
+    assert soup.find(id="button-appeal-refusal")
+
+
+def test_appeal_button_not_shown_for_successful_application(authorized_client, data_standard_case, mock_application_get):
+    pk = data_standard_case["case"]["id"]
+
+    application_url = reverse("applications:application", kwargs={"pk": pk})
+    response = authorized_client.get(application_url)
+    soup = BeautifulSoup(response.content, "html.parser")
+    assert not soup.find(id="button-appeal-refusal")

--- a/unit_tests/exporter/applications/views/test_application_detail.py
+++ b/unit_tests/exporter/applications/views/test_application_detail.py
@@ -31,7 +31,7 @@ def test_appeal_refusal_decision_button(
     application_url = reverse("applications:application", kwargs={"pk": pk})
     response = authorized_client.get(application_url)
     soup = BeautifulSoup(response.content, "html.parser")
-    assert not (not soup.find(id="button-appeal-refusal")) is feature_appeals_status
+    assert bool(soup.find(id="button-appeal-refusal")) == feature_appeals_status
 
 
 def test_appeal_button_not_shown_for_successful_application(


### PR DESCRIPTION
### Aim

Exporters can appeal a refusal decision within 28 days.
Provide an option in exporter dashboard to start the appeal process.

[LTD-4115](https://uktrade.atlassian.net/browse/LTD-4115)
