### PR TITLE
[LTD-4160] Improve message wording when inform letter sent

### DIFF
--- a/caseworker/cases/views/generate_document.py
+++ b/caseworker/cases/views/generate_document.py
@@ -195,13 +195,17 @@ class CreateDocument(LoginRequiredMixin, TemplateView):
 
 
 class SendExistingDocument(LoginRequiredMixin, View):
+    def get_success_message(self, send_response, case):
+        if send_response.json()["document"]["advice_type"] == "inform":
+            return f"Inform letter sent to {case['data']['organisation']['name']}, {case['reference_code']}"
+        return f"Document sent to {case['data']['organisation']['name']}, {case['reference_code']}"
+
     def post(self, request, queue_pk, pk, document_pk):
         response = send_generated_document(request, pk, document_pk)
         case = get_case(request, pk)
         if response.ok:
-            messages.success(
-                self.request, f"Document sent to {case['data']['organisation']['name']}, {case['reference_code']}"
-            )
+            success_message = self.get_success_message(response, case)
+            messages.success(self.request, success_message)
         else:
             messages.error(
                 self.request,

--- a/unit_tests/caseworker/cases/views/test_generate_document.py
+++ b/unit_tests/caseworker/cases/views/test_generate_document.py
@@ -39,7 +39,18 @@ def send_document_url(data_standard_case, data_generated_document_id):
 
 @pytest.fixture
 def mock_send_generated_document(requests_mock, send_document_url, mock_gov_user):
-    return requests_mock.post(url=send_document_url, json={"notification_sent": False})
+    return requests_mock.post(
+        url=send_document_url,
+        json={"notification_sent": False, "document": {"template": "foobar123", "advice_type": None, "text": ""}},
+    )
+
+
+@pytest.fixture
+def mock_send_generated_inform_letter(requests_mock, send_document_url, mock_gov_user):
+    return requests_mock.post(
+        url=send_document_url,
+        json={"notification_sent": False, "document": {"template": "foobar123", "advice_type": "inform", "text": ""}},
+    )
 
 
 @pytest.fixture
@@ -103,7 +114,7 @@ def mock_preview_fail(requests_mock, get_preview_url, mock_gov_user):
     return requests_mock.get(url=get_preview_url, status_code=400, json={"preview": ""})
 
 
-def test_send_existing_document(
+def test_send_existing_document_error(
     authorized_client,
     requests_mock,
     data_standard_case,
@@ -161,6 +172,35 @@ def test_send_existing_document_ok(
         == f"/cases/{data_standard_case['case']['id']}/generated-documents/{data_generated_document_id}/send/"
     )
     assert mock_send_generated_document.last_request.json() == {}
+
+
+def test_send_existing_inform_letter_ok(
+    authorized_client,
+    data_standard_case,
+    queue_pk,
+    mock_send_generated_inform_letter,
+    data_generated_document_id,
+):
+    url = reverse(
+        "cases:generate_document_send",
+        kwargs={
+            "queue_pk": queue_pk,
+            "pk": data_standard_case["case"]["id"],
+            "document_pk": data_generated_document_id,
+        },
+    )
+    response = authorized_client.post(url, follow=True)
+    assert response.status_code == 200
+    messages = [str(msg) for msg in response.context["messages"]]
+    expected_message = f"Inform letter sent to {data_standard_case['case']['data']['organisation']['name']}, {data_standard_case['case']['reference_code']}"
+    assert response.redirect_chain[-1][0] == f"/queues/{queue_pk}/"
+    assert messages == [expected_message]
+    assert mock_send_generated_inform_letter.called
+    assert (
+        mock_send_generated_inform_letter.last_request.path
+        == f"/cases/{data_standard_case['case']['id']}/generated-documents/{data_generated_document_id}/send/"
+    )
+    assert mock_send_generated_inform_letter.last_request.json() == {}
 
 
 def test_finalise_document_create_return_url(


### PR DESCRIPTION
### Aim

Ensure that sending an inform letter results in the correct wording displayed in the success message.  This makes use of a newly added "document" data structure in the "send generated document" endpoint as added in this companion PR: https://github.com/uktrade/lite-api/pull/1568

[LTD-4160](https://uktrade.atlassian.net/browse/LTD-4160)


[LTD-4160]: https://uktrade.atlassian.net/browse/LTD-4160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ