### PR TITLE
[LTD-3938] Inform letter send

### DIFF
--- a/caseworker/advice/templates/advice/decision_documents.html
+++ b/caseworker/advice/templates/advice/decision_documents.html
@@ -18,13 +18,19 @@
             <a class="govuk-link" href="{% url 'cases:document' queue_id case.id data.document.id %}">{{ data.value }}</a>
           </td>
 		  <td class="govuk-table__cell">
-			<div id="status-{{ decision }}" data-status="done" class="govuk-tag govuk-tag--blue">READY TO SEND</div>
+			<div id="status-{{ decision }}" data-status="done" class="govuk-tag govuk-tag--blue">{% if data.document.visible_to_exporter %}SENT{% else %}READY TO SEND{% endif %}</div>
 		  </td>
 		  <td class="govuk-table__cell">
-            <!-- TODO: document.status.sent -->
+             {% if data.document.visible_to_exporter %}
 		     <a href="{% url 'cases:finalise_document_template' queue_id case.id decision %}" class="govuk-button" data-module="govuk-button">
 			Recreate
 		     </a>
+             {% else %}
+             <form action="{% url 'cases:generate_document_send' queue_id case.id data.document.id %}" method="POST">
+                {% csrf_token %}
+                <button type="submit" class="govuk-button" data-module="govuk-button">Send{% if data.value == "Inform"%} inform letter{% endif %}</button>
+             </form>
+             {% endif %}
 
 		  </td>
 		  <td class="govuk-table__cell">

--- a/unit_tests/caseworker/advice/views/test_consolidate.py
+++ b/unit_tests/caseworker/advice/views/test_consolidate.py
@@ -1,4 +1,5 @@
 import pytest
+import uuid
 from bs4 import BeautifulSoup
 from django.urls import reverse
 
@@ -1157,6 +1158,48 @@ def test_decision_document_present(
     soup = BeautifulSoup(response.content, "html.parser")
     table = soup.find("table", attrs={"name": "decision_document"})
     assert bool(table) is True
+
+
+@pytest.mark.parametrize(
+    "visible_to_exporter, expected_status",
+    [
+        [False, "READY TO SEND"],
+        [True, "SENT"],
+    ],
+)
+def test_decision_document_status(
+    requests_mock,
+    authorized_client,
+    data_standard_case,
+    view_consolidate_outcome_url,
+    consolidated_refusal_outcome,
+    mock_gov_lu_user,
+    visible_to_exporter,
+    expected_status,
+    settings,
+):
+    settings.FEATURE_FLAG_REFUSALS = True
+
+    data_standard_case["case"]["advice"] = consolidated_refusal_outcome
+
+    decision_url = client._build_absolute_uri(f"/cases/{data_standard_case['case']['id']}/final-advice-documents/")
+    response_json = {
+        "documents": {
+            "refuse": {"value": "Refuse"},
+            "inform": {
+                "value": "Inform",
+                "document": {"id": str(uuid.uuid4()), "visible_to_exporter": visible_to_exporter},
+            },
+        }
+    }
+    requests_mock.get(url=decision_url, json=response_json)
+
+    response = authorized_client.get(view_consolidate_outcome_url)
+    assert response.status_code == 200
+
+    soup = BeautifulSoup(response.content, "html.parser")
+    table = soup.find("table", attrs={"name": "decision_document"})
+    assert table.find("div", {"id": "status-inform"}).text == expected_status
 
 
 def test_decision_document_not_present(


### PR DESCRIPTION
### Aim

Ensure that inform letter status field progresses from "Ready to send" to "Sent" and wire up generated document send functionality.

[LTD-3938](https://uktrade.atlassian.net/browse/LTD-3938)
