### PR TITLE
Fix ultimate end user missing from exporter application summary

### DIFF
--- a/exporter/applications/helpers/check_your_answers.py
+++ b/exporter/applications/helpers/check_your_answers.py
@@ -128,7 +128,7 @@ def _convert_standard_application(application, editable=False, is_summary=False)
         product_location = {"Product location and journey": _get_product_location_and_journey(application)}
         converted = {**product_location, **converted}
 
-    if has_ultimate_end_users(application):
+    if has_ultimate_end_users(application) and has_incorporated_goods(application):
         ultimate_end_users = [convert_party(item, application, editable) for item in application["ultimate_end_users"]]
         converted[strings.ULTIMATE_END_USERS] = ultimate_end_users
 
@@ -712,7 +712,7 @@ def has_ultimate_end_users(application):
 
 def has_incorporated_goods(application):
     for good in application["goods"]:
-        if good["is_good_incorporated"]:
+        if good.get("is_good_incorporated") or good.get("is_onward_incorporated"):
             return True
 
     return False

--- a/exporter/applications/helpers/check_your_answers.py
+++ b/exporter/applications/helpers/check_your_answers.py
@@ -128,7 +128,7 @@ def _convert_standard_application(application, editable=False, is_summary=False)
         product_location = {"Product location and journey": _get_product_location_and_journey(application)}
         converted = {**product_location, **converted}
 
-    if has_ultimate_end_users(application) and has_incorporated_goods(application):
+    if has_ultimate_end_users(application) and has_incorporated_goods_on_application(application):
         ultimate_end_users = [convert_party(item, application, editable) for item in application["ultimate_end_users"]]
         converted[strings.ULTIMATE_END_USERS] = ultimate_end_users
 
@@ -710,9 +710,9 @@ def has_ultimate_end_users(application):
     return bool(application["ultimate_end_users"])
 
 
-def has_incorporated_goods(application):
-    for good in application["goods"]:
-        if good.get("is_good_incorporated") or good.get("is_onward_incorporated"):
+def has_incorporated_goods_on_application(application):
+    for goa in application["goods"]:
+        if goa.get("is_good_incorporated") or goa.get("is_onward_incorporated"):
             return True
 
     return False

--- a/exporter/applications/helpers/check_your_answers.py
+++ b/exporter/applications/helpers/check_your_answers.py
@@ -128,7 +128,7 @@ def _convert_standard_application(application, editable=False, is_summary=False)
         product_location = {"Product location and journey": _get_product_location_and_journey(application)}
         converted = {**product_location, **converted}
 
-    if has_incorporated_goods(application):
+    if has_ultimate_end_users(application):
         ultimate_end_users = [convert_party(item, application, editable) for item in application["ultimate_end_users"]]
         converted[strings.ULTIMATE_END_USERS] = ultimate_end_users
 
@@ -704,6 +704,10 @@ def _is_application_export_type_temporary(application):
 
 def is_application_export_type_permanent(application):
     return False if not application.get("export_type") else (application.get("export_type").get("key") == PERMANENT)
+
+
+def has_ultimate_end_users(application):
+    return bool(application["ultimate_end_users"])
 
 
 def has_incorporated_goods(application):

--- a/unit_tests/exporter/applications/views/conftest.py
+++ b/unit_tests/exporter/applications/views/conftest.py
@@ -107,13 +107,102 @@ def good_on_application(data_standard_case):
 
 
 @pytest.fixture
-def data_goa_onward_exported(data_standard_case):
+def data_goa_good_incorporated(data_standard_case):
     return {
-        "id": uuid.uuid4(),
+        "id": str(uuid.uuid4()),
+        "created_at": "2024-03-26T15:22:35.714893Z",
+        "updated_at": "2024-03-26T15:22:35.714893Z",
+        "good": {
+            "id": str(uuid.uuid4()),
+            "name": "medium shotgun component",
+            "description": "",
+            "part_number": "",
+            "no_part_number_comments": "",
+            "control_list_entries": [
+                {
+                    "id": "0b9116c2-3aa0-49fb-a590-944b4738b208",  # /PS-IGNORE
+                    "rating": "ML1a",
+                    "text": "Rifles and combination guns, handguns, machine, sub-machine and volley guns",
+                }
+            ],
+            "is_good_controlled": {"key": "True", "value": "Yes"},
+            "flags": [],
+            "documents": [],
+            "is_pv_graded": "no",
+            "status": {"key": "draft", "value": "Draft"},
+            "item_category": {"key": "group2_firearms", "value": "Firearm"},
+            "is_document_available": False,
+            "no_document_comments": "asdf",
+            "firearm_details": {
+                "type": {
+                    "key": "components_for_firearms",
+                    "value": "Components for firearms",
+                },
+                "year_of_manufacture": 0,
+                "calibre": "1",
+                "replica_description": "",
+                "is_covered_by_firearm_act_section_one_two_or_five": "No",
+                "is_covered_by_firearm_act_section_one_two_or_five_explanation": "",
+                "firearms_act_section": "",
+                "section_certificate_missing_reason": "",
+                "serial_numbers_available": "LATER",
+                "no_proof_mark_details": "",
+                "deactivation_standard": "",
+                "deactivation_standard_other": "",
+                "number_of_items": 1,
+                "serial_numbers": [],
+                "not_deactivated_to_standard_comments": "",
+            },
+            "is_precedent": False,
+            "product_description": "",
+        },
+        "application": data_standard_case["case"]["id"],
+        "quantity": 1.0,
+        "unit": {"key": "NAR", "value": "Items"},
+        "value": "1.00",
+        "is_good_incorporated": True,
+        "flags": [],
+        "control_list_entries": [],
+        "end_use_control": [],
+        "audit_trail": [],
+        "firearm_details": {
+            "type": {
+                "key": "components_for_firearms",
+                "value": "Components for firearms",
+            },
+            "year_of_manufacture": 0,
+            "calibre": "1",
+            "replica_description": "",
+            "is_covered_by_firearm_act_section_one_two_or_five": "No",
+            "is_covered_by_firearm_act_section_one_two_or_five_explanation": "",
+            "firearms_act_section": "",
+            "section_certificate_missing_reason": "",
+            "serial_numbers_available": "LATER",
+            "no_proof_mark_details": "",
+            "is_deactivated": False,
+            "deactivation_standard": "",
+            "deactivation_standard_other": "",
+            "number_of_items": 1,
+            "serial_numbers": [],
+            "not_deactivated_to_standard_comments": "",
+        },
+        "is_precedent": False,
+        "is_onward_altered_processed_comments": "",
+        "is_onward_incorporated_comments": "",
+        "regime_entries": [],
+        "nsg_list_type": "",
+        "nsg_assessment_note": "",
+    }
+
+
+@pytest.fixture
+def data_goa_onward_incorporated(data_standard_case):
+    return {
+        "id": str(uuid.uuid4()),
         "created_at": "2024-03-25T10:54:01.465094Z",
         "updated_at": "2024-03-25T10:54:01.465094Z",
         "good": {
-            "id": uuid.uuid4(),
+            "id": str(uuid.uuid4()),
             "name": "medium size widget",
             "description": "",
             "part_number": "asdf",

--- a/unit_tests/exporter/applications/views/conftest.py
+++ b/unit_tests/exporter/applications/views/conftest.py
@@ -107,6 +107,62 @@ def good_on_application(data_standard_case):
 
 
 @pytest.fixture
+def data_goa_onward_exported(data_standard_case):
+    return {
+        "id": uuid.uuid4(),
+        "created_at": "2024-03-25T10:54:01.465094Z",
+        "updated_at": "2024-03-25T10:54:01.465094Z",
+        "good": {
+            "id": uuid.uuid4(),
+            "name": "medium size widget",
+            "description": "",
+            "part_number": "asdf",
+            "no_part_number_comments": "",
+            "control_list_entries": [],
+            "is_good_controlled": {"key": "False", "value": "No"},
+            "flags": [],
+            "documents": [],
+            "is_pv_graded": "no",
+            "status": {"key": "draft", "value": "Draft"},
+            "item_category": {
+                "key": "group1_components",
+                "value": "Component, accessory or module",
+            },
+            "is_military_use": {"key": "no", "value": "No"},
+            "is_component": {
+                "key": "yes_general",
+                "value": "Yes, it's a general purpose component",
+            },
+            "uses_information_security": False,
+            "component_details": "asdf",
+            "information_security_details": "",
+            "is_document_available": False,
+            "no_document_comments": "asdf",
+            "is_precedent": False,
+            "product_description": "asdf",
+        },
+        "application": data_standard_case["case"]["id"],
+        "quantity": 1.0,
+        "unit": {"key": "NAR", "value": "Items"},
+        "value": "1.00",
+        "is_good_incorporated": False,
+        "flags": [],
+        "control_list_entries": [],
+        "end_use_control": [],
+        "audit_trail": [],
+        "is_precedent": False,
+        "is_onward_exported": True,
+        "is_onward_altered_processed": False,
+        "is_onward_altered_processed_comments": "",
+        "is_onward_incorporated": True,
+        "is_onward_incorporated_comments": "asdf",
+        "regime_entries": [],
+        "nsg_list_type": "",
+        "nsg_assessment_note": "",
+    }
+
+
+@pytest.fixture
 def mock_good_on_application_post(requests_mock, data_standard_case, good_on_application):
     application = data_standard_case["case"]["data"]
     url = client._build_absolute_uri(f'/applications/{application["id"]}/goods/')

--- a/unit_tests/exporter/applications/views/test_application_summary.py
+++ b/unit_tests/exporter/applications/views/test_application_summary.py
@@ -108,10 +108,29 @@ def test_application_summary_view(
     assert table_data_govuk_table_cell_text == expected_table_data
 
 
-def test_application_summary_view_shows_ultimate_end_user(
-    data_standard_case, data_goa_onward_exported, requests_mock, mock_get_case_notes, authorized_client, summary_url
+def test_application_summary_view_shows_ultimate_end_user_good_incorporated(
+    data_standard_case, data_goa_good_incorporated, requests_mock, mock_get_case_notes, authorized_client, summary_url
 ):
-    data_standard_case["case"]["data"]["goods"] = [data_goa_onward_exported]
+    data_standard_case["case"]["data"]["goods"] = [data_goa_good_incorporated]
+
+    applications_url = client._build_absolute_uri(f"/applications/{data_standard_case['case']['id']}/")
+    requests_mock.get(url=applications_url, json=data_standard_case["case"]["data"])
+
+    response = authorized_client.get(summary_url)
+    assert response.status_code == 200
+    soup = BeautifulSoup(response.content, "html.parser")
+    headings_govuk_heading_m = soup.find_all("h2", class_="govuk-heading-m")
+    headings_govuk_heading_m_text = [heading.text for heading in headings_govuk_heading_m]
+    assert "Ultimate end-user" in headings_govuk_heading_m_text
+    table_data_govuk_table_cell = soup.find_all("td", class_="govuk-table__cell")
+    table_data_govuk_table_cell_text = [data.text for data in table_data_govuk_table_cell]
+    assert "Ultimate End-user" in table_data_govuk_table_cell_text
+
+
+def test_application_summary_view_shows_ultimate_end_user_onward_incorporated(
+    data_standard_case, data_goa_onward_incorporated, requests_mock, mock_get_case_notes, authorized_client, summary_url
+):
+    data_standard_case["case"]["data"]["goods"] = [data_goa_onward_incorporated]
 
     applications_url = client._build_absolute_uri(f"/applications/{data_standard_case['case']['id']}/")
     requests_mock.get(url=applications_url, json=data_standard_case["case"]["data"])

--- a/unit_tests/exporter/applications/views/test_application_summary.py
+++ b/unit_tests/exporter/applications/views/test_application_summary.py
@@ -1,0 +1,111 @@
+import pytest
+from django.urls import reverse
+from bs4 import BeautifulSoup
+
+from core import client
+
+
+@pytest.fixture(autouse=True)
+def mock_get_application(requests_mock, data_standard_case):
+    applications_url = client._build_absolute_uri(f"/applications/{data_standard_case['case']['id']}/")
+    requests_mock.get(url=applications_url, json=data_standard_case["case"]["data"])
+
+
+@pytest.fixture
+def mock_get_case_notes(application, requests_mock):
+    return requests_mock.get(
+        f"/cases/{application['id']}/case-notes/",
+        json={"case_notes": []},
+    )
+
+
+@pytest.fixture
+def summary_url(data_standard_case):
+    return reverse("applications:summary", kwargs={"pk": data_standard_case["case"]["id"]})
+
+
+def test_application_summary_view(authorized_client, summary_url, mock_get_application, mock_get_case_notes):
+    """
+    This tests that the case data in data_standard_case is shown in the
+    application summary view. It just checks for the presence of these strings
+    and does not check the structure or layout. The test is intended to be a
+    minimal amount of test coverage to catch regressions such as if any of
+    these items stop being displayed in the application summary view.
+    """
+    response = authorized_client.get(summary_url)
+
+    assert response.status_code == 200
+    soup = BeautifulSoup(response.content, "html.parser")
+    headings_govuk_heading_m = soup.find_all("h2", class_="govuk-heading-m")
+    headings_govuk_heading_m_text = [heading.text for heading in headings_govuk_heading_m]
+    assert headings_govuk_heading_m_text == [
+        "Do you have a security approval?",
+        "Products",
+        "End use details",
+        "End user",
+        "Consignee",
+        "Third parties",
+        "Supporting documents",
+        "Route of products",
+        "Locations",
+        "Temporary export details",
+        "Ultimate end-user",
+        "Notes",
+    ]
+    table_data_govuk_table_cell = soup.find_all("td", class_="govuk-table__cell")
+    table_data_govuk_table_cell_text = [data.text for data in table_data_govuk_table_cell]
+    assert table_data_govuk_table_cell_text == [
+        "1.",
+        "p1",
+        "44",
+        "ML1a, ML22b",
+        "444.0 gram(s)",
+        "£444.00",
+        "2.",
+        "p2",
+        "44",
+        "N/A",
+        "444.0 gram(s)",
+        "£444.00",
+        "1.",
+        "Intended end use",
+        "44",
+        "2.",
+        "Informed to apply",
+        "No",
+        "3.",
+        "Informed WMD",
+        "No",
+        "4.",
+        "Suspect WMD",
+        "No",
+        "5.",
+        "EU transfer licence",
+        "No",
+        "1.",
+        "Third party",
+        "Individual",
+        "None",
+        "44, United Kingdom",
+        "N/A",
+        "Consultant",
+        "Attach document",
+        "1.",
+        "Shipped air waybill or lading",
+        "No44",
+        "1.",
+        "44",
+        "44, Brunei",
+        "1.",
+        "Products remaining under your direct control",
+        "No44",
+        "2.",
+        "Date products returning to the UK",
+        "2021-01-01",
+        "1.",
+        "Ultimate End-user",
+        "Individual",
+        "44, United Kingdom",
+        "N/A",
+        "Attach document",
+    ]

--- a/unit_tests/exporter/applications/views/test_application_summary.py
+++ b/unit_tests/exporter/applications/views/test_application_summary.py
@@ -24,88 +24,104 @@ def summary_url(data_standard_case):
     return reverse("applications:summary", kwargs={"pk": data_standard_case["case"]["id"]})
 
 
-def test_application_summary_view(authorized_client, summary_url, mock_get_application, mock_get_case_notes):
-    """
-    This tests that the case data in data_standard_case is shown in the
-    application summary view. It just checks for the presence of these strings
-    and does not check the structure or layout. The test is intended to be a
-    minimal amount of test coverage to catch regressions such as if any of
-    these items stop being displayed in the application summary view.
-    """
+@pytest.mark.parametrize(
+    ("expected_headings", "expected_table_data"),
+    [
+        (
+            [
+                "Do you have a security approval?",
+                "Products",
+                "End use details",
+                "End user",
+                "Consignee",
+                "Third parties",
+                "Supporting documents",
+                "Route of products",
+                "Locations",
+                "Temporary export details",
+                "Notes",
+            ],
+            [
+                "1.",
+                "p1",
+                "44",
+                "ML1a, ML22b",
+                "444.0 gram(s)",
+                "£444.00",
+                "2.",
+                "p2",
+                "44",
+                "N/A",
+                "444.0 gram(s)",
+                "£444.00",
+                "1.",
+                "Intended end use",
+                "44",
+                "2.",
+                "Informed to apply",
+                "No",
+                "3.",
+                "Informed WMD",
+                "No",
+                "4.",
+                "Suspect WMD",
+                "No",
+                "5.",
+                "EU transfer licence",
+                "No",
+                "1.",
+                "Third party",
+                "Individual",
+                "None",
+                "44, United Kingdom",
+                "N/A",
+                "Consultant",
+                "Attach document",
+                "1.",
+                "Shipped air waybill or lading",
+                "No44",
+                "1.",
+                "44",
+                "44, Brunei",
+                "1.",
+                "Products remaining under your direct control",
+                "No44",
+                "2.",
+                "Date products returning to the UK",
+                "2021-01-01",
+            ],
+        )
+    ],
+)
+def test_application_summary_view(
+    authorized_client, summary_url, mock_get_application, mock_get_case_notes, expected_headings, expected_table_data
+):
     response = authorized_client.get(summary_url)
 
     assert response.status_code == 200
     soup = BeautifulSoup(response.content, "html.parser")
     headings_govuk_heading_m = soup.find_all("h2", class_="govuk-heading-m")
     headings_govuk_heading_m_text = [heading.text for heading in headings_govuk_heading_m]
-    assert headings_govuk_heading_m_text == [
-        "Do you have a security approval?",
-        "Products",
-        "End use details",
-        "End user",
-        "Consignee",
-        "Third parties",
-        "Supporting documents",
-        "Route of products",
-        "Locations",
-        "Temporary export details",
-        "Ultimate end-user",
-        "Notes",
-    ]
+    assert headings_govuk_heading_m_text == expected_headings
     table_data_govuk_table_cell = soup.find_all("td", class_="govuk-table__cell")
     table_data_govuk_table_cell_text = [data.text for data in table_data_govuk_table_cell]
-    assert table_data_govuk_table_cell_text == [
-        "1.",
-        "p1",
-        "44",
-        "ML1a, ML22b",
-        "444.0 gram(s)",
-        "£444.00",
-        "2.",
-        "p2",
-        "44",
-        "N/A",
-        "444.0 gram(s)",
-        "£444.00",
-        "1.",
-        "Intended end use",
-        "44",
-        "2.",
-        "Informed to apply",
-        "No",
-        "3.",
-        "Informed WMD",
-        "No",
-        "4.",
-        "Suspect WMD",
-        "No",
-        "5.",
-        "EU transfer licence",
-        "No",
-        "1.",
-        "Third party",
-        "Individual",
-        "None",
-        "44, United Kingdom",
-        "N/A",
-        "Consultant",
-        "Attach document",
-        "1.",
-        "Shipped air waybill or lading",
-        "No44",
-        "1.",
-        "44",
-        "44, Brunei",
-        "1.",
-        "Products remaining under your direct control",
-        "No44",
-        "2.",
-        "Date products returning to the UK",
-        "2021-01-01",
-        "1.",
-        "Ultimate End-user",
-        "Individual",
-        "44, United Kingdom",
-        "N/A",
-        "Attach document",
-    ]
+    assert table_data_govuk_table_cell_text == expected_table_data
+
+
+def test_application_summary_view_shows_ultimate_end_user(
+    data_standard_case, data_goa_onward_exported, requests_mock, mock_get_case_notes, authorized_client, summary_url
+):
+    data_standard_case["case"]["data"]["goods"] = [data_goa_onward_exported]
+
+    applications_url = client._build_absolute_uri(f"/applications/{data_standard_case['case']['id']}/")
+    requests_mock.get(url=applications_url, json=data_standard_case["case"]["data"])
+
+    response = authorized_client.get(summary_url)
+    assert response.status_code == 200
+    soup = BeautifulSoup(response.content, "html.parser")
+    headings_govuk_heading_m = soup.find_all("h2", class_="govuk-heading-m")
+    headings_govuk_heading_m_text = [heading.text for heading in headings_govuk_heading_m]
+    assert "Ultimate end-user" in headings_govuk_heading_m_text
+    table_data_govuk_table_cell = soup.find_all("td", class_="govuk-table__cell")
+    table_data_govuk_table_cell_text = [data.text for data in table_data_govuk_table_cell]
+    assert "Ultimate End-user" in table_data_govuk_table_cell_text


### PR DESCRIPTION
### Aim

This fixes an issue where ultimate end users were not showing in the exporter application summary ("Check your answers" page). 

For some applications where an exporter has added incorporated goods, in the good on application, it is possible that `is_good_incorporated` can be `False` but `is_onward_incorporated` can be `True`.

Previously the way that ultimate end users were toggled on and off for this page was just by checking the value of `is_good_incorporated`.

We would like to check for the presence of `application["ultimate_end_users"]` but as this can be unreliable (as we don't delete this data if an application is edited) it is best to check both of `is_good_incorporated` and `is_onward_incorporated`. If either of these booleans are true then we consider that the application has incorporated goods. 

So, if the application has ultimate end users and has incorporated goods then we would like to show the ultimate end users section in the exporter summary.

[LTD-4853](https://uktrade.atlassian.net/browse/LTD-4853)


[LTD-4853]: https://uktrade.atlassian.net/browse/LTD-4853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ