### PR TITLE
Add "None" as the label for a blank sub-status on form

### DIFF
--- a/caseworker/cases/forms/change_sub_status.py
+++ b/caseworker/cases/forms/change_sub_status.py
@@ -10,7 +10,7 @@ class ChangeSubStatusForm(BaseForm):
 
     sub_status = forms.ChoiceField(
         choices=[
-            ("", ""),
+            ("", "None"),
         ],  # updated in init
         label="",
         required=False,

--- a/unit_tests/caseworker/cases/views/test_change_sub_status.py
+++ b/unit_tests/caseworker/cases/views/test_change_sub_status.py
@@ -96,7 +96,7 @@ def test_get_change_sub_status(
     select = soup.find(id="id_sub_status")
     options = [(option["value"], option.text) for option in select.find_all("option")]
     assert options == [
-        ("", ""),
+        ("", "None"),
         ("status-1", "Status 1"),
         ("status-2", "Status 2"),
     ]


### PR DESCRIPTION
### Aim

Use "None" as label for unsetting sub-status.

[LTD-4218](https://uktrade.atlassian.net/browse/LTD-4218)


[LTD-4218]: https://uktrade.atlassian.net/browse/LTD-4218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ