### PR TITLE
LTD-4978 change org signup region error text

### DIFF
--- a/exporter/core/organisation/forms.py
+++ b/exporter/core/organisation/forms.py
@@ -244,7 +244,7 @@ class RegisterAddressDetailsUKForm(RegisterAddressDetailsBaseForm):
     region = forms.CharField(
         label="County or state",
         error_messages={
-            "required": "Enter a county or state”",
+            "required": "Enter a county or state",
         },
     )
 


### PR DESCRIPTION
### Aim

Minor change to error text on organisation sign-up.

Branch incorrectly labeled at 4987

[LTD-4978](https://uktrade.atlassian.net/browse/LTD-4978)


[LTD-4978]: https://uktrade.atlassian.net/browse/LTD-4978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ