### PR TITLE
Fix PartyReuseForm page title

### DIFF
--- a/exporter/applications/views/parties/end_users.py
+++ b/exporter/applications/views/parties/end_users.py
@@ -74,6 +74,11 @@ class AddEndUserView(LoginRequiredMixin, FormView):
     form_class = PartyReuseForm
     template_name = "core/form.html"
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["form_title"] = self.form_class.title
+        return context
+
     def form_valid(self, form):
         reuse_party = str_to_bool(form.cleaned_data.get("reuse_party"))
         if reuse_party:

--- a/unit_tests/exporter/applications/views/parties/test_end_users.py
+++ b/unit_tests/exporter/applications/views/parties/test_end_users.py
@@ -3,6 +3,7 @@ from django.core.files.storage import Storage
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 from unittest.mock import patch
+from bs4 import BeautifulSoup
 
 from core import client
 from exporter.core.constants import (
@@ -431,3 +432,13 @@ def test_edit_end_user_ec3_document(requests_mock, authorized_client, data_stand
         "s3_key": actual["s3_key"],
         "size": 0,
     }
+
+
+def test_add_end_user_view(authorized_client, data_standard_case):
+    application_id = data_standard_case["case"]["id"]
+
+    url = reverse("applications:add_end_user", kwargs={"pk": application_id})
+    response = authorized_client.get(url)
+    soup = BeautifulSoup(response.content, "html.parser")
+
+    assert soup.title.string == "Do you want to reuse an existing party? - LITE - GOV.UK"


### PR DESCRIPTION
### Aim

Extra change to fix a missing exporter page title left off LTD-4063. 

[LTD-4147](https://uktrade.atlassian.net/browse/LTD-4147)


[LTD-4147]: https://uktrade.atlassian.net/browse/LTD-4147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ