### PR TITLE
Display confirmation page after creating an appeal

### DIFF
--- a/core/assets/styles/overrides/_panel.scss
+++ b/core/assets/styles/overrides/_panel.scss
@@ -1,7 +1,4 @@
-.govuk-panel {
-	@include govuk-responsive-padding(6);
-	text-align: left;
-
+.lite-panel {
 	.govuk-panel__title {
 		@include govuk-font($size: 36, $weight: bold);
 	}
@@ -9,53 +6,56 @@
 	.govuk-panel__body {
 		@include govuk-font($size: 24, $line-height: 1.66);
 	}
-}
 
-.lite-panel--confirmation {
-	background: govuk-colour("blue");
+	&--confirmation {
+		@include govuk-responsive-padding(6);
+		background: govuk-colour("blue");
+		text-align: left;
+	}
 
-	.lite-panel__status {
+	&__status {
 		display: grid;
 		grid-template-columns: 1fr 1fr 1fr;
 		grid-gap: govuk-spacing(6);
-	}
 
-	.lite-panel__status__item {
-		p {
-			font-weight: bold;
-			margin-top: govuk-spacing(6);
-			margin-bottom: govuk-spacing(1);
-		}
-	}
-
-	.lite-panel__status__item__progress {
-		position: relative;
-		width: 100%;
-		height: govuk-spacing(1);
-		background-color: rgba(govuk-colour("white"), 0.4);
-
-		&--in-progress {
-			opacity: 1;
-
-			&:after {
-				content: "";
-				position: absolute;
-				top: 0;
-				left: 0;
-				bottom: 0;
-				background-color: govuk-colour("white");
-				animation-name: lite-in-progress-pulse;
-				animation-duration: 1.5s;
-				animation-iteration-count: infinite;
-				animation-timing-function: ease-out;
+		&__item {
+			p {
+				font-weight: bold;
+				margin-top: govuk-spacing(6);
+				margin-bottom: govuk-spacing(1);
 			}
-		}
 
-		&--complete {
-			background-color: govuk-colour("white");
+			&__progress {
+				position: relative;
+				width: 100%;
+				height: govuk-spacing(1);
+				background-color: rgba(govuk-colour("white"), 0.4);
+
+				&--in-progress {
+					opacity: 1;
+
+					&:after {
+						content: "";
+						position: absolute;
+						top: 0;
+						left: 0;
+						bottom: 0;
+						background-color: govuk-colour("white");
+						animation-name: lite-in-progress-pulse;
+						animation-duration: 1.5s;
+						animation-iteration-count: infinite;
+						animation-timing-function: ease-out;
+					}
+				}
+
+				&--complete {
+					background-color: govuk-colour("white");
+				}
+			}
 		}
 	}
 }
+
 @keyframes lite-in-progress-pulse {
 	0% {
 		width: 0;

--- a/exporter/applications/services.py
+++ b/exporter/applications/services.py
@@ -558,13 +558,19 @@ def edit_good_on_application_firearm_details_serial_numbers(request, pk, good_on
 
 
 def post_appeal(request, application_pk, data):
-    data = client.post(request, f"/applications/{application_pk}/appeal/", data=data)
+    data = client.post(request, f"/applications/{application_pk}/appeals/", data=data)
     return data.json(), data.status_code
 
 
 def post_appeal_document(request, appeal_pk, data):
     data = client.post(request, f"/appeals/{appeal_pk}/documents/", data=data)
     return data.json(), data.status_code
+
+
+def get_appeal(request, application_pk, appeal_pk):
+    response = client.get(request, f"/applications/{application_pk}/appeal/{appeal_pk}/")
+    response.raise_for_status()
+    return response.json(), response.status_code
 
 
 def get_appeal_document(request, appeal_pk, document_pk):

--- a/exporter/applications/urls.py
+++ b/exporter/applications/urls.py
@@ -500,6 +500,11 @@ urlpatterns = [
     path("<uuid:pk>/surrender/", common.SurrenderApplication.as_view(), name="surrender"),
     path("<uuid:case_pk>/appeal/", common.AppealApplication.as_view(), name="appeal"),
     path(
+        "<uuid:case_pk>/appeal/<uuid:appeal_pk>/confirmation/",
+        common.AppealApplicationConfirmation.as_view(),
+        name="appeal_confirmation",
+    ),
+    path(
         "<uuid:case_pk>/appeal/<uuid:appeal_pk>/document/<uuid:document_pk>/download/",
         documents.DownloadAppealDocument.as_view(),
         name="appeal_document",

--- a/exporter/templates/applications/appeal-confirmation.html
+++ b/exporter/templates/applications/appeal-confirmation.html
@@ -1,0 +1,34 @@
+{% extends 'layouts/base.html' %}
+
+{% block title %}Appeal request complete - {{ application.reference_code }}{% endblock %}
+
+{% block back_link %}
+    <a href="{% url "applications:application" application.id %}" id="back-link" class="govuk-back-link">Back to application</a>
+{% endblock %}
+
+{% block body %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-panel govuk-panel--confirmation">
+                <h1 class="govuk-panel__title">
+                    Appeal request complete
+                </h1>
+                <div class="govuk-panel__body">
+                    Application reference number<br><strong>{{ application.reference_code }}</strong>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row govuk-!-margin-top-4">
+        <div class="govuk-grid-column-two-thirds">
+            <h2 class="govuk-heading-m">What happens next</h2>
+            <p class="govuk-body">ECJU will review your grounds for appeal to decide if they are valid. You'll receive an email to let you know the outcome.</p>
+            <p class="govuk-body">If your appeal is considered valid, ECJU will start a review of the refusal decision.</p>
+        </div>
+    </div>
+    <div class="govuk-grid-row govuk-!-margin-top-4">
+        <div class="govuk-grid-column-two-thirds">
+            <a class="govuk-button" href="{% url "applications:application" application.id %}">Back to application</a>
+        </div>
+    </div>
+{% endblock %}

--- a/lite_forms/templates/confirmation.html
+++ b/lite_forms/templates/confirmation.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block body %}
-	<div class="govuk-panel govuk-panel--confirmation {% if animated %}lite-panel--confirmation{% endif %} {% if request.GET.animate %}lite-spinner{% endif %}">
+	<div class="govuk-panel govuk-panel--confirmation lite-panel {% if animated %}lite-panel--confirmation{% endif %} {% if request.GET.animate %}lite-spinner{% endif %}">
 		<h1 id="registration-confirmation-value" class="govuk-panel__title">
 			{{ title }}
 		</h1>

--- a/unit_tests/exporter/applications/views/test_appeal.py
+++ b/unit_tests/exporter/applications/views/test_appeal.py
@@ -11,7 +11,7 @@ from exporter.applications.forms.appeal import AppealForm
 
 
 @pytest.fixture(autouse=True)
-def setup(mock_refused_application_get):
+def setup(mock_refused_application_get, mock_application_get):
     yield
 
 
@@ -30,6 +30,11 @@ def application_pk(data_standard_case):
     return data_standard_case["case"]["data"]["id"]
 
 
+@pytest.fixture
+def application_reference_number(data_standard_case):
+    return data_standard_case["case"]["reference_code"]
+
+
 @pytest.fixture(autouse=True)
 def mock_get_application_invalid_pk(requests_mock, invalid_application_pk):
     requests_mock.get(
@@ -40,13 +45,41 @@ def mock_get_application_invalid_pk(requests_mock, invalid_application_pk):
 
 
 @pytest.fixture
-def post_appeal_api_url(application_pk):
-    return client._build_absolute_uri(f"/applications/{application_pk}/appeal/")
+def appeal_pk():
+    return "c7e010b4-6c0c-4640-9a68-5bdee38c47d1"
 
 
 @pytest.fixture
-def appeal_pk():
-    return "c7e010b4-6c0c-4640-9a68-5bdee38c47d1"
+def invalid_appeal_pk():
+    return "155eca7b-0528-4922-b652-03246b7fd0a8"
+
+
+@pytest.fixture
+def get_appeal_api_url(application_pk, appeal_pk):
+    return client._build_absolute_uri(f"/applications/{application_pk}/appeal/{appeal_pk}/")
+
+
+@pytest.fixture(autouse=True)
+def mock_get_appeal(requests_mock, application_pk, appeal_pk):
+    return requests_mock.get(
+        client._build_absolute_uri(f"/applications/{application_pk}/appeal/{appeal_pk}/"),
+        json={"id": appeal_pk},
+        status_code=200,
+    )
+
+
+@pytest.fixture(autouse=True)
+def mock_get_appeal_invalid_pk(requests_mock, application_pk, invalid_appeal_pk):
+    return requests_mock.get(
+        client._build_absolute_uri(f"/applications/{application_pk}/appeal/{invalid_appeal_pk}/"),
+        json={},
+        status_code=404,
+    )
+
+
+@pytest.fixture
+def post_appeal_api_url(application_pk):
+    return client._build_absolute_uri(f"/applications/{application_pk}/appeals/")
 
 
 @pytest.fixture
@@ -100,6 +133,11 @@ def appeal_url(application_pk):
     return reverse("applications:appeal", kwargs={"case_pk": application_pk})
 
 
+@pytest.fixture
+def appeal_confirmation_url(application_pk, appeal_pk):
+    return reverse("applications:appeal_confirmation", kwargs={"case_pk": application_pk, "appeal_pk": appeal_pk})
+
+
 def test_appeal_view_feature_flag_off(authorized_client, appeal_url, settings):
     settings.FEATURE_FLAG_APPEALS = False
 
@@ -131,14 +169,14 @@ def test_appeal_view(authorized_client, appeal_url, application_url):
     assert soup.find("textarea", {"name": "grounds_for_appeal"})
 
 
-def test_post_appeal(authorized_client, appeal_url, application_url, mock_post_appeal):
+def test_post_appeal(authorized_client, appeal_url, appeal_confirmation_url, mock_post_appeal):
     response = authorized_client.post(
         appeal_url,
         data={"grounds_for_appeal": "These are my grounds for appeal"},
     )
 
     assert response.status_code == 302
-    assert response.url == application_url
+    assert response.url == appeal_confirmation_url
     assert mock_post_appeal.called_once
     assert mock_post_appeal.last_request.json() == {"grounds_for_appeal": "These are my grounds for appeal"}
 
@@ -146,7 +184,7 @@ def test_post_appeal(authorized_client, appeal_url, application_url, mock_post_a
 def test_post_appeal_with_files(
     authorized_client,
     appeal_url,
-    application_url,
+    appeal_confirmation_url,
     mock_post_appeal,
     mock_post_appeal_document,
 ):
@@ -162,7 +200,7 @@ def test_post_appeal_with_files(
     )
 
     assert response.status_code == 302
-    assert response.url == application_url
+    assert response.url == appeal_confirmation_url
 
     assert mock_post_appeal.called_once
     assert mock_post_appeal.last_request.json() == {"grounds_for_appeal": "These are my grounds for appeal"}
@@ -199,3 +237,42 @@ def test_post_appeal_with_files_failure(
     )
 
     assertContains(response, "Unexpected error creating appeal document")
+
+
+def test_appeal_confirmation_view(
+    authorized_client,
+    appeal_confirmation_url,
+    application_reference_number,
+):
+    response = authorized_client.get(appeal_confirmation_url)
+
+    assertTemplateUsed(response, "applications/appeal-confirmation.html")
+    assertContains(response, "Appeal request complete")
+    assertContains(response, "Application reference number")
+    assertContains(response, application_reference_number)
+
+
+def test_appeal_confirmation_view_invalid_application_pk(
+    authorized_client,
+    invalid_application_pk,
+    appeal_pk,
+):
+    url = reverse(
+        "applications:appeal_confirmation", kwargs={"case_pk": invalid_application_pk, "appeal_pk": appeal_pk}
+    )
+    response = authorized_client.get(url)
+
+    assert response.status_code == 404
+
+
+def test_appeal_confirmation_view_invalid_appeal_pk(
+    authorized_client,
+    application_pk,
+    invalid_appeal_pk,
+):
+    url = reverse(
+        "applications:appeal_confirmation", kwargs={"case_pk": application_pk, "appeal_pk": invalid_appeal_pk}
+    )
+    response = authorized_client.get(url)
+
+    assert response.status_code == 404

--- a/unit_tests/exporter/applications/views/test_appeal.py
+++ b/unit_tests/exporter/applications/views/test_appeal.py
@@ -1,9 +1,12 @@
 import pytest
 
+from datetime import timedelta
+
 from bs4 import BeautifulSoup
 from pytest_django.asserts import assertContains, assertTemplateUsed
 
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.utils import timezone
 from django.urls import reverse
 
 from core import client
@@ -11,8 +14,9 @@ from exporter.applications.forms.appeal import AppealForm
 
 
 @pytest.fixture(autouse=True)
-def setup(mock_refused_application_get, mock_application_get):
-    yield
+def setup(mock_refused_application_get, mock_application_get, data_standard_case):
+    data_standard_case["case"]["data"]["status"] = "finalised"
+    data_standard_case["case"]["data"]["appeal_deadline"] = (timezone.now() + timedelta(days=1)).isoformat()
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
### Aim

Add a confirmation page for the exporter once they have appealed their refusal.

[LTD-4125](https://uktrade.atlassian.net/browse/LTD-4125)


[LTD-4125]: https://uktrade.atlassian.net/browse/LTD-4125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ