### PR TITLE
LTD-4702 Upgrade lite-frontend to use govuk-frontend v4.8.0

### DIFF
--- a/core/assets/styles/components/_case-note.scss
+++ b/core/assets/styles/components/_case-note.scss
@@ -10,7 +10,7 @@
 			}
 
 			.lite-case-note__controls {
-				border: $govuk-border-width-form-element-error solid $govuk-error-colour;
+				border-color: $govuk-error-colour;
 				border-top-width: 0;
 				padding: govuk-spacing(3) - 2px;
 				padding-top: govuk-spacing(3);

--- a/core/assets/styles/overrides/_checkboxes.scss
+++ b/core/assets/styles/overrides/_checkboxes.scss
@@ -23,10 +23,6 @@
 	// Add an error state to checkboxes as GOV.UK Frontend lacks it
 	color: $govuk-error-colour;
 
-	&::before {
-		border-width: $govuk-border-width-form-element-error;
-	}
-
 	&::after {
 		color: govuk-colour("black");
 	}

--- a/core/assets/styles/overrides/_form-group.scss
+++ b/core/assets/styles/overrides/_form-group.scss
@@ -1,6 +1,6 @@
 .govuk-form-group--error {
 	.lite-autocomplete__input {
-		border: $govuk-border-width-form-element-error solid $govuk-error-colour;
+		border-color: $govuk-error-colour;
 
 		&:focus {
 			border-color: $govuk-input-border-colour;

--- a/core/assets/styles/overrides/_radios.scss
+++ b/core/assets/styles/overrides/_radios.scss
@@ -2,10 +2,6 @@
 	// Add an error state to radio buttons
 	color: $govuk-error-colour;
 
-	&::before {
-		border-width: $govuk-border-width-form-element-error;
-	}
-
 	&::after {
 		color: govuk-colour("black");
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "eslint-plugin-jest": "^27.2.3",
         "events": "^3.3.0",
         "fetch-polyfill": "^0.8.2",
-        "govuk-frontend": "^3.14.0",
+        "govuk-frontend": "^4.0.0",
         "highlight-within-textarea": "^2.0.5",
         "jquery": "^3.6.0",
         "lightpick": "^1.6.2",
@@ -6410,9 +6410,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.15.0.tgz",
-      "integrity": "sha512-kInDei8hrkMcrW7yC2EwhbSNBOBBPTdLxIDAye2G7KNrD9cyvNAfd0KchrfP/nWBOzu67ANoz2rtoRDLWiBN2w==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.8.0.tgz",
+      "integrity": "sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -14686,9 +14686,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.15.0.tgz",
-      "integrity": "sha512-kInDei8hrkMcrW7yC2EwhbSNBOBBPTdLxIDAye2G7KNrD9cyvNAfd0KchrfP/nWBOzu67ANoz2rtoRDLWiBN2w=="
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.8.0.tgz",
+      "integrity": "sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw=="
     },
     "graceful-fs": {
       "version": "4.2.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "eslint-plugin-jest": "^27.2.3",
         "events": "^3.3.0",
         "fetch-polyfill": "^0.8.2",
-        "govuk-frontend": "^4.4.0",
+        "govuk-frontend": "^4.5.0",
         "highlight-within-textarea": "^2.0.5",
         "jquery": "^3.6.0",
         "lightpick": "^1.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "eslint-plugin-jest": "^27.2.3",
         "events": "^3.3.0",
         "fetch-polyfill": "^0.8.2",
-        "govuk-frontend": "^4.2.0",
+        "govuk-frontend": "^4.3.0",
         "highlight-within-textarea": "^2.0.5",
         "jquery": "^3.6.0",
         "lightpick": "^1.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "eslint-plugin-jest": "^27.2.3",
         "events": "^3.3.0",
         "fetch-polyfill": "^0.8.2",
-        "govuk-frontend": "^4.1.0",
+        "govuk-frontend": "^4.2.0",
         "highlight-within-textarea": "^2.0.5",
         "jquery": "^3.6.0",
         "lightpick": "^1.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "eslint-plugin-jest": "^27.2.3",
         "events": "^3.3.0",
         "fetch-polyfill": "^0.8.2",
-        "govuk-frontend": "^4.5.0",
+        "govuk-frontend": "^4.6.0",
         "highlight-within-textarea": "^2.0.5",
         "jquery": "^3.6.0",
         "lightpick": "^1.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "eslint-plugin-jest": "^27.2.3",
         "events": "^3.3.0",
         "fetch-polyfill": "^0.8.2",
-        "govuk-frontend": "^4.3.0",
+        "govuk-frontend": "^4.4.0",
         "highlight-within-textarea": "^2.0.5",
         "jquery": "^3.6.0",
         "lightpick": "^1.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "eslint-plugin-jest": "^27.2.3",
         "events": "^3.3.0",
         "fetch-polyfill": "^0.8.2",
-        "govuk-frontend": "^3.13.0",
+        "govuk-frontend": "^3.14.0",
         "highlight-within-textarea": "^2.0.5",
         "jquery": "^3.6.0",
         "lightpick": "^1.6.2",
@@ -6410,9 +6410,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.13.0.tgz",
-      "integrity": "sha512-JiPCeasuHZ+9m1VyqhsfE81PhWIW4Sweoe6Jvn6oMjQNr75ZpupiytN3DGwA+WKOoESHZibIG+heAzlkdZ/MhA==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.15.0.tgz",
+      "integrity": "sha512-kInDei8hrkMcrW7yC2EwhbSNBOBBPTdLxIDAye2G7KNrD9cyvNAfd0KchrfP/nWBOzu67ANoz2rtoRDLWiBN2w==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -14686,9 +14686,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.13.0.tgz",
-      "integrity": "sha512-JiPCeasuHZ+9m1VyqhsfE81PhWIW4Sweoe6Jvn6oMjQNr75ZpupiytN3DGwA+WKOoESHZibIG+heAzlkdZ/MhA=="
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.15.0.tgz",
+      "integrity": "sha512-kInDei8hrkMcrW7yC2EwhbSNBOBBPTdLxIDAye2G7KNrD9cyvNAfd0KchrfP/nWBOzu67ANoz2rtoRDLWiBN2w=="
     },
     "graceful-fs": {
       "version": "4.2.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "eslint-plugin-jest": "^27.2.3",
         "events": "^3.3.0",
         "fetch-polyfill": "^0.8.2",
-        "govuk-frontend": "^4.7.0",
+        "govuk-frontend": "^4.8.0",
         "highlight-within-textarea": "^2.0.5",
         "jquery": "^3.6.0",
         "lightpick": "^1.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "eslint-plugin-jest": "^27.2.3",
         "events": "^3.3.0",
         "fetch-polyfill": "^0.8.2",
-        "govuk-frontend": "^4.6.0",
+        "govuk-frontend": "^4.7.0",
         "highlight-within-textarea": "^2.0.5",
         "jquery": "^3.6.0",
         "lightpick": "^1.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "eslint-plugin-jest": "^27.2.3",
         "events": "^3.3.0",
         "fetch-polyfill": "^0.8.2",
-        "govuk-frontend": "^4.0.0",
+        "govuk-frontend": "^4.1.0",
         "highlight-within-textarea": "^2.0.5",
         "jquery": "^3.6.0",
         "lightpick": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eslint-plugin-jest": "^27.2.3",
     "events": "^3.3.0",
     "fetch-polyfill": "^0.8.2",
-    "govuk-frontend": "^4.0.0",
+    "govuk-frontend": "^4.1.0",
     "highlight-within-textarea": "^2.0.5",
     "jquery": "^3.6.0",
     "lightpick": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eslint-plugin-jest": "^27.2.3",
     "events": "^3.3.0",
     "fetch-polyfill": "^0.8.2",
-    "govuk-frontend": "^3.14.0",
+    "govuk-frontend": "^4.0.0",
     "highlight-within-textarea": "^2.0.5",
     "jquery": "^3.6.0",
     "lightpick": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eslint-plugin-jest": "^27.2.3",
     "events": "^3.3.0",
     "fetch-polyfill": "^0.8.2",
-    "govuk-frontend": "^4.5.0",
+    "govuk-frontend": "^4.6.0",
     "highlight-within-textarea": "^2.0.5",
     "jquery": "^3.6.0",
     "lightpick": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eslint-plugin-jest": "^27.2.3",
     "events": "^3.3.0",
     "fetch-polyfill": "^0.8.2",
-    "govuk-frontend": "^3.13.0",
+    "govuk-frontend": "^3.14.0",
     "highlight-within-textarea": "^2.0.5",
     "jquery": "^3.6.0",
     "lightpick": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eslint-plugin-jest": "^27.2.3",
     "events": "^3.3.0",
     "fetch-polyfill": "^0.8.2",
-    "govuk-frontend": "^4.3.0",
+    "govuk-frontend": "^4.4.0",
     "highlight-within-textarea": "^2.0.5",
     "jquery": "^3.6.0",
     "lightpick": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eslint-plugin-jest": "^27.2.3",
     "events": "^3.3.0",
     "fetch-polyfill": "^0.8.2",
-    "govuk-frontend": "^4.1.0",
+    "govuk-frontend": "^4.2.0",
     "highlight-within-textarea": "^2.0.5",
     "jquery": "^3.6.0",
     "lightpick": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eslint-plugin-jest": "^27.2.3",
     "events": "^3.3.0",
     "fetch-polyfill": "^0.8.2",
-    "govuk-frontend": "^4.4.0",
+    "govuk-frontend": "^4.5.0",
     "highlight-within-textarea": "^2.0.5",
     "jquery": "^3.6.0",
     "lightpick": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eslint-plugin-jest": "^27.2.3",
     "events": "^3.3.0",
     "fetch-polyfill": "^0.8.2",
-    "govuk-frontend": "^4.7.0",
+    "govuk-frontend": "^4.8.0",
     "highlight-within-textarea": "^2.0.5",
     "jquery": "^3.6.0",
     "lightpick": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eslint-plugin-jest": "^27.2.3",
     "events": "^3.3.0",
     "fetch-polyfill": "^0.8.2",
-    "govuk-frontend": "^4.6.0",
+    "govuk-frontend": "^4.7.0",
     "highlight-within-textarea": "^2.0.5",
     "jquery": "^3.6.0",
     "lightpick": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eslint-plugin-jest": "^27.2.3",
     "events": "^3.3.0",
     "fetch-polyfill": "^0.8.2",
-    "govuk-frontend": "^4.2.0",
+    "govuk-frontend": "^4.3.0",
     "highlight-within-textarea": "^2.0.5",
     "jquery": "^3.6.0",
     "lightpick": "^1.6.2",


### PR DESCRIPTION
### Aim

This upgrades lite-frontend to use govuk-frontend v4.8.0 which is a recent release for govuk-frontend including the crown logo changes.

The GOV.UK team released v5.0.0 after v4.7.0 so this was tried initially but as there are many breaking changes that may take time to resolve, we have opted for v4.8.0 which is the latest release for the 4.x series. 

[LTD-4702](https://uktrade.atlassian.net/browse/LTD-4702)

Below is my original draft PR description:

> My current plan to do the upgrade is to move lite-frontend through all major and minor (skipping patch) released versions of govuk-frontend, one version per commit, and seeing that the full test suite passes at each commit.
> 
> If there are no problems, then great.
> 
> If there are problems on a commit when it is tested, these can be fixed at that point, and the issues will be easier to identify as they can be related to a particular version change.
> 
> The major and minor versions (skipping patches) we should check are:
> - [GOV.UK Frontend v3.14.0](https://github.com/alphagov/govuk-frontend/releases/tag/v3.14.0)
> - [GOV.UK Frontend v4.0.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.0.0)
> - [GOV.UK Frontend v4.1.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.1.0)
> - [GOV.UK Frontend v4.2.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.2.0)
> - [GOV.UK Frontend v4.3.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.3.0)
> - [GOV.UK Frontend v4.4.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.4.0)
> - [GOV.UK Frontend v4.5.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.5.0)
> - [GOV.UK Frontend v4.6.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.6.0)
> - [GOV.UK Frontend v4.7.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.7.0)
> - [GOV.UK Frontend v5.0.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.0.0)
> - [GOV.UK Frontend v5.1.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.1.0)
> 
> EDIT: we can now also upgrade to v5.2.0 as this has now become available
> - [GOV.UK Frontend v5.2.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.2.0)
> 
> EDIT 2: we are now decided to go with v4.8.0 as this has the crown logo changes on it and there are many breaking changes in v5.0.0 that may take some time to resolve.
> - [GOV.UK Frontend v4.8.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.8.0)
> 


[LTD-4702]: https://uktrade.atlassian.net/browse/LTD-4702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ