### PR TITLE
Ltd 4926 spell out ECJU in first use in lite

### DIFF
--- a/lite_content/lite_exporter_frontend/applications.py
+++ b/lite_content/lite_exporter_frontend/applications.py
@@ -823,7 +823,7 @@ class EndUseDetails:
 
     INTENDED_END_USE = "Provide details of the intended end use of the products"
     INFORMED_TO_APPLY = (
-        "Have you received a letter from Export Control Unit (ECJU) informing you that the products "
+        "Have you received a letter from Export Control Joint Unit (ECJU) informing you that the products "
         "require a licence to export or are controlled under the military end use controls?"
     )
     INFORMED_WMD = (

--- a/lite_content/lite_exporter_frontend/applications.py
+++ b/lite_content/lite_exporter_frontend/applications.py
@@ -823,7 +823,7 @@ class EndUseDetails:
 
     INTENDED_END_USE = "Provide details of the intended end use of the products"
     INFORMED_TO_APPLY = (
-        "Have you received a letter from ECJU informing you that the products "
+        "Have you received a letter from Export Control Unit (ECJU) informing you that the products "
         "require a licence to export or are controlled under the military end use controls?"
     )
     INFORMED_WMD = (


### PR DESCRIPTION
### Aim

<!--

Change ECJU acronym to full name Export Control Joint Unit (ECJU) for accessibility reasons on first mention.
-->

[LTD-4946](https://uktrade.atlassian.net/browse/LTD-4926)
