### PR TITLE
LTD-4895 Rewrite existing example denial data csv

### DIFF
--- a/caseworker/external_data/example.csv
+++ b/caseworker/external_data/example.csv
@@ -1,2 +1,2 @@
-reference,name,address,notifying_government,final_destination,item_list_codes,item_description,consignee_name,end_use,field_one,field_two,field_n
-ABC123,44,123 fake street,France,Germany,ABC123,Grapes,Fred Example,Used in car,value_one,value_two,value_n
+reference,regime_reg_ref,name,address,notifying_government,country,item_list_codes,item_description,consignee_name,end_use,reason_for_refusal,spire_entity_id
+DN2000/0000,AB-CD-EF-000,Organisation Name,"1000 Street Name, City Name",Country Name,Country Name,0A00100,Medium Size Widget,Example Name,Used in industry,Risk of outcome,123


### PR DESCRIPTION
### Aim

I chose the columns based on the fields of the `DenialEntity` model: https://github.com/uktrade/lite-api/blob/dev/api/external_data/models.py#L30

Also I looked at the csv extract of real denials data I took from the spire replica to double check fields as well as understand what the data typically looks like.

[LTD-4895](https://uktrade.atlassian.net/browse/LTD-4895)

[LTD-4895]: https://uktrade.atlassian.net/browse/LTD-4895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ