### PR TITLE
LTD-4203: Expose finalise status for LU users

### DIFF
--- a/caseworker/core/services.py
+++ b/caseworker/core/services.py
@@ -71,6 +71,7 @@ def get_permissible_statuses(request, case):
     statuses, _ = get_statuses(request)
     case_sub_type = case["case_type"]["sub_type"]["key"]
     case_type = case["case_type"]["type"]["key"]
+    case_type_applicable_statuses = []
 
     if case_type == CaseType.APPLICATION.value:
         case_type_applicable_statuses = [
@@ -87,64 +88,7 @@ def get_permissible_statuses(request, case):
                 CaseStatusEnum.SURRENDERED,
             ]
         ]
-    elif case_type == CaseType.QUERY.value:
-        if case_sub_type == CaseType.END_USER_ADVISORY.value:
-            case_type_applicable_statuses = [
-                status for status in statuses if status["key"] in CaseStatusEnum.base_query_statuses()
-            ]
-        else:
-            # if the query is not an end user advisory, then check if CLC/PV statuses are required
-            goods_query_status_keys = CaseStatusEnum.base_query_statuses().copy()
 
-            if case.data["clc_responded"] is not None:
-                goods_query_status_keys.insert(1, CaseStatusEnum.CLC)
-
-            if case.data["pv_grading_responded"] is not None:
-                # add PV status into the correct location
-                if case.data["clc_responded"] is not None:
-                    goods_query_status_keys.insert(2, CaseStatusEnum.PV)
-                else:
-                    goods_query_status_keys.insert(1, CaseStatusEnum.PV)
-
-            case_type_applicable_statuses = [status for status in statuses if status["key"] in goods_query_status_keys]
-    elif case_type == CaseType.COMPLIANCE.value:
-        if case_sub_type == CaseType.COMPLIANCE_SITE.value:
-            case_type_applicable_statuses = [
-                status
-                for status in statuses
-                if status["key"]
-                in [
-                    CaseStatusEnum.OPEN,
-                    CaseStatusEnum.CLOSED,
-                ]
-            ]
-        elif case_sub_type == CaseType.COMPLIANCE_VISIT.value:
-            case_type_applicable_statuses = [
-                status
-                for status in statuses
-                if status["key"]
-                in [
-                    CaseStatusEnum.OPEN,
-                    CaseStatusEnum.UNDER_INTERNAL_REVIEW,
-                    CaseStatusEnum.RETURN_TO_INSPECTOR,
-                    CaseStatusEnum.AWAITING_EXPORTER_RESPONSE,
-                    CaseStatusEnum.CLOSED,
-                ]
-            ]
-    elif case_type == CaseType.REGISTRATION.value:
-        case_type_applicable_statuses = [
-            status
-            for status in statuses
-            if status["key"]
-            in [
-                CaseStatusEnum.REGISTERED,
-                CaseStatusEnum.UNDER_ECJU_REVIEW,
-                CaseStatusEnum.REVOKED,
-                CaseStatusEnum.SUSPENDED,
-                CaseStatusEnum.SURRENDERED,
-                CaseStatusEnum.DEREGISTERED,
-            ]
-        ]
     return [status for status in case_type_applicable_statuses if status in user_permissible_statuses]
 
 


### PR DESCRIPTION
## Change description

LU users have a requirement to manually set the status as 'Finalised' at the end of an appeal process.
By default 'Finalised' status cannot be set manually so allow this option only for LU users that have additional permissions which are checked in the API.

[LTD-4203](https://uktrade.atlassian.net/browse/LTD-4203)


[LTD-4203]: https://uktrade.atlassian.net/browse/LTD-4203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ