### PR TITLE
LTD-4157: Appeal refusal button display checks

### DIFF
--- a/exporter/applications/rules.py
+++ b/exporter/applications/rules.py
@@ -52,7 +52,7 @@ rules.add_rule(
     & is_application_finalised
     & is_application_refused
     & appeal_within_deadline
-    & ~is_application_appealed,
+    & ~is_application_appealed,  # noqa
 )
 
 rules.add_rule(

--- a/exporter/applications/rules.py
+++ b/exporter/applications/rules.py
@@ -52,6 +52,6 @@ rules.add_rule(
 )
 
 rules.add_rule(
-    "appeal_exists_for_case",
+    "can_view_appeal_details",
     is_appeal_feature_flag_set & is_application_refused & is_application_appealed,
 )

--- a/exporter/applications/rules.py
+++ b/exporter/applications/rules.py
@@ -48,7 +48,11 @@ def is_application_appealed(request, application):
 
 rules.add_rule(
     "can_user_appeal_case",
-    is_appeal_feature_flag_set & is_application_finalised & is_application_refused & appeal_within_deadline,
+    is_appeal_feature_flag_set
+    & is_application_finalised
+    & is_application_refused
+    & appeal_within_deadline
+    & ~is_application_appealed,
 )
 
 rules.add_rule(

--- a/exporter/applications/rules.py
+++ b/exporter/applications/rules.py
@@ -38,7 +38,20 @@ def appeal_within_deadline(request, application):
     return appeal_deadline.date() >= datetime.today().date()
 
 
+@rules.predicate
+def is_application_appealed(request, application):
+    if not application:
+        return False
+
+    return bool(application.appeal)
+
+
 rules.add_rule(
     "can_user_appeal_case",
     is_appeal_feature_flag_set & is_application_finalised & is_application_refused & appeal_within_deadline,
+)
+
+rules.add_rule(
+    "appeal_exists_for_case",
+    is_appeal_feature_flag_set & is_application_refused & is_application_appealed,
 )

--- a/exporter/templates/applications/application.html
+++ b/exporter/templates/applications/application.html
@@ -47,8 +47,8 @@
 						</a>
 					{% endif %}
 					{% test_rule 'can_user_appeal_case' request application as can_user_appeal_case %}
-					{% test_rule 'appeal_exists_for_case' request application as appeal_exists_for_case %}
-					{% if can_user_appeal_case and not appeal_exists_for_case %}
+					{% test_rule 'can_view_appeal_details' request application as can_view_appeal_details %}
+					{% if can_user_appeal_case and not can_view_appeal_details %}
 						<a href="{% url 'applications:appeal' application.id %}" id="button-appeal-refusal" class="govuk-button govuk-button--secondary">
 							Appeal refusal decision
 						</a>
@@ -245,8 +245,8 @@
 					{% lcs 'applications.ApplicationSummaryPage.Tabs.ACTIVITY' %}
 				</a>
 
-				{% test_rule 'appeal_exists_for_case' request application as appeal_exists_for_case %}
-				{% if appeal_exists_for_case %}
+				{% test_rule 'can_view_appeal_details' request application as can_view_appeal_details %}
+				{% if can_view_appeal_details %}
 					<a href="{% url 'applications:application' application.id 'appeal-details' %}" class="lite-tabs__tab {% if type == 'appeal-details' %}lite-tabs__tab--selected{% endif %}" id="link-appeal-details">
 						{% lcs 'applications.ApplicationSummaryPage.Tabs.APPEAL' %}
 					</a>

--- a/exporter/templates/applications/application.html
+++ b/exporter/templates/applications/application.html
@@ -243,9 +243,13 @@
 				<a href="{% url 'applications:application' application.id 'activity' %}" class="lite-tabs__tab {% if type == 'activity' %}lite-tabs__tab--selected{% endif %}" id="link-activity">
 					{% lcs 'applications.ApplicationSummaryPage.Tabs.ACTIVITY' %}
 				</a>
-				<a href="{% url 'applications:application' application.id 'appeal-details' %}" class="lite-tabs__tab {% if type == 'appeal-details' %}lite-tabs__tab--selected{% endif %}" id="link-appeal-details">
-					{% lcs 'applications.ApplicationSummaryPage.Tabs.APPEAL' %}
-				</a>
+
+				{% test_rule 'appeal_exists_for_case' request application as appeal_exists_for_case %}
+				{% if appeal_exists_for_case %}
+					<a href="{% url 'applications:application' application.id 'appeal-details' %}" class="lite-tabs__tab {% if type == 'appeal-details' %}lite-tabs__tab--selected{% endif %}" id="link-appeal-details">
+						{% lcs 'applications.ApplicationSummaryPage.Tabs.APPEAL' %}
+					</a>
+				{% endif %}
 			</div>
 		</div>
 	{% endif %}

--- a/exporter/templates/applications/application.html
+++ b/exporter/templates/applications/application.html
@@ -47,7 +47,8 @@
 						</a>
 					{% endif %}
 					{% test_rule 'can_user_appeal_case' request application as can_user_appeal_case %}
-					{% if can_user_appeal_case %}
+					{% test_rule 'appeal_exists_for_case' request application as appeal_exists_for_case %}
+					{% if can_user_appeal_case and not appeal_exists_for_case %}
 						<a href="{% url 'applications:appeal' application.id %}" id="button-appeal-refusal" class="govuk-button govuk-button--secondary">
 							Appeal refusal decision
 						</a>

--- a/exporter/templates/applications/application.html
+++ b/exporter/templates/applications/application.html
@@ -47,8 +47,7 @@
 						</a>
 					{% endif %}
 					{% test_rule 'can_user_appeal_case' request application as can_user_appeal_case %}
-					{% test_rule 'can_view_appeal_details' request application as can_view_appeal_details %}
-					{% if can_user_appeal_case and not can_view_appeal_details %}
+					{% if can_user_appeal_case %}
 						<a href="{% url 'applications:appeal' application.id %}" id="button-appeal-refusal" class="govuk-button govuk-button--secondary">
 							Appeal refusal decision
 						</a>

--- a/unit_tests/exporter/applications/test_rules.py
+++ b/unit_tests/exporter/applications/test_rules.py
@@ -17,6 +17,7 @@ def test_can_user_appeal_case_rule_predicates(settings, rf, data_standard_case):
     assert not appeal_rules.is_application_finalised(request, None)
     assert not appeal_rules.is_application_refused(request, None)
     assert not appeal_rules.appeal_within_deadline(request, None)
+    assert not appeal_rules.is_application_appealed(request, None)
 
     application = Application(data_standard_case["case"]["data"])
     assert not appeal_rules.appeal_within_deadline(request, application)

--- a/unit_tests/exporter/applications/test_rules.py
+++ b/unit_tests/exporter/applications/test_rules.py
@@ -23,23 +23,25 @@ def test_can_user_appeal_case_rule_predicates(settings, rf, data_standard_case):
 
 
 @pytest.mark.parametrize(
-    "flag_value, status, licence, days_until_deadline, expected",
+    "flag_value, status, licence, days_until_deadline, appeal_details, expected",
     (
-        (False, "submitted", None, None, False),
-        (True, "under_final_review", {"reference_code": "GBSIEL/2023/0000001/P"}, None, False),
-        (True, "finalised", {"reference_code": "GBSIEL/2023/0000001/P"}, None, False),
-        (True, "finalised", None, -1, False),  # we are past deadline by 1 day
-        (True, "finalised", None, 0, True),  # today is the deadline
-        (True, "finalised", None, 5, True),  # deadline is 5 days from today
+        (False, "submitted", None, None, None, False),
+        (True, "under_final_review", {"reference_code": "GBSIEL/2023/0000001/P"}, None, None, False),
+        (True, "finalised", {"reference_code": "GBSIEL/2023/0000001/P"}, None, None, False),
+        (True, "finalised", None, -1, None, False),  # we are past deadline by 1 day
+        (True, "finalised", None, 0, None, True),  # today is the deadline
+        (True, "finalised", None, 5, None, True),  # deadline is 5 days from today
+        (True, "finalised", None, 5, {"grounds_for_appeal": "test appeal"}, False),
     ),
 )
 def test_can_user_appeal_case_based_on_feature_flag(
-    settings, rf, data_standard_case, flag_value, status, licence, days_until_deadline, expected
+    settings, rf, data_standard_case, flag_value, status, licence, days_until_deadline, appeal_details, expected
 ):
     settings.FEATURE_FLAG_APPEALS = flag_value
     data_standard_case["case"]["data"]["status"] = {"key": status, "value": status.title()}
     data_standard_case["case"]["data"]["licence"] = licence
     data_standard_case["case"]["data"]["appeal_deadline"] = ""
+    data_standard_case["case"]["data"]["appeal"] = appeal_details
 
     if days_until_deadline is not None:
         appeal_deadline = timezone.localtime() + timedelta(days_until_deadline)
@@ -58,7 +60,7 @@ def test_can_user_appeal_case_based_on_feature_flag(
         (True, {"grounds_for_appeal": "test appeal"}, True),
     ),
 )
-def test_appeal_tab_display(settings, rf, data_standard_case, flag_value, appeal, expected):
+def test_view_appeal_details(settings, rf, data_standard_case, flag_value, appeal, expected):
     settings.FEATURE_FLAG_APPEALS = flag_value
     data_standard_case["case"]["data"]["status"] = {"key": "finalised", "value": "Finalised"}
     data_standard_case["case"]["data"]["licence"] = None
@@ -68,4 +70,4 @@ def test_appeal_tab_display(settings, rf, data_standard_case, flag_value, appeal
     application = Application(data_standard_case["case"]["data"])
 
     request = rf.get("/")
-    assert rules.test_rule("appeal_exists_for_case", request, application) is expected
+    assert rules.test_rule("can_view_appeal_details", request, application) is expected

--- a/unit_tests/exporter/applications/test_rules.py
+++ b/unit_tests/exporter/applications/test_rules.py
@@ -49,3 +49,25 @@ def test_can_user_appeal_case_based_on_feature_flag(
 
     request = rf.get("/")
     assert rules.test_rule("can_user_appeal_case", request, application) is expected
+
+
+@pytest.mark.parametrize(
+    "flag_value, appeal, expected",
+    (
+        (True, None, False),
+        (True, {"grounds_for_appeal": "test appeal"}, True),
+    ),
+)
+def test_appeal_tab_display(
+    settings, rf, data_standard_case, flag_value, appeal, expected
+):
+    settings.FEATURE_FLAG_APPEALS = flag_value
+    data_standard_case["case"]["data"]["status"] = {"key": 'finalised', "value": 'Finalised'}
+    data_standard_case["case"]["data"]["licence"] = None
+    data_standard_case["case"]["data"]["appeal_deadline"] = timezone.localtime().isoformat()
+    data_standard_case["case"]["data"]["appeal"] = appeal
+
+    application = Application(data_standard_case["case"]["data"])
+
+    request = rf.get("/")
+    assert rules.test_rule("appeal_exists_for_case", request, application) is expected

--- a/unit_tests/exporter/applications/test_rules.py
+++ b/unit_tests/exporter/applications/test_rules.py
@@ -58,11 +58,9 @@ def test_can_user_appeal_case_based_on_feature_flag(
         (True, {"grounds_for_appeal": "test appeal"}, True),
     ),
 )
-def test_appeal_tab_display(
-    settings, rf, data_standard_case, flag_value, appeal, expected
-):
+def test_appeal_tab_display(settings, rf, data_standard_case, flag_value, appeal, expected):
     settings.FEATURE_FLAG_APPEALS = flag_value
-    data_standard_case["case"]["data"]["status"] = {"key": 'finalised', "value": 'Finalised'}
+    data_standard_case["case"]["data"]["status"] = {"key": "finalised", "value": "Finalised"}
     data_standard_case["case"]["data"]["licence"] = None
     data_standard_case["case"]["data"]["appeal_deadline"] = timezone.localtime().isoformat()
     data_standard_case["case"]["data"]["appeal"] = appeal


### PR DESCRIPTION
### Aim

Fixes a bug where we display this button even after User started an appeal

[LTD-4157](https://uktrade.atlassian.net/browse/LTD-4157)


[LTD-4157]: https://uktrade.atlassian.net/browse/LTD-4157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ