### PR TITLE
changed applicant to addressee

### DIFF
--- a/caseworker/templates/teams/markdown-help.html
+++ b/caseworker/templates/teams/markdown-help.html
@@ -15,7 +15,7 @@
 
 <p class="govuk-inset-text govuk-inset-text--slim govuk-!-margin-top-0">
 	{% verbatim %}
-		Hello <span class="lite-highlight lite-highlight--blue">{{ applicant.name }}</span>, your reference is <span class="lite-highlight lite-highlight--blue">{{ refence_number }}</span>
+		Hello <span class="lite-highlight lite-highlight--blue">{{ addressee.name }}</span>, your reference is <span class="lite-highlight lite-highlight--blue">{{ refence_number }}</span>
 	{% endverbatim %}</p>
 
 <p class="govuk-body govuk-!-margin-bottom-2">Use magic brackets to have conditional content:</p>

--- a/caseworker/templates/teams/markdown-help.html
+++ b/caseworker/templates/teams/markdown-help.html
@@ -15,7 +15,7 @@
 
 <p class="govuk-inset-text govuk-inset-text--slim govuk-!-margin-top-0">
 	{% verbatim %}
-		Hello <span class="lite-highlight lite-highlight--blue">{{ addressee.name }}</span>, your reference is <span class="lite-highlight lite-highlight--blue">{{ refence_number }}</span>
+		Hello <span class="lite-highlight lite-highlight--blue">{{ addressee.name }}</span>, your reference is <span class="lite-highlight lite-highlight--blue">{{ case_reference }}</span>
 	{% endverbatim %}</p>
 
 <p class="govuk-body govuk-!-margin-bottom-2">Use magic brackets to have conditional content:</p>


### PR DESCRIPTION
### Aim
Addressee.name is referenced in the help with formatting/variable options

It looks like applicant.name was added in and has caused confusion as to why the applicant's name wasn't pulling through

[LTD-4108](https://uktrade.atlassian.net/browse/LTD-4108)
