### PR TITLE
LTD-4949 Update denials upload example csv

### DIFF
--- a/caseworker/external_data/example.csv
+++ b/caseworker/external_data/example.csv
@@ -1,2 +1,2 @@
-reference,regime_reg_ref,name,address,notifying_government,country,item_list_codes,item_description,consignee_name,end_use,reason_for_refusal,spire_entity_id
-DN2000/0000,AB-CD-EF-000,Organisation Name,"1000 Street Name, City Name",Country Name,Country Name,0A00100,Medium Size Widget,Example Name,Used in industry,Risk of outcome,123
+reference,regime_reg_ref,notifying_government,item_list_codes,item_description,end_use,reason_for_refusal,name,address,country,consignee_name,spire_entity_id,end_user_flag,consignee_flag,other_role
+DN2000/0000,AB-CD-EF-000,Country Name,0A00100,Medium Size Widget,Used in industry,Risk of outcome,Organisation Name,"1000 Street Name, City Name",Country Name,Example Name,123,TRUE,FALSE,Other Role

--- a/caseworker/external_data/example.csv
+++ b/caseworker/external_data/example.csv
@@ -1,2 +1,2 @@
-reference,regime_reg_ref,notifying_government,item_list_codes,item_description,end_use,reason_for_refusal,name,address,country,consignee_name,spire_entity_id,end_user_flag,consignee_flag,other_role
-DN2000/0000,AB-CD-EF-000,Country Name,0A00100,Medium Size Widget,Used in industry,Risk of outcome,Organisation Name,"1000 Street Name, City Name",Country Name,Example Name,123,TRUE,FALSE,Other Role
+reference,regime_reg_ref,notifying_government,item_list_codes,item_description,end_use,reason_for_refusal,name,address,country,spire_entity_id,end_user_flag,consignee_flag,other_role
+DN2000/0000,AB-CD-EF-000,Country Name,0A00100,Medium Size Widget,Used in industry,Risk of outcome,Organisation Name,"1000 Street Name, City Name",Country Name,123,TRUE,FALSE,Other Role

--- a/caseworker/external_data/example.csv
+++ b/caseworker/external_data/example.csv
@@ -1,2 +1,4 @@
-reference,regime_reg_ref,notifying_government,item_list_codes,item_description,end_use,reason_for_refusal,name,address,country,spire_entity_id,end_user_flag,consignee_flag,other_role
-DN2000/0000,AB-CD-EF-000,Country Name,0A00100,Medium Size Widget,Used in industry,Risk of outcome,Organisation Name,"1000 Street Name, City Name",Country Name,123,TRUE,FALSE,Other Role
+reference,regime_reg_ref,notifying_government,item_list_codes,item_description,end_use,reason_for_refusal,name,address,country,spire_entity_id,entity_type
+DN2000/0000,AB-CD-EF-000,Country Name,0A00100,Medium Size Widget,Used in industry,Risk of outcome,Organisation Name,"1000 Street Name, City Name",Country Name,123,consignee
+DN2000/1000,AB-CD-EF-100,Country Name 2,0A01100,Small Size Widget,Used in industry,Risk of outcome,Organisation Name 2,"2000 Street Name, City Name 2",Country Name 2,234,end_user
+DN2000/2000,AB-CD-EF-200,Country Name 3,0A02100,Unknown Size Widget,Used in industry,Risk of outcome,Organisation Name 3,"3000 Street Name, City Name 3",Country Name 3,345,third_party


### PR DESCRIPTION
### Aim

This adds the `entity_type` column to the example csv as we want users to be able to set this directly in their data upload. Also, the columns specific to Denial have been moved to the left and columns specific to DenialEntity have been moved to the right - this is what we did for our demo to them so we should reflect that in our example csv file.

[LTD-4949](https://uktrade.atlassian.net/browse/LTD-4949)


[LTD-4949]: https://uktrade.atlassian.net/browse/LTD-4949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ