### PR TITLE
[LTD-4888] Ensure consignee/third party document upload is optional

### DIFF
--- a/core/builtins/custom_tags.py
+++ b/core/builtins/custom_tags.py
@@ -838,6 +838,8 @@ def get_parties_status_optional_documents(parties):
         if not parties["documents"]:
             if parties["type"] == "end_user" and parties["end_user_document_available"] is False:
                 return DONE
+            if parties["type"] == "consignee" and parties["address"]:
+                return DONE
             return IN_PROGRESS
 
     return DONE

--- a/lite_content/lite_exporter_frontend/strings.py
+++ b/lite_content/lite_exporter_frontend/strings.py
@@ -158,7 +158,7 @@ class UltimateEndUser:
         VIRUS_INFECTED = "The selected file contains a virus"
 
         class AttachDocuments:
-            TITLE = "Attach a document"
+            TITLE = "Attach a document (optional)"
             DESCRIPTION = (
                 "Upload a DOCX, DOC, PDF or PNG file."
                 "\n\nDo not attach a document that's above OFFICIAL-SENSITIVE."
@@ -187,7 +187,7 @@ class Consignee:
         VIRUS_INFECTED = "The selected file contains a virus"
 
         class AttachDocuments:
-            TITLE = "Attach a document"
+            TITLE = "Attach a document (optional)"
             DESCRIPTION = (
                 "Upload a DOCX, DOC, PDF or PNG file."
                 "\n\nDo not attach a document that's above OFFICIAL-SENSITIVE."
@@ -219,7 +219,7 @@ class ThirdParties:
         VIRUS_INFECTED = "The selected file contains a virus"
 
         class AttachDocuments:
-            TITLE = "Attach a document"
+            TITLE = "Attach a document (optional)"
             DESCRIPTION = (
                 "Upload a DOCX, DOC, PDF or PNG file."
                 "\n\nDo not attach a document that's above OFFICIAL-SENSITIVE."

--- a/unit_tests/core/builtins/test_custom_tags.py
+++ b/unit_tests/core/builtins/test_custom_tags.py
@@ -6,6 +6,12 @@ from decimal import Decimal
 from core.builtins import custom_tags
 from core.builtins.custom_tags import highlight_text
 
+from exporter.core.constants import (
+    NOT_STARTED,
+    DONE,
+    IN_PROGRESS,
+)
+
 from exporter.core import constants
 from exporter.core.objects import Application
 
@@ -373,3 +379,21 @@ def test_pprint_dict(data, expected):
 )
 def test_str_time_on_date(input_string, expected_output):
     assert custom_tags.str_time_on_date(input_string) == expected_output
+
+
+@pytest.mark.parametrize(
+    ("parties", "expected_status"),
+    [
+        ([], NOT_STARTED),
+        ([None], NOT_STARTED),
+        ({"documents": None, "type": "sometype"}, IN_PROGRESS),
+        ({"documents": None, "type": "end_user", "end_user_document_available": True}, IN_PROGRESS),
+        ({"documents": None, "type": "end_user", "end_user_document_available": False}, DONE),
+        ({"documents": None, "type": "consignee", "address": None}, IN_PROGRESS),
+        ({"documents": None, "type": "consignee", "address": "some address"}, DONE),
+        ({"documents": "something"}, DONE),
+        (["some party"], DONE),
+    ],
+)
+def test_get_parties_status_optional_documents(parties, expected_status):
+    assert custom_tags.get_parties_status_optional_documents(parties) == expected_status


### PR DESCRIPTION
### Aim

This change ensures that third party/consignee document uploads are signalled as optional on the exporter application flow.

To prevent an erroneous "In progress" state on the consignee entry of the task list, the `get_parties_status_optional_documents` template tag was updated.  The addition to that tag is not ideal, but ideally we will have a much more programmatic/DRY way of doing task lists/completion statuses as we move more towards django forms in the exporter flows in future.

[LTD-4888](https://uktrade.atlassian.net/browse/LTD-4888)


[LTD-4888]: https://uktrade.atlassian.net/browse/LTD-4888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ