### PR TITLE
Parts of the example configs aren't parsable, convert those to comments.

### DIFF
--- a/example.caseworker.env
+++ b/example.caseworker.env
@@ -9,7 +9,7 @@ GTM_ID=''
 LITE_API_HAWK_KEY=
 
 LITE_API_URL=http://host.docker.internal:8100
-comment above LITE_API_URL and uncomment below if running outside docker
+# comment above LITE_API_URL and uncomment below if running outside docker
 #LITE_API_URL=http://127.0.0.1:8100
 
 # Auth
@@ -52,7 +52,7 @@ PERMISSIONS_FINDER_URL=
 STATICFILES_STORAGE=django.contrib.staticfiles.storage.StaticFilesStorage
 
 REDIS_URL=redis://redis:6379/caseworker
-comment above REDIS_URL and uncomment below if running outside docker
+# comment above REDIS_URL and uncomment below if running outside docker
 #REDIS_URL=redis://127.0.0.1:6379/caseworker
 
 NOTIFY_KEY="super-secret-gov-uk-api-key-that-is-quite-long-and-hence-this-text"

--- a/example.exporter.env
+++ b/example.exporter.env
@@ -9,7 +9,7 @@ GTM_ID=
 FEEDBACK_URL=mailto:
 
 LITE_API_URL=http://host.docker.internal:8100
-comment above LITE_API_URL and uncomment below if running outside docker
+# comment above LITE_API_URL and uncomment below if running outside docker
 #LITE_API_URL=http://127.0.0.1:8100
 
 # Auth
@@ -48,7 +48,7 @@ FEATURE_FLAG_GOVUK_SIGNIN_ENABLED=True
 FEATURE_FLAG_ONLY_ALLOW_FIREARMS_PRODUCTS=True
 
 REDIS_URL=redis://redis:6379/exporter
-comment above REDIS_URL and uncomment below if running outside docker
+# comment above REDIS_URL and uncomment below if running outside docker
 #REDIS_URL=redis://127.0.0.1:6379/exporter
 
 NOTIFY_KEY="super-secret-gov-uk-api-key-that-is-quite-long-and-hence-this-text"


### PR DESCRIPTION
### Aim
This is a really minor nit - but it was preventing me using a script to do the setup.

Makes sure the lines that start "comment the above..." to be comments themselves, so one less config.

In this way, the settings still need fixing by the user, but we avoid anything that make python_dotenv complain it can't parse the file itself.