### PR TITLE
Set back link to details page for case form template

### DIFF
--- a/caseworker/templates/case/form.html
+++ b/caseworker/templates/case/form.html
@@ -3,7 +3,7 @@
 {% block title %}{{ form.Layout.TITLE }} - {{ block.super }}{% endblock %}
 
 {% block back_link %}
-    <a class="app-case__form-wrapper__back-link" href="{% url 'cases:case' queue_pk=queue.id pk=case.id %}" id="back-link">Back</a>
+    <a class="app-case__form-wrapper__back-link" href="{% url 'cases:case' queue_pk=queue.id pk=case.id tab="details" %}" id="back-link">Back</a>
 {% endblock %}
 
 {% block two_thirds %}


### PR DESCRIPTION
### Aim

Set the back button for sub-status as the case details page.

This uses a base form template that I've changed the default to be the case details page as I think this will make the most sense for it in general, if anything deviates from that then it can be overridden explicitly there.

[LTD-4214](https://uktrade.atlassian.net/browse/LTD-4214)


[LTD-4214]: https://uktrade.atlassian.net/browse/LTD-4214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ