### PR TITLE
LTD-4896 Add basic CSV upload functionality

### DIFF
--- a/caseworker/core/context_processors.py
+++ b/caseworker/core/context_processors.py
@@ -95,6 +95,7 @@ def lite_menu(request):
                 or Permission.MANAGE_ALL_ROUTING_RULES.value in permissions,
                 {"title": "Routing rules", "url": reverse_lazy("routing_rules:list"), "icon": "menu/routing-rules"},
             ),
+            {"title": "Denial records", "url": reverse_lazy("external_data:denials-upload"), "icon": "menu/cases"},
         ]
     else:
         pages = []

--- a/caseworker/core/context_processors.py
+++ b/caseworker/core/context_processors.py
@@ -95,7 +95,6 @@ def lite_menu(request):
                 or Permission.MANAGE_ALL_ROUTING_RULES.value in permissions,
                 {"title": "Routing rules", "url": reverse_lazy("routing_rules:list"), "icon": "menu/routing-rules"},
             ),
-            {"title": "Denial records", "url": reverse_lazy("external_data:denials-upload"), "icon": "menu/cases"},
         ]
     else:
         pages = []

--- a/caseworker/external_data/views.py
+++ b/caseworker/external_data/views.py
@@ -5,7 +5,6 @@ from django.contrib.messages.views import SuccessMessageMixin
 from django.urls import reverse
 from django.views.generic import TemplateView
 from django.views.generic.edit import FormView, CreateView
-from django.http import Http404
 
 from core.auth.views import LoginRequiredMixin
 
@@ -21,9 +20,6 @@ class DenialUploadView(LoginRequiredMixin, SuccessMessageMixin, CreateView):
     form_class = forms.DenialUploadForm
     success_message = "Denials created successfully"
     extra_context = {"base_64_csv": base_64_csv}
-
-    def dispatch(self, request, *args, **kwargs):
-        raise Http404("CSV denials uploads have been disabled")
 
     def form_valid(self, form):
         response = services.upload_denials(request=self.request, data=form.cleaned_data)

--- a/caseworker/external_data/views.py
+++ b/caseworker/external_data/views.py
@@ -18,7 +18,7 @@ with open(settings.BASE_DIR + "/caseworker/external_data/example.csv", "rb") as 
 class DenialUploadView(LoginRequiredMixin, SuccessMessageMixin, CreateView):
     template_name = "external_data/denial-upload.html"
     form_class = forms.DenialUploadForm
-    success_message = "Denials created successfully"
+    success_message = "Denials created or updated successfully"
     extra_context = {"base_64_csv": base_64_csv}
 
     def form_valid(self, form):

--- a/unit_tests/caseworker/external_data/test_views.py
+++ b/unit_tests/caseworker/external_data/test_views.py
@@ -41,6 +41,7 @@ def mock_denial_patch(requests_mock):
     yield requests_mock.patch(url=url, json={})
 
 
+<<<<<<< HEAD
 def test_upload_denial_404(authorized_client, mock_denial_upload, settings):
     # given the case has activity from system user
     url = reverse(
@@ -62,6 +63,8 @@ def test_upload_denial_404(authorized_client, mock_denial_upload, settings):
 
 
 @pytest.mark.skip(reason="CSV denials upload has been disabled")
+=======
+>>>>>>> 12ae42e4a (Enable denials csv upload)
 def test_upload_denial_valid_file(authorized_client, mock_denial_upload, settings):
     # given the case has activity from system user
     url = reverse(
@@ -81,7 +84,6 @@ def test_upload_denial_valid_file(authorized_client, mock_denial_upload, setting
         assert mock_denial_upload.last_request.json() == {"csv_file": f.read()}
 
 
-@pytest.mark.skip(reason="CSV denials upload has been disabled")
 def test_upload_denial_invalid_file(authorized_client, mock_denial_upload_validation_error, settings):
     # given the case has activity from system user
     url = reverse(

--- a/unit_tests/caseworker/external_data/test_views.py
+++ b/unit_tests/caseworker/external_data/test_views.py
@@ -41,30 +41,6 @@ def mock_denial_patch(requests_mock):
     yield requests_mock.patch(url=url, json={})
 
 
-<<<<<<< HEAD
-def test_upload_denial_404(authorized_client, mock_denial_upload, settings):
-    # given the case has activity from system user
-    url = reverse(
-        "external_data:denials-add-by-csv"
-    )  # TODO: rename back to ""denials-upload" when we are ready to release this to users
-
-    file_path = os.path.join(settings.BASE_DIR, "caseworker/external_data/example.csv")
-    data = {"csv_file": open(file_path, "rb")}
-
-    # when the case is viewed
-    response = authorized_client.post(url, data, format="multipart")
-
-    # then it does not error
-    assert response.status_code == 404
-    # and the upstream endpoint was posted
-
-    response = authorized_client.get(url)
-    assert response.status_code == 404
-
-
-@pytest.mark.skip(reason="CSV denials upload has been disabled")
-=======
->>>>>>> 12ae42e4a (Enable denials csv upload)
 def test_upload_denial_valid_file(authorized_client, mock_denial_upload, settings):
     # given the case has activity from system user
     url = reverse(


### PR DESCRIPTION
### Aim

These are the frontend changes required to enable the denials CSV upload functionality along with some minor edits.

There is a corresponding PR in lite-api.

[LTD-4896](https://uktrade.atlassian.net/browse/LTD-4896)


[LTD-4896]: https://uktrade.atlassian.net/browse/LTD-4896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ