### PR TITLE
Update build_caseworker script to build desnz js file

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "build_exporter": "parcel build ./exporter/assets/javascripts/main.js ./exporter/assets/javascripts/cookie-policy-form.js --dist-dir exporter/assets/built --public-url /assets/",
-    "build_caseworker": "parcel build ./caseworker/assets/javascripts/{main,head,bookmarks,cookie-policy-form,beis,tau,tau-edit,tau-multiple-assessment-edit,case-filters,refusal-review-consolidate,search-products}.js --dist-dir caseworker/assets/built --public-url /assets/",
+    "build_caseworker": "parcel build ./caseworker/assets/javascripts/{main,head,bookmarks,cookie-policy-form,desnz,tau,tau-edit,tau-multiple-assessment-edit,case-filters,refusal-review-consolidate,search-products}.js --dist-dir caseworker/assets/built --public-url /assets/",
     "watch_exporter": "PARCEL_WORKERS=0 parcel watch --port 8400 ./exporter/assets/javascripts/{main,head}.js ./exporter/assets/javascripts/cookie-policy-form.js --dist-dir exporter/assets/built --public-url /assets/",
     "watch_caseworker": "PARCEL_WORKERS=0 parcel watch --port 8401 ./caseworker/assets/javascripts/{main,head,bookmarks,cookie-policy-form,search-cases,beis,tau,tau-edit,tau-multiple-assessment-edit,case-filters,refusal-review-consolidate,search-products}.js --dist-dir caseworker/assets/built --public-url /assets/",
     "watch": "rm -rf .parcel-cache && npm run build_exporter && npm run build_caseworker && concurrently 'npm run watch_exporter' 'npm run watch_caseworker'",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build_exporter": "parcel build ./exporter/assets/javascripts/main.js ./exporter/assets/javascripts/cookie-policy-form.js --dist-dir exporter/assets/built --public-url /assets/",
     "build_caseworker": "parcel build ./caseworker/assets/javascripts/{main,head,bookmarks,cookie-policy-form,desnz,tau,tau-edit,tau-multiple-assessment-edit,case-filters,refusal-review-consolidate,search-products}.js --dist-dir caseworker/assets/built --public-url /assets/",
     "watch_exporter": "PARCEL_WORKERS=0 parcel watch --port 8400 ./exporter/assets/javascripts/{main,head}.js ./exporter/assets/javascripts/cookie-policy-form.js --dist-dir exporter/assets/built --public-url /assets/",
-    "watch_caseworker": "PARCEL_WORKERS=0 parcel watch --port 8401 ./caseworker/assets/javascripts/{main,head,bookmarks,cookie-policy-form,search-cases,beis,tau,tau-edit,tau-multiple-assessment-edit,case-filters,refusal-review-consolidate,search-products}.js --dist-dir caseworker/assets/built --public-url /assets/",
+    "watch_caseworker": "PARCEL_WORKERS=0 parcel watch --port 8401 ./caseworker/assets/javascripts/{main,head,bookmarks,cookie-policy-form,search-cases,desnz,tau,tau-edit,tau-multiple-assessment-edit,case-filters,refusal-review-consolidate,search-products}.js --dist-dir caseworker/assets/built --public-url /assets/",
     "watch": "rm -rf .parcel-cache && npm run build_exporter && npm run build_caseworker && concurrently 'npm run watch_exporter' 'npm run watch_caseworker'",
     "build": "npm install --no-save && npm run build_all",
     "build_all": "export NODE_ENV=production && concurrently 'npm run build_exporter' 'npm run build_caseworker'",


### PR DESCRIPTION
### Aim

The desnz js file was not getting built and this was causing errors in prod e.g. [sentry link removed]

This change updates the `build_caseworker` script which is what generates the built js files, which should fix the issue once this makes its way to prod environment. We can test on UAT first by running through a DESNZ caseworker journey to verify this fixes the issue.

[LTD-4925](https://uktrade.atlassian.net/browse/LTD-4925)
