### PR TITLE
Add UI tests for exporter red dot notification persisting until responded 

### DIFF
--- a/ui_tests/exporter/features/ecju_queries.feature
+++ b/ui_tests/exporter/features/ecju_queries.feature
@@ -26,7 +26,7 @@ So that I can quickly identify where action is required by me and respond to any
     | Test    | Rifle   | PL9002      | Automated End user | 1234, High street | BE      | Automated Consignee | 1234, Trade centre  | Research and development | False                    |
 
   @ecju_query
-  Scenario: See that the notification red dot persists when I have not responded to an ECJU query
+  Scenario: See that the notification red dot persists when I have not responded to an ECJU query until I have responded
     Given I signin and go to exporter homepage and choose Test Org
     And I submit an application with <name>,<product>,<clc_rating>,<end_user_name>,<end_user_address>,<consignee_name>,<consignee_address>,<country>,<end_use>,<is_mod_security_approved>
     And Caseworker creates an ECJU query with "Some unique query"
@@ -44,6 +44,18 @@ So that I can quickly identify where action is required by me and respond to any
     Then I see a notification next to the application
     When I click on my application
     Then I see a notification next to ECJU queries
+
+    # See that the notification is cleared when I have responded to the query
+    When I click the ECJU Queries tab
+    Then I see "Some unique query" as the query under open queries
+    When I click to respond to the ECJU query
+    And I enter "Some unique response" for the response and click submit
+    And I click "Continue"
+    Then I see "Some unique response" as the response under closed queries
+    When I go to exporter homepage
+    When I click check progress
+    When I click on my application
+    Then I do not see a notification next to ECJU queries
 
     Examples:
     | name    | product | clc_rating  | end_user_name      | end_user_address  | country | consignee_name      | consignee_address   | end_use                  | is_mod_security_approved |

--- a/ui_tests/exporter/features/ecju_queries.feature
+++ b/ui_tests/exporter/features/ecju_queries.feature
@@ -24,3 +24,27 @@ So that I can quickly identify where action is required by me and respond to any
     Examples:
     | name    | product | clc_rating  | end_user_name      | end_user_address  | country | consignee_name      | consignee_address   | end_use                  | is_mod_security_approved |
     | Test    | Rifle   | PL9002      | Automated End user | 1234, High street | BE      | Automated Consignee | 1234, Trade centre  | Research and development | False                    |
+
+  @ecju_query
+  Scenario: See that the notification red dot persists when I have not responded to an ECJU query
+    Given I signin and go to exporter homepage and choose Test Org
+    And I submit an application with <name>,<product>,<clc_rating>,<end_user_name>,<end_user_address>,<consignee_name>,<consignee_address>,<country>,<end_use>,<is_mod_security_approved>
+    And Caseworker creates an ECJU query with "Some unique query"
+    When I go to exporter homepage
+    Then I see a notification next to check progress
+    When I click check progress
+    Then I see a notification next to the application
+    When I click on my application
+    Then I see a notification next to ECJU queries
+
+    # See that the notification persists when I navigate to another page
+    When I go to exporter homepage
+    Then I see a notification next to check progress
+    When I click check progress
+    Then I see a notification next to the application
+    When I click on my application
+    Then I see a notification next to ECJU queries
+
+    Examples:
+    | name    | product | clc_rating  | end_user_name      | end_user_address  | country | consignee_name      | consignee_address   | end_use                  | is_mod_security_approved |
+    | Test    | Rifle   | PL9002      | Automated End user | 1234, High street | BE      | Automated Consignee | 1234, Trade centre  | Research and development | False                    |

--- a/ui_tests/exporter/pages/application_page.py
+++ b/ui_tests/exporter/pages/application_page.py
@@ -1,4 +1,7 @@
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions
+from selenium.webdriver.support.wait import WebDriverWait
+from selenium.common.exceptions import TimeoutException
 
 from ui_tests.exporter.pages.BasePage import BasePage
 from ui_tests.exporter.pages.shared import Shared
@@ -55,6 +58,17 @@ class ApplicationPage(BasePage):
             .find_element(by=By.CSS_SELECTOR, value=Shared.NOTIFICATION)
             .text.strip()
         )
+
+    def ecju_query_does_not_have_notifications(self):
+        try:
+            element_not_visible = WebDriverWait(self.driver, 10).until(
+                expected_conditions.invisibility_of_element_located(
+                    (By.CSS_SELECTOR, f"#{self.LINK_ECJU_QUERY_TAB_ID} {Shared.NOTIFICATION}")
+                )
+            )
+            return element_not_visible
+        except TimeoutException:
+            print(f"Element with class {Shared.NOTIFICATION} remained visible throughout the time frame")
 
     def click_generated_documents_tab(self):
         self.driver.find_element(by=By.ID, value=self.LINK_GENERATED_DOCUMENTS_TAB_ID).click()

--- a/ui_tests/exporter/step_defs/test_ecju_queries.py
+++ b/ui_tests/exporter/step_defs/test_ecju_queries.py
@@ -61,6 +61,11 @@ def should_see_notification_ecju_queries(driver):
     assert ApplicationPage(driver).ecju_query_notification_count() == "1"
 
 
+@then("I do not see a notification next to ECJU queries")
+def should_not_see_notification_ecju_queries(driver):
+    assert ApplicationPage(driver).ecju_query_does_not_have_notifications()
+
+
 @then(parsers.parse('I see "{query}" as the query under open queries'))
 def should_see_query_in_open_queries(driver, query):
     assert query in ApplicationPage(driver).get_open_queries_text()


### PR DESCRIPTION
### Aim

This is a test scenario for the red dot notification persisting when the user has not yet responded to the query, and then being cleared when the query has been responded to.

[LTD-4683](https://uktrade.atlassian.net/browse/LTD-4683)


[LTD-4683]: https://uktrade.atlassian.net/browse/LTD-4683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ