### PR TITLE
LTD-4984 clarify SIC usage for multiple SICs when registering a commercial org

### DIFF
--- a/exporter/core/organisation/forms.py
+++ b/exporter/core/organisation/forms.py
@@ -108,7 +108,7 @@ class RegisterDetailsBaseForm(BaseForm):
         label=SIC_CODE_LABEL,
         help_text=(
             "<a href='https://www.gov.uk/government/publications/standard-industrial-classification-of-economic-activities-sic'"
-            "class='govuk-link govuk-link--no-visited-state' target='_blank'>Find your SIC code.</a>"
+            "class='govuk-link govuk-link--no-visited-state' target='_blank'>Find your SIC code</a>.  If you have more than one, enter the SIC code you use most frequently."
         ),
         error_messages={
             "required": "Enter a SIC code",

--- a/exporter/core/organisation/forms.py
+++ b/exporter/core/organisation/forms.py
@@ -108,7 +108,8 @@ class RegisterDetailsBaseForm(BaseForm):
         label=SIC_CODE_LABEL,
         help_text=(
             "<a href='https://www.gov.uk/government/publications/standard-industrial-classification-of-economic-activities-sic'"
-            "class='govuk-link govuk-link--no-visited-state' target='_blank'>Find your SIC code</a>.  If you have more than one, enter the SIC code you use most frequently."
+            "class='govuk-link govuk-link--no-visited-state' target='_blank'>Find your SIC code</a>.  If you have more than "
+            "one, enter the SIC code you use most frequently."
         ),
         error_messages={
             "required": "Enter a SIC code",


### PR DESCRIPTION
### Aim

Change wording when registering a commerical org to make clear which SIC org should use

[LTD-4984](https://uktrade.atlassian.net/browse/LTD-4984)


[LTD-4984]: https://uktrade.atlassian.net/browse/LTD-4984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ