### PR TITLE
 LTD-4132-remove-inform-on-finialization-screen 

### DIFF
--- a/caseworker/advice/views.py
+++ b/caseworker/advice/views.py
@@ -766,8 +766,8 @@ class ViewConsolidatedAdviceView(AdviceView, FormView):
             finalise_case = not (lu_countersign_required or rejected_lu_countersignature)
 
         refusal_note = [advice for advice in consolidated_advice if advice["is_refusal_note"]]
-
         # Only show an inform letter on the decision documents
+
         decisions, _ = get_final_decision_documents(self.request, self.case.id)
         decision_documents = {key: value for key, value in decisions.get("documents", {}).items() if key == "inform"}
 

--- a/caseworker/advice/views.py
+++ b/caseworker/advice/views.py
@@ -766,6 +766,7 @@ class ViewConsolidatedAdviceView(AdviceView, FormView):
             finalise_case = not (lu_countersign_required or rejected_lu_countersignature)
 
         refusal_note = [advice for advice in consolidated_advice if advice["is_refusal_note"]]
+
         # Only show an inform letter on the decision documents
 
         decisions, _ = get_final_decision_documents(self.request, self.case.id)

--- a/caseworker/cases/views/advice.py
+++ b/caseworker/cases/views/advice.py
@@ -298,10 +298,8 @@ class FinaliseGenerateDocuments(LoginRequiredMixin, SingleFormView):
         decisions, _ = get_final_decision_documents(request, self.object_pk)
 
         # Remove the inform letter from finalisation documents
-        import pdb
-        pdb.set_trace()
-        
-        decisions = {key:value for (key, value) in decisions["documents"].items() if key!='inform'}
+
+        decisions = {key: value for (key, value) in decisions["documents"].items() if key != "inform"}
         can_submit = all([decision.get("document") for decision in decisions.values()])
         self.context = {
             "case": case,

--- a/caseworker/cases/views/advice.py
+++ b/caseworker/cases/views/advice.py
@@ -296,7 +296,12 @@ class FinaliseGenerateDocuments(LoginRequiredMixin, SingleFormView):
         case = get_case(request, self.object_pk)
         self.form = generate_documents_form(kwargs["queue_pk"], self.object_pk)
         decisions, _ = get_final_decision_documents(request, self.object_pk)
-        decisions = decisions["documents"]
+
+        # Remove the inform letter from finalisation documents
+        import pdb
+        pdb.set_trace()
+        
+        decisions = {key:value for (key, value) in decisions["documents"].items() if key!='inform'}
         can_submit = all([decision.get("document") for decision in decisions.values()])
         self.context = {
             "case": case,

--- a/caseworker/cases/views/generate_document.py
+++ b/caseworker/cases/views/generate_document.py
@@ -186,7 +186,6 @@ class SendExistingDocument(LoginRequiredMixin, View):
             )
         return redirect(reverse("queues:cases", kwargs={"queue_pk": queue_pk}))
 
-
 class CreateDocumentFinalAdvice(LoginRequiredMixin, TemplateView):
     def post(self, request, queue_pk, pk, decision_key, tpk):
         text = request.POST.get(TEXT)

--- a/caseworker/cases/views/generate_document.py
+++ b/caseworker/cases/views/generate_document.py
@@ -195,7 +195,7 @@ class CreateDocumentFinalAdvice(LoginRequiredMixin, TemplateView):
             str(pk),
             {"template": str(tpk), TEXT: text, "visible_to_exporter": False, "advice_type": decision_key},
         )
-        
+
         if status_code != HTTPStatus.CREATED:
             return generate_document_error_page()
         if request.POST.get("return_url"):

--- a/caseworker/cases/views/generate_document.py
+++ b/caseworker/cases/views/generate_document.py
@@ -186,6 +186,7 @@ class SendExistingDocument(LoginRequiredMixin, View):
             )
         return redirect(reverse("queues:cases", kwargs={"queue_pk": queue_pk}))
 
+
 class CreateDocumentFinalAdvice(LoginRequiredMixin, TemplateView):
     def post(self, request, queue_pk, pk, decision_key, tpk):
         text = request.POST.get(TEXT)

--- a/caseworker/cases/views/generate_document.py
+++ b/caseworker/cases/views/generate_document.py
@@ -195,7 +195,7 @@ class CreateDocumentFinalAdvice(LoginRequiredMixin, TemplateView):
             str(pk),
             {"template": str(tpk), TEXT: text, "visible_to_exporter": False, "advice_type": decision_key},
         )
-
+        
         if status_code != HTTPStatus.CREATED:
             return generate_document_error_page()
         if request.POST.get("return_url"):

--- a/unit_tests/caseworker/cases/views/test_generate_document.py
+++ b/unit_tests/caseworker/cases/views/test_generate_document.py
@@ -170,13 +170,17 @@ def test_finalise_document_create(
     assert response.url == redirect_url
 
 
-
-
 @pytest.mark.parametrize(
     "document_data, expected",
     (
-        ({'documents': {'refuse': {'value': 'Refuse'}, 'inform': {'value': 'Inform'}}}, {'refuse': {'value': 'Refuse'}}),
-        ({'documents': {'refuse': {'value': 'Refuse'}, 'nla': {'value': 'nla'}}}, {'refuse': {'value': 'Refuse'}, 'nla': {'value': 'nla'}}),
+        (
+            {"documents": {"refuse": {"value": "Refuse"}, "inform": {"value": "Inform"}}},
+            {"refuse": {"value": "Refuse"}},
+        ),
+        (
+            {"documents": {"refuse": {"value": "Refuse"}, "nla": {"value": "nla"}}},
+            {"refuse": {"value": "Refuse"}, "nla": {"value": "nla"}},
+        ),
     ),
 )
 def test_finalise_documents(
@@ -188,15 +192,13 @@ def test_finalise_documents(
     data_standard_case,
 ):
     pk = data_standard_case["case"]["id"]
-        
+
     mock_send_generated_document_create = requests_mock.get(
-        url=f' /cases/{pk}/final-advice-documents/', json=document_data
+        url=f" /cases/{pk}/final-advice-documents/", json=document_data
     )
-    
-    
+
     finalisation_document_url = reverse("cases:finalise_documents", kwargs={"queue_pk": queue_pk, "pk": pk})
     response = authorized_client.get(finalisation_document_url)
 
     assert response.status_code == 200
-    assert response.context['decisions'] == expected
-    
+    assert response.context["decisions"] == expected

--- a/unit_tests/caseworker/cases/views/test_generate_document.py
+++ b/unit_tests/caseworker/cases/views/test_generate_document.py
@@ -194,7 +194,7 @@ def test_finalise_documents(
     pk = data_standard_case["case"]["id"]
 
     mock_send_generated_document_create = requests_mock.get(
-        url=f" /cases/{pk}/final-advice-documents/", json=document_data
+        url=f"/cases/{pk}/final-advice-documents/", json=document_data
     )
 
     finalisation_document_url = reverse("cases:finalise_documents", kwargs={"queue_pk": queue_pk, "pk": pk})

--- a/unit_tests/caseworker/cases/views/test_generate_document.py
+++ b/unit_tests/caseworker/cases/views/test_generate_document.py
@@ -168,3 +168,35 @@ def test_finalise_document_create(
     redirect_url = reverse("cases:finalise_documents", kwargs={"queue_pk": queue_pk, "pk": pk})
     assert response.status_code == 302
     assert response.url == redirect_url
+
+
+
+
+@pytest.mark.parametrize(
+    "document_data, expected",
+    (
+        ({'documents': {'refuse': {'value': 'Refuse'}, 'inform': {'value': 'Inform'}}}, {'refuse': {'value': 'Refuse'}}),
+        ({'documents': {'refuse': {'value': 'Refuse'}, 'nla': {'value': 'nla'}}}, {'refuse': {'value': 'Refuse'}, 'nla': {'value': 'nla'}}),
+    ),
+)
+def test_finalise_documents(
+    document_data,
+    expected,
+    authorized_client,
+    queue_pk,
+    requests_mock,
+    data_standard_case,
+):
+    pk = data_standard_case["case"]["id"]
+        
+    mock_send_generated_document_create = requests_mock.get(
+        url=f' /cases/{pk}/final-advice-documents/', json=document_data
+    )
+    
+    
+    finalisation_document_url = reverse("cases:finalise_documents", kwargs={"queue_pk": queue_pk, "pk": pk})
+    response = authorized_client.get(finalisation_document_url)
+
+    assert response.status_code == 200
+    assert response.context['decisions'] == expected
+    


### PR DESCRIPTION
https://uktrade.atlassian.net/browse/LTD-4129

This is to hide the inform document from the finalisation screen.  Can't be feature flagged since we are looking to migrate documents away from this screen long term. 