### PR TITLE
LTD-4803 Fix radios not showing correctly in exporter journey

### DIFF
--- a/exporter/applications/forms/end_use_details.py
+++ b/exporter/applications/forms/end_use_details.py
@@ -100,7 +100,6 @@ def is_informed_wmd_form(caption):
                     ),
                     Option(key=False, value="No"),
                 ],
-                classes=["govuk-radios--inline"],
             )
         ],
         default_button_name=generic.SAVE_AND_CONTINUE,
@@ -132,7 +131,6 @@ def is_suspected_wmd_form(caption):
                     ),
                     Option(key=False, value="No"),
                 ],
-                classes=["govuk-radios--inline"],
             )
         ],
         default_button_name=generic.SAVE_AND_CONTINUE,
@@ -178,7 +176,6 @@ def is_compliant_limitations_eu_form(caption):
                         ],
                     ),
                 ],
-                classes=["govuk-radios--inline"],
             )
         ],
         default_button_name=generic.SAVE_AND_CONTINUE,

--- a/exporter/applications/forms/export_details.py
+++ b/exporter/applications/forms/export_details.py
@@ -124,7 +124,6 @@ def is_temp_direct_control_form():
                         ],
                     ),
                 ],
-                classes=["govuk-radios--inline"],
             )
         ],
         default_button_name=CONTINUE,
@@ -171,7 +170,6 @@ def route_of_goods_form():
                         ],
                     ),
                 ],
-                classes=["govuk-radios--inline"],
             ),
             HiddenField("section_certificate_step", True),
             HTMLBlock(

--- a/exporter/applications/forms/route_of_goods.py
+++ b/exporter/applications/forms/route_of_goods.py
@@ -26,7 +26,6 @@ def route_of_goods_form(back_link):
                         ],
                     ),
                 ],
-                classes=["govuk-radios--inline"],
             ),
             HiddenField("section_certificate_step", True),
             HTMLBlock(


### PR DESCRIPTION
### Aim

This fixes an issue that we noticed with certain exporter forms (lite_forms) where radios were not displaying correctly if one of the radio options had an associated textarea. Those forms had the class `govuk-radios--inline` set when the lite form was created, and removing this has fixed the issue. Other existing forms where that class was set but where the radio options were a simple choice (i.e. no textarea) have not been changed.

[LTD-4803](https://uktrade.atlassian.net/browse/LTD-4803)


[LTD-4803]: https://uktrade.atlassian.net/browse/LTD-4803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ