### PR TITLE
LTD-4824 Update DESNZ team, queue, flag names in frontend

### DIFF
--- a/caseworker/advice/services.py
+++ b/caseworker/advice/services.py
@@ -483,9 +483,9 @@ def update_countersign_decision_advice(request, case, caseworker, formset_data):
             {
                 "id": countersign_advice["id"],
                 "outcome_accepted": form_data["outcome_accepted"],
-                "reasons": form_data["approval_reasons"]
-                if form_data["outcome_accepted"]
-                else form_data["rejected_reasons"],
+                "reasons": (
+                    form_data["approval_reasons"] if form_data["outcome_accepted"] else form_data["rejected_reasons"]
+                ),
             }
             for countersign_advice in countersign_advice_data
         ]
@@ -559,7 +559,7 @@ def get_advice_tab_context(case, caseworker, queue_id):
                 context["buttons"]["clear_recommendation"] = True
                 context["buttons"]["move_case_forward"] = True
 
-            # BEIS Nuclear need to assess products first before giving recommendation
+            # DESNZ Nuclear need to assess products first before giving recommendation
             if team_alias == BEIS_NUCLEAR and queue_alias == BEIS_NUCLEAR_CASES_TO_REVIEW and not existing_advice:
                 context["buttons"]["assess_trigger_list_products"] = len(unassessed_trigger_list_goods(case)) > 0
 

--- a/caseworker/advice/views.py
+++ b/caseworker/advice/views.py
@@ -855,7 +855,7 @@ class BEISAssessmentBase:
 
 
 class BEISProductAssessmentView(AdviceView, BEISNuclearMixin, BEISAssessmentBase, FormView):
-    """This renders trigger list product assessment for BEIS Nuclear"""
+    """This renders trigger list product assessment for DESNZ Nuclear"""
 
     template_name = "advice/trigger_list_home.html"
     form_class = BEISTriggerListAssessmentForm
@@ -918,7 +918,7 @@ class BEISProductAssessmentView(AdviceView, BEISNuclearMixin, BEISAssessmentBase
 
 
 class BEISProductAssessmentEditView(AdviceView, BEISNuclearMixin, BEISAssessmentBase, FormView):
-    """This renders editing of trigger list product assessment for BEIS Nuclear"""
+    """This renders editing of trigger list product assessment for DESNZ Nuclear"""
 
     template_name = "advice/trigger_list_edit.html"
     form_class = BEISTriggerListAssessmentEditForm

--- a/exporter/templates/includes/ecju-queries.html
+++ b/exporter/templates/includes/ecju-queries.html
@@ -8,7 +8,7 @@
 				{% if "BEIS_CHEMICAL" == ecju_query.team.alias %}
 					<p class="app-ecju-query__heading">BEIS</p>
 				{% elif "BEIS_NUCLEAR" == ecju_query.team.alias %}
-					<p class="app-ecju-query__heading">BEIS Nuclear</p>
+					<p class="app-ecju-query__heading">DESNZ Nuclear</p>
 				{% else %}
 					<p class="app-ecju-query__heading">{{ ecju_query.team.name }}</p>
 				{% endif %}

--- a/exporter/templates/includes/ecju-queries.html
+++ b/exporter/templates/includes/ecju-queries.html
@@ -6,7 +6,7 @@
 		<div class="app-ecju-query" id="open-ecju-query">
 			<div class="app-ecju-query__item">
 				{% if "BEIS_CHEMICAL" == ecju_query.team.alias %}
-					<p class="app-ecju-query__heading">BEIS</p>
+					<p class="app-ecju-query__heading">DESNZ Chemical</p>
 				{% elif "BEIS_NUCLEAR" == ecju_query.team.alias %}
 					<p class="app-ecju-query__heading">DESNZ Nuclear</p>
 				{% else %}

--- a/unit_tests/caseworker/advice/views/test_advice_view.py
+++ b/unit_tests/caseworker/advice/views/test_advice_view.py
@@ -21,7 +21,7 @@ def mock_beis_nuclear_queue(requests_mock):
     data = {
         "id": "00000000-0000-0000-0000-000000000001",
         "alias": "BEIS_NUCLEAR_CASES_TO_REVIEW",
-        "name": "BEIS Nuclear",
+        "name": "DESNZ Nuclear",
         "is_system_queue": True,
         "countersigning_queue": None,
     }

--- a/unit_tests/caseworker/conftest.py
+++ b/unit_tests/caseworker/conftest.py
@@ -146,7 +146,7 @@ def flags(fcdo_team, lu_team):
         },
         {
             "id": "dcb9ab9e-0dff-4b78-bc85-71b879c18a38",
-            "name": "BEIS CW",
+            "name": "DESNZ CW",
             **defaults,
             "alias": "BEIS_CW",
             "level": "Good",

--- a/unit_tests/caseworker/conftest.py
+++ b/unit_tests/caseworker/conftest.py
@@ -89,7 +89,7 @@ def flags(fcdo_team, lu_team):
     }
     beis_chem_team = {
         "id": "56273dd4-4634-4ad7-a782-e480f85a85a9",
-        "name": "BEIS Chemical",
+        "name": "DESNZ Chemical",
         "alias": "BEIS_CHEMICAL",
         "part_of_ecju": False,
         "is_ogd": True,

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -2434,7 +2434,7 @@ def data_ecju_queries():
                 "responded_by_user": None,
                 "team": {
                     "id": "56273dd4-4634-4ad7-a782-e480f85a85a9",
-                    "name": "BEIS Chemical",
+                    "name": "DESNZ Chemical",
                     "part_of_ecju": False,
                     "is_ogd": True,
                     "alias": "BEIS_CHEMICAL",
@@ -2453,7 +2453,7 @@ def data_ecju_queries():
                 "responded_by_user": None,
                 "team": {
                     "id": "88164d59-8724-4596-811b-40b60b5cf892",
-                    "name": "BEIS Nuclear controls",
+                    "name": "DESNZ Nuclear controls",
                     "part_of_ecju": False,
                     "is_ogd": True,
                     "alias": "BEIS_NUCLEAR",

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -262,7 +262,7 @@ def data_open_case():
                     "type": "internal",
                     "team": {
                         "id": "51358bb7-0743-481b-b60f-edf16f644d52",
-                        "name": "BEIS CWC",
+                        "name": "DESNZ Chemical",
                         "part_of_ecju": None,
                         "is_ogd": False,
                         "alias": None,
@@ -617,7 +617,7 @@ def data_standard_case(
                     "type": "internal",
                     "team": {
                         "id": "51358bb7-0743-481b-b60f-edf16f644d52",
-                        "name": "BEIS CWC",
+                        "name": "DESNZ Chemical",
                         "part_of_ecju": None,
                         "is_ogd": False,
                         "alias": None,
@@ -2415,7 +2415,7 @@ def data_ecju_queries():
                 "responded_by_user": None,
                 "team": {
                     "id": "51358bb7-0743-481b-b60f-edf16f644d52",
-                    "name": "BEIS CWC",
+                    "name": "DESNZ Chemical",
                     "part_of_ecju": None,
                     "is_ogd": False,
                     "alias": None,

--- a/unit_tests/exporter/applications/views/ecju_queries/test_ecju_query_team_name.py
+++ b/unit_tests/exporter/applications/views/ecju_queries/test_ecju_query_team_name.py
@@ -45,7 +45,7 @@ def test_shortens_beis_chemical_team_name(rendered_ecju_queries):
 
 
 def test_shortens_beis_nuclear_team_name(rendered_ecju_queries):
-    assert rendered_ecju_queries[2].p.get_text() == "BEIS Nuclear"
+    assert rendered_ecju_queries[2].p.get_text() == "DESNZ Nuclear"
 
 
 def test_renders_is_manually_closed_query(rendered_ecju_closed_queries):

--- a/unit_tests/exporter/applications/views/ecju_queries/test_ecju_query_team_name.py
+++ b/unit_tests/exporter/applications/views/ecju_queries/test_ecju_query_team_name.py
@@ -37,11 +37,11 @@ def rendered_ecju_queries(authorized_client, url):
 
 
 def test_renders_team_name(rendered_ecju_queries):
-    assert rendered_ecju_queries[0].p.get_text() == "BEIS CWC"
+    assert rendered_ecju_queries[0].p.get_text() == "DESNZ Chemical"
 
 
 def test_shortens_beis_chemical_team_name(rendered_ecju_queries):
-    assert rendered_ecju_queries[1].p.get_text() == "BEIS"
+    assert rendered_ecju_queries[1].p.get_text() == "DESNZ Chemical"
 
 
 def test_shortens_beis_nuclear_team_name(rendered_ecju_queries):


### PR DESCRIPTION
### Aim

As BEIS no longer exists, and the BEIS Chemical and BEIS Nuclear teams are now part of DESNZ, we need to change the queue names, team names, flag names shown to users in LITE.

Note that the lite-routing changes that enable this in [LTD-4764](https://uktrade.atlassian.net/browse/LTD-4764) changed the names but not the aliases. This means that there is code in lite-frontend which still use aliases such as `BEIS_NUCLEAR` which is as expected. 

[LTD-4824](https://uktrade.atlassian.net/browse/LTD-4824)


[LTD-4824]: https://uktrade.atlassian.net/browse/LTD-4824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LTD-4764]: https://uktrade.atlassian.net/browse/LTD-4764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ