### PR TITLE
LTD-5005 and LTD-5006 remove spire_id and reference from CSV upload

### DIFF
--- a/caseworker/external_data/example.csv
+++ b/caseworker/external_data/example.csv
@@ -1,4 +1,4 @@
-reference,regime_reg_ref,notifying_government,item_list_codes,item_description,end_use,reason_for_refusal,name,address,country,spire_entity_id,entity_type
-DN2000/0000,AB-CD-EF-000,Country Name,0A00100,Medium Size Widget,Used in industry,Risk of outcome,Organisation Name,"1000 Street Name, City Name",Country Name,123,consignee
-DN2000/1000,AB-CD-EF-100,Country Name 2,0A01100,Small Size Widget,Used in industry,Risk of outcome,Organisation Name 2,"2000 Street Name, City Name 2",Country Name 2,234,end_user
-DN2000/2000,AB-CD-EF-200,Country Name 3,0A02100,Unknown Size Widget,Used in industry,Risk of outcome,Organisation Name 3,"3000 Street Name, City Name 3",Country Name 3,345,third_party
+reference,regime_reg_ref,notifying_government,item_list_codes,item_description,end_use,reason_for_refusal,name,address,country,entity_type
+DN2000/0000,AB-CD-EF-000,Country Name,0A00100,Medium Size Widget,Used in industry,Risk of outcome,Organisation Name,"1000 Street Name, City Name",Country Name,consignee
+,AB-CD-EF-100,Country Name 2,0A01100,Small Size Widget,Used in industry,Risk of outcome,Organisation Name 2,"2000 Street Name, City Name 2",Country Name 2,end_user
+DN2000/2000,AB-CD-EF-200,Country Name 3,0A02100,Unknown Size Widget,Used in industry,Risk of outcome,Organisation Name 3,"3000 Street Name, City Name 3",Country Name 3,third_party


### PR DESCRIPTION
### Aim

removed spire_entity_id from example csv

Corresponding API PR: https://github.com/uktrade/lite-api/pull/1987

[LTD-5005](https://uktrade.atlassian.net/browse/LTD-5005)
[LTD-5006](https://uktrade.atlassian.net/browse/LTD-5006)

[LTD-5005]: https://uktrade.atlassian.net/browse/LTD-5005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LTD-5006]: https://uktrade.atlassian.net/browse/LTD-5006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ