### PR TITLE
LTD-4946-add-help-email-and-number-to-exporter-dashboard

### DIFF
--- a/exporter/templates/core/hub.html
+++ b/exporter/templates/core/hub.html
@@ -153,6 +153,22 @@
 
 
 			</div>
+			{# Help and support tile #}
+			<div class="app-tile">
+
+				<h2 class="govuk-!-margin-top-0">
+					<span class="govuk-heading-s" id="link-eua">
+						{% lcs 'hub.Tiles.HELP_AND_SUPPORT' %}
+					</span>
+				</h2>
+				<div class="app-tile__body">
+					{% comment %}/PS-IGNORE{% endcomment %}For support with this service, contact <a href="mailto:LITE.support@businessandtrade.gov.uk">LITE.support@businessandtrade.gov.uk</a>
+					or call +44(0)20 7215 4595 (select option 2).
+				</div>
+				<div class="app-tile__body">
+					View <a href="https://exporter.lite.service.uat.uktrade.digital/signature-help/" target="_blank">guidance on LITE document digital signatures.</a>
+				</div>
+			</div>
 		</div>
 	{% else %}
 		<div class="app-tiles">

--- a/lite_content/lite_exporter_frontend/hub.py
+++ b/lite_content/lite_exporter_frontend/hub.py
@@ -17,6 +17,7 @@ class Tiles:
     END_USER_ADVISORIES = "<!--View your--> End user advisories"
     OPEN_LICENCE_RETURNS = "<!--View your--> Open licence returns"
     COMPLIANCE_HEADING = "<!--View your--> Compliance and annual returns"
+    HELP_AND_SUPPORT = "<!--View--> Help and support"
 
     # Standard dashboard
     class Apply:


### PR DESCRIPTION
### Aim

Please can we add another tile on the bottom row called 'help and support' hen move the digital signatures link to this new box, so we can remove it from the top.

[LTD-4946](https://uktrade.atlassian.net/browse/LTD-4946)
