### PR TITLE
Removing case notes transition animation

### DIFF
--- a/caseworker/assets/styles/components/_case-note.scss
+++ b/caseworker/assets/styles/components/_case-note.scss
@@ -7,7 +7,6 @@
     &__textarea {
         margin-bottom: govuk-spacing(4);
         min-height: 140px;
-        transition: min-height .2s;
         width: 100%;
 
         .js-enabled & {


### PR DESCRIPTION
Removing case notes transition animation.

Animations often cause flakiness during tests and it's also better for accessibility to not have animations if not necessary.

