### PR TITLE
LTD-4993-add-dn-highlighting-party-details 

### DIFF
--- a/caseworker/cases/views/main.py
+++ b/caseworker/cases/views/main.py
@@ -700,4 +700,6 @@ class Denials(LoginRequiredMixin, TemplateView):
             results = response["results"]
             total_pages = response["total_pages"]
 
-        return super().get_context_data(case=case, results=results, total_pages=total_pages, **kwargs)
+        return super().get_context_data(
+            case=case, results=results, total_pages=total_pages, parties=parties_to_search, **kwargs
+        )

--- a/caseworker/templates/case/denial-for-case.html
+++ b/caseworker/templates/case/denial-for-case.html
@@ -11,6 +11,28 @@
         <div class="govuk-grid-column-full govuk-!-margin-bottom-6">
             <a class="lite-back-link-button" id="back-link" href="{% url 'cases:case' queue_pk=queue.id pk=case.id tab="details" %}">Back</a>
         </div>
+        <div class="govuk-grid-column-two-thirds">
+            <table id="table-Party-details" class="govuk-table">
+                <thead class="govuk-table__head">
+                    <tr class="govuk-table__row">
+                            <th scope="col" class="govuk-table__header">Name</th>
+                            <th scope="col" class="govuk-table__header">Address</th>
+                            <th scope="col" class="govuk-table__header">Country</th>
+                            <th scope="col" class="govuk-table__header">Entity type</th>
+                    </tr>
+                </thead>
+                <tbody class="govuk-table__body">
+                    {% for party in parties %}
+                        <tr class="govuk-table__row">
+                            <td class="govuk-table__cell">{{ party.name|safe }}</td>
+                            <td class="govuk-table__cell">{{ party.address|safe }}</td>
+                            <td class="govuk-table__cell">{{ party.country.name }}</td>
+                            <td class="govuk-table__cell">{{ party.type_display_value }}</td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
         <div class="govuk-grid-column-full">
             <h2 class="govuk-heading-l govuk-!-margin-top-6 govuk-!-margin-bottom-3">
                 Denial matches
@@ -73,8 +95,8 @@
                                     <a style="position: relative;" href="{% url 'external_data:denial-detail' pk=denial.id %}">{{ denial.regime_reg_ref }}</a>
                                 </td>
                                 <td class="govuk-table__cell">{{ denial.reference|sentence_case }}</td>
-                                <td class="govuk-table__cell">{{ denial.name }}</td>
-                                <td class="govuk-table__cell">{{ denial.address }}</td>
+                                <td class="govuk-table__cell">{{ denial.name|safe }}</td>
+                                <td class="govuk-table__cell">{{ denial.address|safe }}</td>
                                 <td class="govuk-table__cell">{{ denial.country }}</td>
                                 <td class="govuk-table__cell">{{ denial.item_list_codes }}</td>
                                 <td class="govuk-table__cell">{{ denial.item_description }}</td>


### PR DESCRIPTION
https://uktrade.atlassian.net/browse/LTD-4993 



Adds Party Denial Details on the screen together with ability to highlight. Highlight is depended on API change which has a PR but it won’t break without that change.