### PR TITLE
Ltd 4982 change entity type label to party type

### DIFF
--- a/caseworker/external_data/example.csv
+++ b/caseworker/external_data/example.csv
@@ -1,4 +1,4 @@
-reference,regime_reg_ref,notifying_government,item_list_codes,item_description,end_use,reason_for_refusal,name,address,country,spire_entity_id,party_type
+reference,regime_reg_ref,notifying_government,item_list_codes,item_description,end_use,reason_for_refusal,name,address,country,spire_entity_id,entity_type
 DN2000/0000,AB-CD-EF-000,Country Name,0A00100,Medium Size Widget,Used in industry,Risk of outcome,Organisation Name,"1000 Street Name, City Name",Country Name,123,consignee
 DN2000/1000,AB-CD-EF-100,Country Name 2,0A01100,Small Size Widget,Used in industry,Risk of outcome,Organisation Name 2,"2000 Street Name, City Name 2",Country Name 2,234,end_user
 DN2000/2000,AB-CD-EF-200,Country Name 3,0A02100,Unknown Size Widget,Used in industry,Risk of outcome,Organisation Name 3,"3000 Street Name, City Name 3",Country Name 3,345,third_party

--- a/caseworker/external_data/example.csv
+++ b/caseworker/external_data/example.csv
@@ -1,4 +1,4 @@
-reference,regime_reg_ref,notifying_government,item_list_codes,item_description,end_use,reason_for_refusal,name,address,country,spire_entity_id,entity_type
+reference,regime_reg_ref,notifying_government,item_list_codes,item_description,end_use,reason_for_refusal,name,address,country,spire_entity_id,party_type
 DN2000/0000,AB-CD-EF-000,Country Name,0A00100,Medium Size Widget,Used in industry,Risk of outcome,Organisation Name,"1000 Street Name, City Name",Country Name,123,consignee
 DN2000/1000,AB-CD-EF-100,Country Name 2,0A01100,Small Size Widget,Used in industry,Risk of outcome,Organisation Name 2,"2000 Street Name, City Name 2",Country Name 2,234,end_user
 DN2000/2000,AB-CD-EF-200,Country Name 3,0A02100,Unknown Size Widget,Used in industry,Risk of outcome,Organisation Name 3,"3000 Street Name, City Name 3",Country Name 3,345,third_party

--- a/caseworker/templates/case/denial-for-case.html
+++ b/caseworker/templates/case/denial-for-case.html
@@ -55,7 +55,7 @@
                                 <th scope="col" class="govuk-table__header">Item list codes</th>
                                 <th scope="col" class="govuk-table__header">Item description</th>
                                 <th scope="col" class="govuk-table__header">End use</th>
-                                <th scope="col" class="govuk-table__header">Entity type</th>
+                                <th scope="col" class="govuk-table__header">Party type</th>
                             {% endif %}
                         </tr>
                     </thead>

--- a/caseworker/templates/external_data/denial-detail.html
+++ b/caseworker/templates/external_data/denial-detail.html
@@ -40,7 +40,7 @@
                 <td class="govuk-table__cell">{{ denial.regime_reg_ref }}</td>
             </tr>
             <tr class="govuk-table__row app-table__row">
-                <th scope="row" class="govuk-table__header">Entity type</th>
+                <th scope="row" class="govuk-table__header">Party type</th>
                 <td class="govuk-table__cell">{{ denial.entity_type.value }}</td>
             </tr>
             <tr class="govuk-table__row app-table__row">

--- a/caseworker/templates/external_data/denial-detail.html
+++ b/caseworker/templates/external_data/denial-detail.html
@@ -40,7 +40,7 @@
                 <td class="govuk-table__cell">{{ denial.regime_reg_ref }}</td>
             </tr>
             <tr class="govuk-table__row app-table__row">
-                <th scope="row" class="govuk-table__header">Entity type</th>
+                <th scope="row" class="govuk-table__header">Party type</th>
                 <td class="govuk-table__cell">{{ denial.entity_type }}</td>
             </tr>
             <tr class="govuk-table__row app-table__row">

--- a/unit_tests/caseworker/cases/test_views.py
+++ b/unit_tests/caseworker/cases/test_views.py
@@ -289,7 +289,7 @@ def test_search_denials(authorized_client, data_standard_case, requests_mock, qu
         "Item list codes",
         "Item description",
         "End use",
-        "Entity type",
+        "Party type",
     ]
     header_values = [header.text for header in headers]
     assert header_values == header_order


### PR DESCRIPTION
### Aim

Change Entity Type to Party Type on denial matches page and denial details page, and in the CSV.  There is a corresponding API PR here: https://github.com/uktrade/lite-api/pull/1978

[LTD-4982](https://uktrade.atlassian.net/browse/LTD-4982)

[LTD-4982]: https://uktrade.atlassian.net/browse/LTD-4982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ