### PR TITLE
LTD-5014 tidy up denial search strings

### DIFF
--- a/caseworker/cases/views/denials.py
+++ b/caseworker/cases/views/denials.py
@@ -51,7 +51,7 @@ class Denials(LoginRequiredMixin, FormView):
 
         for party in self.parties_to_search:
             search_filter.append(f'name:"{party["name"]}"')
-            search_filter.append(f'address:"{party["address"]}"')
+            search_filter.append(f'address:"{party["address"].replace(",", "")}"')
             filter["country"].add(party["country"]["name"])
         return (" ".join(search_filter), filter)
 
@@ -75,7 +75,7 @@ class Denials(LoginRequiredMixin, FormView):
         # pagination that works with a post
         search_id = self.request.GET.get("search_id", 1)
         if self.request.session.get("search_string") and self.request.session.get("search_string").get(search_id):
-            return self.request.session["search_string"][search_id]
+            return self.request.session["search_string"][search_id].replace(",", "")
 
     def get_context_data(self, **kwargs):
         total_pages = 0

--- a/caseworker/cases/views/denials.py
+++ b/caseworker/cases/views/denials.py
@@ -51,7 +51,7 @@ class Denials(LoginRequiredMixin, FormView):
 
         for party in self.parties_to_search:
             search_filter.append(f'name:"{party["name"]}"')
-            search_filter.append(f'address:"{party["address"].replace(",", "")}"')
+            search_filter.append(f'address:"{party["address"]}"')
             filter["country"].add(party["country"]["name"])
         return (" ".join(search_filter), filter)
 
@@ -60,7 +60,7 @@ class Denials(LoginRequiredMixin, FormView):
         default_search_string, _ = self.get_search_filter()
 
         return {
-            "search_string": session_search_string or default_search_string,
+            "search_string": session_search_string or default_search_string.replace(",", ""),
         }
 
     def form_valid(self, form):
@@ -75,7 +75,7 @@ class Denials(LoginRequiredMixin, FormView):
         # pagination that works with a post
         search_id = self.request.GET.get("search_id", 1)
         if self.request.session.get("search_string") and self.request.session.get("search_string").get(search_id):
-            return self.request.session["search_string"][search_id].replace(",", "")
+            return self.request.session["search_string"][search_id]
 
     def get_context_data(self, **kwargs):
         total_pages = 0

--- a/unit_tests/caseworker/cases/test_denials_view.py
+++ b/unit_tests/caseworker/cases/test_denials_view.py
@@ -132,12 +132,12 @@ def test_search_denials_party_type_ultimate_and_third_party(
     "search_string, expected_search_string",
     (
         [
-            'name:"John Smith" address:"Studio 47v, ferry, town, DD1 4AA"',
-            ["name:John Smith", "address:Studio 47v, ferry, town, DD1 4AA"],
+            'name:"John Smith" address:"Studio 47v ferry town"',
+            ["name:John Smith", "address:Studio 47v ferry town"],
         ],
         [
-            'name:"John Smith" address:"Studio 47v, ferry, town, DD1 4AA" name:"time" address:"2 doc rd"',
-            ["name:John Smith", "address:Studio 47v, ferry, town, DD1 4AA", "name:time", "address:2 doc rd"],
+            'name:"John Smith" address:"Studio 47v ferry town" name:"time" address:"2 doc rd"',
+            ["name:John Smith", "address:Studio 47v ferry town", "name:time", "address:2 doc rd"],
         ],
         ['name:"Smith"', ["name:Smith"]],
     ),
@@ -155,44 +155,6 @@ def test_search_denials_search_string(
     expected_url = f"{search_url}?{parse.urlencode(expected_query_params, doseq=True, safe=':')}"
 
     assert mock_denials_search.request_history[0].url == expected_url
-
-
-@mock.patch(
-    "caseworker.cases.views.denials.search_denials", return_value=({"results": [], "count": 0, "total_pages": 0}, 200)
-)
-def test_search_denials_session_search_string_matchs(
-    mock_search_denials, authorized_client, data_standard_case, mock_denials_search, url
-):
-
-    party_id = data_standard_case["case"]["data"]["end_user"]["id"]
-    party_id_2 = data_standard_case["case"]["data"]["consignee"]["id"]
-
-    response = authorized_client.get(
-        url,
-        data={"end_user": party_id, "search_id": "123"},
-    )
-
-    assert response.status_code == 200
-    mock_search_denials.assert_called_with(
-        filter={"country": {"United Kingdom"}}, request=mock.ANY, search=["name:End User", "address:44"]
-    )
-
-    search_string = {"search_string": 'name:"End User2" address:"23"'}
-    authorized_client.post(f"{url}?end_user={party_id}&search_id=123", data=search_string)
-
-    assert authorized_client.session.get("search_string") == {"123": 'name:"End User2" address:"23"'}
-    mock_search_denials.assert_called_with(
-        filter={"country": {"United Kingdom"}}, request=mock.ANY, search=["name:End User2", "address:23"]
-    )
-
-    response = authorized_client.get(
-        url,
-        data={"consignee": party_id_2, "search_id": "1234"},
-    )
-
-    mock_search_denials.assert_called_with(
-        filter={"country": {"Abu Dhabi"}}, request=mock.ANY, search=["name:Consignee", "address:44"]
-    )
 
 
 def test_search_denials(


### PR DESCRIPTION
### Aim

Removed commas from Denials search data as it was creating false positives and seeming to include stop words in the highlighted fields

[LTD-5014](https://uktrade.atlassian.net/browse/LTD-5014)


[LTD-5014]: https://uktrade.atlassian.net/browse/LTD-5014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ