### PR TITLE
LTD-4943 Add csv field validation to frontend csv upload form

### DIFF
--- a/caseworker/external_data/forms.py
+++ b/caseworker/external_data/forms.py
@@ -1,4 +1,10 @@
+import csv
+import io
+import os
+
 from django import forms
+from django.core.exceptions import ValidationError
+from django.conf import settings
 
 from storages.backends.s3boto3 import S3Boto3StorageFile
 
@@ -9,15 +15,30 @@ class DenialUploadForm(forms.Form):
 
     # the CreateView expects `instance` to be passed in here
     def __init__(self, instance, *args, **kwargs):
+        self.set_required_headers_from_example_csv()
         super().__init__(*args, **kwargs)
+
+    def set_required_headers_from_example_csv(self):
+        # Set required_headers from the example csv so they stay up to date
+        file_path = os.path.join(settings.BASE_DIR, "caseworker/external_data/example.csv")
+        with open(file_path, mode="r", encoding="utf-8") as file:
+            reader = csv.DictReader(file)
+            self.required_headers = reader.fieldnames
 
     def clean_csv_file(self):
         value = self.cleaned_data["csv_file"]
         if isinstance(value, S3Boto3StorageFile):
             s3_obj = value.obj.get()["Body"]
             return s3_obj.read().decode("utf-8")
+        value = value.read().decode("utf-8")
 
-        return value.read().decode("utf-8")
+        csv_file = io.StringIO(value)
+        reader = csv.DictReader(csv_file)
+        # Check if required headers are present
+        if not (set(self.required_headers)).issubset(set(reader.fieldnames)):  # type: ignore
+            raise ValidationError("Missing required headers in CSV file")
+
+        return value
 
     def save(self):
         # the CreateView expects this method

--- a/pii-secret-exclude.txt
+++ b/pii-secret-exclude.txt
@@ -110,3 +110,4 @@ unit_tests/caseworker/advice/views/test_trigger_list_view.py
 unit_tests/caseworker/advice/views/test_advice_view.py
 unit_tests/caseworker/advice/views/test_view_ogd_advice_countersign.py
 unit_tests/caseworker/queues/test_views.py
+unit_tests/caseworker/external_data/denial_invalid.csv

--- a/unit_tests/caseworker/external_data/denial_invalid.csv
+++ b/unit_tests/caseworker/external_data/denial_invalid.csv
@@ -1,0 +1,2 @@
+reference,regime_reg_ref,notifying_government,item_list_codes,item_description,end_use,reason_for_refusal
+DN2000/0000,AB-CD-EF-000,Country Name,0A00100,Medium Size Widget,Used in industry,Risk of outcome

--- a/unit_tests/caseworker/external_data/test_views.py
+++ b/unit_tests/caseworker/external_data/test_views.py
@@ -75,6 +75,17 @@ def test_upload_denial_invalid_file(authorized_client, mock_denial_upload_valida
     }
 
 
+def test_upload_denial_missing_required_headers_error(authorized_client, settings):
+    url = reverse("external_data:denials-upload")
+    file_path = os.path.join(settings.BASE_DIR, "unit_tests/caseworker/external_data/denial_invalid.csv")
+    data = {"csv_file": open(file_path, "rb")}
+
+    response = authorized_client.post(url, data, format="multipart")
+
+    assert response.status_code == 200
+    assert response.context_data["form"].errors == {"csv_file": ["Missing required headers in CSV file"]}
+
+
 def test_denial_detail(authorized_client, mock_denial_retrieve):
     url = reverse("external_data:denial-detail", kwargs={"pk": denial_pk})
 


### PR DESCRIPTION
### Aim

This adds form validation of the csv file in the frontend to check required headers are present. The required headers are determined from the example csv file.

[LTD-4943](https://uktrade.atlassian.net/browse/LTD-4943)


[LTD-4943]: https://uktrade.atlassian.net/browse/LTD-4943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ