### PR TITLE
LTD: Provide option to create a copy of application when performing major edits

### DIFF
--- a/exporter/applications/forms/amendments.py
+++ b/exporter/applications/forms/amendments.py
@@ -1,0 +1,31 @@
+from crispy_forms_gds.helper import FormHelper
+from crispy_forms_gds.layout import Layout, Submit
+
+from django import forms
+
+from core.forms.utils import coerce_str_to_bool
+
+
+class ApplicationCopyConfirmationForm(forms.Form):
+    DOCUMENT_TITLE = "Review and countersign this case"
+    CONFIRMATION_CHOICES = [(True, "Yes"), (False, "No")]
+    help_text = """Selecting Yes creates an exact copy of the current application which can be used
+    to make amendments. You can still view current application but cannot modify it.
+    The new application will need to be submitted again after all amendments."""
+
+    confirm_copy = forms.TypedChoiceField(
+        choices=CONFIRMATION_CHOICES,
+        widget=forms.RadioSelect,
+        coerce=coerce_str_to_bool,
+        help_text=help_text,
+        label="Confirm to create a copy of this application for amending it",
+        error_messages={"required": "Confirmation required to copy application or not"},
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper = FormHelper()
+        self.helper.layout = Layout(
+            "confirm_copy",
+            Submit("submit", "Submit"),
+        )

--- a/exporter/applications/services.py
+++ b/exporter/applications/services.py
@@ -518,6 +518,12 @@ def copy_application(request, pk, data):
     return data.json(), data.status_code
 
 
+def create_application_copy(request, pk, data):
+    response = client.post(request, f"/amendments/create-application-copy/{pk}/", data)
+    response.raise_for_status()
+    return response.json(), response.status_code
+
+
 def post_exhibition(request, pk, data):
     post_data = format_date_fields(data)
     data = client.post(request, f"/applications/{pk}/exhibition-details/", data=post_data)

--- a/exporter/applications/urls.py
+++ b/exporter/applications/urls.py
@@ -64,6 +64,7 @@ urlpatterns = [
     path("<uuid:pk>/submit-success/", common.ApplicationSubmitSuccessPage.as_view(), name="success_page"),
     path("<uuid:pk>/hcsat/<uuid:sid>/", HCSATApplicationPage.as_view(), name="application-hcsat"),
     path("<uuid:pk>/edit-type/", common.ApplicationEditType.as_view(), name="edit_type"),
+    path("<uuid:pk>/confirm-copy/", common.ApplicationCopyConfirmationView.as_view(), name="confirm_copy"),
     path("<uuid:pk>/check-your-answers/", common.CheckYourAnswers.as_view(), name="check_your_answers"),
     path("<uuid:pk>/submit/", common.Submit.as_view(), name="submit"),
     path("<uuid:pk>/copy/", common.ApplicationCopy.as_view(), name="copy"),

--- a/exporter/templates/applications/create-copy-confirmation.html
+++ b/exporter/templates/applications/create-copy-confirmation.html
@@ -1,0 +1,26 @@
+{% extends 'layouts/base.html' %}
+
+{% load crispy_forms_tags crispy_forms_gds %}
+
+{% block title %}Create application copy{% endblock %}
+
+{% block back_link %}
+	<a href="{{ back_link_url }}" id="back-link" class="govuk-back-link">{{ back_link_text|default:"Back" }}</a>
+{% endblock %}
+
+{% block two_thirds %}
+	{% if errors %}
+		{% include "forms-errors.html" %}
+	{% endif %}
+
+	<form action="{{ form_action_url }}" method="post" enctype="multipart/form-data">
+		{% csrf_token %}
+
+		{% error_summary form %}
+
+		<div class="govuk-body">
+			{% crispy form %}
+		</div>
+
+	</form>
+{% endblock %}


### PR DESCRIPTION
## Change description

With major edits application need to be resubmitted. This can interfere with the existing state of the application so it is better to create a copy of existing application and then make required amendments. Also resubmitting starts the processing from the beginning and can take more time.

If user decided to make major changes then provide an option to confirm creating a copy of application.