### PR TITLE
Add sub-status to case details page

### DIFF
--- a/caseworker/templates/case/slices/summary.html
+++ b/caseworker/templates/case/slices/summary.html
@@ -104,6 +104,18 @@
 			{% endif %}
 		</dd>
 	</div>
+	<div class="app-case__summary-list__row" id="case-sub-status">
+		<dt class="app-case__summary-list__key">
+			{% lcs 'cases.CasePage.DetailsTab.SUB_STATUS' %}
+		</dt>
+		<dd class="app-case__summary-list__value">
+			{% if case.data.sub_status %}
+				{{ case.data.sub_status.name }}
+			{% else %}
+				<span class="govuk-hint govuk-!-margin-0">No sub-status set</span>
+			{% endif %}
+		</dd>
+	</div>
 	<div class="app-case__summary-list__row">
 		<dt class="app-case__summary-list__key">
 			{% lcs 'cases.CasePage.DetailsTab.ASSIGNED_QUEUES' %}

--- a/lite_content/lite_internal_frontend/cases.py
+++ b/lite_content/lite_internal_frontend/cases.py
@@ -131,6 +131,7 @@ class CasePage:
         SUBMITTED_AT = "Submitted at"
         SUBMITTED_BY = "Submitted by"
         STATUS = "Status"
+        SUB_STATUS = "Sub-status"
         ASSIGNED_QUEUES = "Assigned queues"
         TYPE = "Type"
         LAST_UPDATED = "Last updated"

--- a/unit_tests/caseworker/cases/views/test_case_details.py
+++ b/unit_tests/caseworker/cases/views/test_case_details.py
@@ -213,3 +213,34 @@ def test_case_details_appeal_details_no_appeal(
     response = authorized_client.get(case_url)
 
     assertTemplateNotUsed(response, "case/slices/appeal-details.html")
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    (
+        (None, "No sub-status set"),
+        (
+            {
+                "id": "status-1",
+                "name": "Status 1",
+            },
+            "Status 1",
+        ),
+    ),
+)
+def test_case_details_sub_status(
+    data_standard_case,
+    data_queue,
+    authorized_client,
+    value,
+    expected,
+):
+    data_standard_case["case"]["data"]["sub_status"] = value
+    case_url = reverse("cases:case", kwargs={"queue_pk": data_queue["id"], "pk": data_standard_case["case"]["id"]})
+    response = authorized_client.get(case_url)
+
+    html = BeautifulSoup(response.content, "html.parser")
+    dt = html.find("dt", string=re.compile("Sub-status"))
+    assert dt
+    dd = dt.find_next()
+    assert dd.get_text().replace("\n", "").replace("\t", "") == expected


### PR DESCRIPTION
### Aim

Add sub-status to case details page.

At this point I've not added the link to actually change the status to keep this PR small. We should add another ticket and add this link separately.

[LTD-4175](https://uktrade.atlassian.net/browse/LTD-4175)


[LTD-4175]: https://uktrade.atlassian.net/browse/LTD-4175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ