### PR TITLE
LTD-4948 Add link to Denial records to caseworker menu bar

### DIFF
--- a/caseworker/core/context_processors.py
+++ b/caseworker/core/context_processors.py
@@ -95,6 +95,7 @@ def lite_menu(request):
                 or Permission.MANAGE_ALL_ROUTING_RULES.value in permissions,
                 {"title": "Routing rules", "url": reverse_lazy("routing_rules:list"), "icon": "menu/routing-rules"},
             ),
+            {"title": "Denial records", "url": reverse_lazy("external_data:denials-upload"), "icon": "menu/cases"},
         ]
     else:
         pages = []

--- a/caseworker/external_data/urls.py
+++ b/caseworker/external_data/urls.py
@@ -5,9 +5,7 @@ from caseworker.external_data import views
 app_name = "external_data"
 
 urlpatterns = [
-    path(
-        "denials/add-by-csv/", views.DenialUploadView.as_view(), name="denials-add-by-csv"
-    ),  # TODO: rename back to "denials/upload/" and "denials-upload" when we are ready to release this to users
+    path("denials/upload/", views.DenialUploadView.as_view(), name="denials-upload"),
     path("denials/<uuid:pk>/", views.DenialDetailView.as_view(), name="denial-detail"),
     path("denials/<uuid:pk>/revoke/", views.DenialRevokeView.as_view(), name="denial-revoke"),
 ]

--- a/unit_tests/caseworker/external_data/test_views.py
+++ b/unit_tests/caseworker/external_data/test_views.py
@@ -43,9 +43,7 @@ def mock_denial_patch(requests_mock):
 
 def test_upload_denial_valid_file(authorized_client, mock_denial_upload, settings):
     # given the case has activity from system user
-    url = reverse(
-        "external_data:denials-add-by-csv"
-    )  # TODO: rename back to ""denials-upload" when we are ready to release this to users
+    url = reverse("external_data:denials-upload")
 
     file_path = os.path.join(settings.BASE_DIR, "caseworker/external_data/example.csv")
     data = {"csv_file": open(file_path, "rb")}
@@ -62,9 +60,7 @@ def test_upload_denial_valid_file(authorized_client, mock_denial_upload, setting
 
 def test_upload_denial_invalid_file(authorized_client, mock_denial_upload_validation_error, settings):
     # given the case has activity from system user
-    url = reverse(
-        "external_data:denials-add-by-csv"
-    )  # TODO: rename back to ""denials-upload" when we are ready to release this to users
+    url = reverse("external_data:denials-upload")
 
     file_path = os.path.join(settings.BASE_DIR, "caseworker/external_data/example.csv")
     data = {"csv_file": open(file_path, "rb")}


### PR DESCRIPTION
### Aim

This renames the denials upload url back to what we had before as it is no longer a hidden url but something we want to release to users. The Denial records link is also added back to the menu bar so that users can find their way to the Denials upload page.

[LTD-4948](https://uktrade.atlassian.net/browse/LTD-4948)


[LTD-4948]: https://uktrade.atlassian.net/browse/LTD-4948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ