### PR TITLE
Allow company details test to specify unique company house number

### DIFF
--- a/tests_common/api_client/libraries/request_data.py
+++ b/tests_common/api_client/libraries/request_data.py
@@ -66,7 +66,9 @@ def build_organisation(name, type, address, eori_number, registration_number):
     }
 
 
-def build_organisation_with_primary_site(name, type, eori_number, uk_vat_number, primary_site, phone_number):
+def build_organisation_with_primary_site(
+    name, type, eori_number, uk_vat_number, primary_site, phone_number, registration_number
+):
     return {
         "name": name,
         "type": type,
@@ -74,7 +76,7 @@ def build_organisation_with_primary_site(name, type, eori_number, uk_vat_number,
         "sic_number": "12345",
         "vat_number": uk_vat_number,
         "phone_number": phone_number,
-        "registration_number": "12345678",
+        "registration_number": registration_number,
         "website": "http://www.example-org.com",
         "user": {"email": "name@example.com"},
         "site": {

--- a/ui_tests/caseworker/features/organisation.feature
+++ b/ui_tests/caseworker/features/organisation.feature
@@ -35,7 +35,7 @@ Feature: I want to add a company to LITE
   @check_company_details
   Scenario: Check company details
     Given I sign in to SSO or am signed into SSO
-    And an anonymous user creates and organisation for review with <eori_number>,<uk_vat_number>,<primary_site>,<phone_number>
+    And an anonymous user creates and organisation for review with <eori_number>,<uk_vat_number>,<primary_site>,<phone_number>,<registration_number>
     When I navigate to organisations
     And I click on In review tab
     Then I should see details of organisation previously created
@@ -49,5 +49,5 @@ Feature: I want to add a company to LITE
     Then I should see details of organisation previously created
 
     Examples:
-    |eori_number    | uk_vat_number | primary_site              | phone_number   |
-    |GB205672212000 | 123456789     | HQ London United Kingdom  | +441234567890  |
+    |eori_number    | uk_vat_number | primary_site             | phone_number  | registration_number |
+    |GB205672212000 | 123456789     | HQ London United Kingdom | +441234567890 | GB111111            |

--- a/ui_tests/caseworker/step_defs/test_organisation.py
+++ b/ui_tests/caseworker/step_defs/test_organisation.py
@@ -153,13 +153,25 @@ def in_review_organisation(context, api_test_client, get_eori_number, get_regist
 
 
 @given(
-    "an anonymous user creates and organisation for review with <eori_number>,<uk_vat_number>,<primary_site>,<phone_number>"
+    "an anonymous user creates and organisation for review with <eori_number>,<uk_vat_number>,<primary_site>,<phone_number>,<registration_number>"
 )
 def create_organisation_with_primary_site(
-    context, api_test_client, eori_number, uk_vat_number, primary_site, phone_number
+    context,
+    api_test_client,
+    eori_number,
+    uk_vat_number,
+    primary_site,
+    phone_number,
+    registration_number,
 ):
     data = build_organisation_with_primary_site(
-        f"Org-{get_current_date_time()}", "commercial", eori_number, uk_vat_number, primary_site, phone_number
+        f"Org-{get_current_date_time()}",
+        "commercial",
+        eori_number,
+        uk_vat_number,
+        primary_site,
+        phone_number,
+        registration_number,
     )
     response = api_test_client.organisations.anonymous_user_create_org(data)
     context.organisation_id = response["id"]


### PR DESCRIPTION
Allow company details test to specify unique company house number to allow the tests to fully pass.
