### PR TITLE
Fix flaky refusal E2E tests

### DIFF
--- a/ui_tests/caseworker/pages/advice.py
+++ b/ui_tests/caseworker/pages/advice.py
@@ -91,6 +91,11 @@ class RecommendationsAndDecisionPage(BasePage):
         self.driver.find_element(by=By.XPATH, value="//a[contains(text(), 'Make recommendation')]").click()
 
     def click_refuse(self):
+        # Scroll to the bottom of the page.
+        #   This hack is necessary to ensure that the radio button can
+        #   be interacted with properly.  It seems like the GDS styling
+        #   we use does some weird things that get in the way of selenium's clicks
+        self.driver.execute_script("window.scrollTo(0, document.body.scrollHeight);")
         self.driver.find_element(by=By.XPATH, value="//input[@type='radio' and @value='refuse']").click()
 
     def click_approve_all(self):


### PR DESCRIPTION
### Aim

Fix flaky test cases which manifest with errors about selecting refusal criteria.

>       And I click the recommendations and decision tab
>        And I click "Review and combine"
>        And I click refuse
>        And I click continue
>        And [FAILED] I select refusal criteria "1a, 1b, 1c, 1d, 1e, 1f"

It turns out that this is because selenium has sporadic issues with clicking the "refuse" radio button when it is "below the fold".  This is probably something to do with the way that our GDS styling positions the radio input/label.

This fix rectifies that issue by firstly scrolling to the bottom of the page in question before clicking the button, ensuring that the button is wholly visible within the browser view.