### PR TITLE
Add a longer grace period for bringing up containers in E2E tests

### DIFF
--- a/makefile
+++ b/makefile
@@ -8,8 +8,8 @@ else
 	docker-e2e-exporter = docker-compose -p lite -f docker-compose.base.yml -f docker-compose.api.yml -f docker-compose.exporter.yml
 endif
 
-wait-for-caseworker = dockerize -wait http://caseworker:8200/healthcheck -timeout 5m -wait-retry-interval 5s
-wait-for-exporter = dockerize -wait http://exporter:8300/healthcheck -timeout 5m -wait-retry-interval 5s
+wait-for-caseworker = dockerize -wait http://caseworker:8200/healthcheck -timeout 10m -wait-retry-interval 5s
+wait-for-exporter = dockerize -wait http://exporter:8300/healthcheck -timeout 10m -wait-retry-interval 5s
 
 ifdef CI
 	start-command = up --build --force-recreate -d


### PR DESCRIPTION
## Change description

When running E2E tests the current timeout to wait for containers to come up is 5 min.
We have couple of data migrations recently related to Denials and adding new ones related to Report summaries which are pushing it over 5min limit. These migrations are already optimised as possible but we may exceeding the timeout slightly so increase the timeout to allow for these changes.
