### PR TITLE
[LTD-4215] Enable customisation of sub-status in case quick summary tab

### DIFF
--- a/caseworker/templates/case/tabs/quick-summary.html
+++ b/caseworker/templates/case/tabs/quick-summary.html
@@ -11,6 +11,7 @@
     "options_hint": "Select items to show",
     "toggleable_elements": [
         {"label": "Status", "key": "status", "default_visible": false},
+        {"label": "Sub-status", "key": "sub_status", "default_visible": false},
         {"label": "Licensing Unit case officer", "key": "lu_case_officer", "default_visible": true},
         {"label": "Case adviser", "key": "case_advisers", "default_visible": false},
         {"label": "Temporary or permanent", "key": "temporary_permanent", "default_visible": false},


### PR DESCRIPTION
### Aim

Minor fix to ensure that sub-status row is customisable on case quick summary page.

[LTD-LTD-4215](https://uktrade.atlassian.net/browse/LTD-LTD-4215)
