### PR TITLE
Allow ODT file uploads in exporter

### DIFF
--- a/conf/base.py
+++ b/conf/base.py
@@ -166,10 +166,11 @@ FILE_UPLOAD_HANDLERS = env.list("FILE_UPLOAD_HANDLERS", default=["core.file_hand
 ACCEPTED_FILE_UPLOAD_MIME_TYPES = env.list(
     "ACCEPTED_FILE_UPLOAD_MIME_TYPES",
     default=(
-        # Default file-types supported by LITE are pdf, doc, docx,
-        # rtf, jpeg, png and tiff
+        # Default file types supported by LITE are
+        # DOCX, DOC, PDF, PNG, JPEG, ODT
         "application/pdf",
         "application/msword",
+        "application/vnd.oasis.opendocument.text",
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         "application/rtf",
         "application/xml",

--- a/exporter/applications/forms/parties.py
+++ b/exporter/applications/forms/parties.py
@@ -351,7 +351,7 @@ class PartyDocumentsForm(forms.Form):
 class PartyDocumentUploadForm(forms.Form):
     title = "Upload an end-user document"
     party_document = forms.FileField(
-        label="Upload a DOCX, DOC, PDF or PNG file.",
+        label="Upload a DOCX, DOC, PDF, PNG, JPEG or ODT file.",
         error_messages={
             "required": "Select an end-user document",
         },
@@ -407,7 +407,7 @@ class PartyDocumentUploadForm(forms.Form):
 class PartyEnglishTranslationDocumentUploadForm(forms.Form):
     title = "Upload an English translation"
     party_eng_translation_document = forms.FileField(
-        label="Upload a DOCX, DOC, PDF or PNG file.",
+        label="Upload a DOCX, DOC, PDF, PNG, JPEG or ODT file.",
         error_messages={
             "required": "Select an English translation",
         },
@@ -432,7 +432,7 @@ class PartyEnglishTranslationDocumentUploadForm(forms.Form):
 class PartyCompanyLetterheadDocumentUploadForm(forms.Form):
     title = "Upload a document on company letterhead"
     party_letterhead_document = forms.FileField(
-        label="Upload a DOCX, DOC, PDF or PNG file.",
+        label="Upload a DOCX, DOC, PDF, PNG, JPEG or ODT file.",
         error_messages={
             "required": "Select a document on company letterhead",
         },

--- a/exporter/applications/forms/parties.py
+++ b/exporter/applications/forms/parties.py
@@ -8,7 +8,7 @@ from django.urls import reverse_lazy
 from core.common.forms import BaseForm
 from core.forms.layouts import ConditionalRadios, ConditionalRadiosQuestion
 from core.forms.widgets import Autocomplete
-from exporter.core.constants import CaseTypes
+from exporter.core.constants import CaseTypes, FileUploadFileTypes
 from exporter.core.services import get_countries
 from lite_content.lite_exporter_frontend import strings
 from lite_content.lite_exporter_frontend.applications import PartyForm, PartyTypeForm
@@ -351,7 +351,7 @@ class PartyDocumentsForm(forms.Form):
 class PartyDocumentUploadForm(forms.Form):
     title = "Upload an end-user document"
     party_document = forms.FileField(
-        label="Upload a DOCX, DOC, PDF, PNG, JPEG or ODT file.",
+        label=FileUploadFileTypes.UPLOAD_GUIDANCE_TEXT,
         error_messages={
             "required": "Select an end-user document",
         },
@@ -407,7 +407,7 @@ class PartyDocumentUploadForm(forms.Form):
 class PartyEnglishTranslationDocumentUploadForm(forms.Form):
     title = "Upload an English translation"
     party_eng_translation_document = forms.FileField(
-        label="Upload a DOCX, DOC, PDF, PNG, JPEG or ODT file.",
+        label=FileUploadFileTypes.UPLOAD_GUIDANCE_TEXT,
         error_messages={
             "required": "Select an English translation",
         },
@@ -432,7 +432,7 @@ class PartyEnglishTranslationDocumentUploadForm(forms.Form):
 class PartyCompanyLetterheadDocumentUploadForm(forms.Form):
     title = "Upload a document on company letterhead"
     party_letterhead_document = forms.FileField(
-        label="Upload a DOCX, DOC, PDF, PNG, JPEG or ODT file.",
+        label=FileUploadFileTypes.UPLOAD_GUIDANCE_TEXT,
         error_messages={
             "required": "Select a document on company letterhead",
         },

--- a/exporter/core/constants.py
+++ b/exporter/core/constants.py
@@ -241,3 +241,7 @@ class OrganisationStatus:
     DRAFT = "draft"
     REVIEW = "in_review"
     ACTIVE = "active"
+
+
+class FileUploadFileTypes:
+    UPLOAD_GUIDANCE_TEXT = "Upload a DOCX, DOC, PDF, PNG, JPEG or ODT file."

--- a/exporter/goods/forms/common.py
+++ b/exporter/goods/forms/common.py
@@ -24,7 +24,7 @@ from exporter.core.services import (
     get_units,
 )
 from exporter.core.validators import PastDateValidator
-from exporter.core.constants import ProductSecurityFeatures
+from exporter.core.constants import ProductSecurityFeatures, FileUploadFileTypes
 
 
 class ProductNameForm(BaseForm):
@@ -358,7 +358,7 @@ class ProductDocumentUploadForm(BaseForm):
         TITLE = "Upload a document that shows what your product is designed to do"
 
     product_document = forms.FileField(
-        label="Upload a DOCX, DOC, PDF, PNG, JPEG or ODT file.",
+        label=FileUploadFileTypes.UPLOAD_GUIDANCE_TEXT,
         error_messages={
             "required": "Select a document that shows what your product is designed to do",
         },

--- a/exporter/goods/forms/common.py
+++ b/exporter/goods/forms/common.py
@@ -358,7 +358,7 @@ class ProductDocumentUploadForm(BaseForm):
         TITLE = "Upload a document that shows what your product is designed to do"
 
     product_document = forms.FileField(
-        label="Upload a DOCX, DOC, PDF or PNG file.",
+        label="Upload a DOCX, DOC, PDF, PNG, JPEG or ODT file.",
         error_messages={
             "required": "Select a document that shows what your product is designed to do",
         },

--- a/exporter/goods/forms/firearms.py
+++ b/exporter/goods/forms/firearms.py
@@ -27,6 +27,7 @@ from exporter.core.validators import (
     RelativeDeltaDateValidator,
 )
 from exporter.goods.forms.goods import SerialNumbersField
+from exporter.core.constants import FileUploadFileTypes
 
 
 class FirearmCategoryForm(BaseForm):
@@ -217,7 +218,7 @@ class FirearmAttachRFDCertificate(BaseForm):
         TITLE = "Upload a registered firearms dealer certificate"
 
     file = forms.FileField(
-        label="Upload a DOCX, DOC, PDF, PNG, JPEG or ODT file.",
+        label=FileUploadFileTypes.UPLOAD_GUIDANCE_TEXT,
         error_messages={
             "required": "Select a registered firearms dealer certificate",
         },

--- a/exporter/goods/forms/firearms.py
+++ b/exporter/goods/forms/firearms.py
@@ -217,7 +217,7 @@ class FirearmAttachRFDCertificate(BaseForm):
         TITLE = "Upload a registered firearms dealer certificate"
 
     file = forms.FileField(
-        label="Upload a DOCX, DOC, PDF or PNG file.",
+        label="Upload a DOCX, DOC, PDF, PNG, JPEG or ODT file.",
         error_messages={
             "required": "Select a registered firearms dealer certificate",
         },

--- a/exporter/goods/forms/goods.py
+++ b/exporter/goods/forms/goods.py
@@ -261,7 +261,7 @@ def format_list_item(link, name, description):
 def upload_firearms_act_certificate_form(section, filename, back_link):
     return Form(
         title=f"Attach your Firearms Act 1968 {section} certificate",
-        description="Upload a DOCX, DOC, PDF or PNG file.\n\nThe file must be smaller than 50MB.",
+        description="Upload a DOCX, DOC, PDF, PNG, JPEG or ODT file.\n\nThe file must be smaller than 50MB.",
         questions=[
             HiddenField("firearms_certificate_uploaded", False),
             FileUpload(),
@@ -1095,7 +1095,7 @@ class AttachFirearmsDealerCertificateForm(forms.Form):
     title = "Attach your registered firearms dealer certificate"
 
     file = forms.FileField(
-        label="Upload a DOCX, DOC, PDF or PNG file.",
+        label="Upload a DOCX, DOC, PDF, PNG, JPEG or ODT file.",
         help_text="The file must be smaller than 50MB",
         error_messages={
             "required": "Select certificate file to upload",

--- a/exporter/goods/forms/goods.py
+++ b/exporter/goods/forms/goods.py
@@ -18,6 +18,7 @@ from exporter.core.constants import (
     ProductSecurityFeatures,
     ProductDeclaredAtCustoms,
     FIREARM_AMMUNITION_COMPONENT_TYPES,
+    FileUploadFileTypes,
 )
 from exporter.core.helpers import (
     convert_control_list_entries,
@@ -261,7 +262,7 @@ def format_list_item(link, name, description):
 def upload_firearms_act_certificate_form(section, filename, back_link):
     return Form(
         title=f"Attach your Firearms Act 1968 {section} certificate",
-        description="Upload a DOCX, DOC, PDF, PNG, JPEG or ODT file.\n\nThe file must be smaller than 50MB.",
+        description=FileUploadFileTypes.UPLOAD_GUIDANCE_TEXT + "\n\nThe file must be smaller than 50MB.",
         questions=[
             HiddenField("firearms_certificate_uploaded", False),
             FileUpload(),
@@ -1095,7 +1096,7 @@ class AttachFirearmsDealerCertificateForm(forms.Form):
     title = "Attach your registered firearms dealer certificate"
 
     file = forms.FileField(
-        label="Upload a DOCX, DOC, PDF, PNG, JPEG or ODT file.",
+        label=FileUploadFileTypes.UPLOAD_GUIDANCE_TEXT,
         help_text="The file must be smaller than 50MB",
         error_messages={
             "required": "Select certificate file to upload",

--- a/exporter/organisation/forms.py
+++ b/exporter/organisation/forms.py
@@ -8,6 +8,8 @@ from crispy_forms_gds.fields import DateInputField
 from crispy_forms_gds.helper import FormHelper
 from crispy_forms_gds.layout import Submit, Layout, HTML
 
+from exporter.core.constants import FileUploadFileTypes
+
 
 def validate_expiry_date(value):
     today = timezone.now().date()
@@ -58,7 +60,7 @@ class UploadFirearmsCertificateForm(forms.Form):
         TITLE = "Attach your registered firearms dealer certificate"
 
     file = forms.FileField(
-        label="Upload a DOCX, DOC, PDF, PNG, JPEG or ODT file.",
+        label=FileUploadFileTypes.UPLOAD_GUIDANCE_TEXT,
         help_text="The file must be smaller than 50MB",
         error_messages={"required": "Select certificate file to upload"},
     )

--- a/exporter/organisation/forms.py
+++ b/exporter/organisation/forms.py
@@ -58,7 +58,7 @@ class UploadFirearmsCertificateForm(forms.Form):
         TITLE = "Attach your registered firearms dealer certificate"
 
     file = forms.FileField(
-        label="Upload a DOCX, DOC, PDF or PNG file.",
+        label="Upload a DOCX, DOC, PDF, PNG, JPEG or ODT file.",
         help_text="The file must be smaller than 50MB",
         error_messages={"required": "Select certificate file to upload"},
     )

--- a/lite_content/lite_exporter_frontend/goods.py
+++ b/lite_content/lite_exporter_frontend/goods.py
@@ -334,7 +334,7 @@ class EditGoodForm:
 class AttachDocumentForm:
     TITLE = "Attach a document"
     DESCRIPTION = (
-        "Upload a DOCX, DOC, PDF or PNG file."
+        "Upload a DOCX, DOC, PDF, PNG, JPEG or ODT file."
         "\n\nDocumentation could be specifications, datasheets, sales brochures, drawings "
         "or anything else that fully details what the product is and what it's designed to do."
         "\n\nDo not attach a document that’s above OFFICIAL-SENSITIVE. "

--- a/lite_content/lite_exporter_frontend/goods.py
+++ b/lite_content/lite_exporter_frontend/goods.py
@@ -1,6 +1,8 @@
 from lite_content.lite_exporter_frontend import generic
 from lite_content.lite_exporter_frontend.generic import PERMISSION_FINDER_LINK
 
+from exporter.core.constants import FileUploadFileTypes
+
 
 class GoodsList:
     TITLE = "Product list"
@@ -334,8 +336,8 @@ class EditGoodForm:
 class AttachDocumentForm:
     TITLE = "Attach a document"
     DESCRIPTION = (
-        "Upload a DOCX, DOC, PDF, PNG, JPEG or ODT file."
-        "\n\nDocumentation could be specifications, datasheets, sales brochures, drawings "
+        FileUploadFileTypes.UPLOAD_GUIDANCE_TEXT
+        + "\n\nDocumentation could be specifications, datasheets, sales brochures, drawings "
         "or anything else that fully details what the product is and what it's designed to do."
         "\n\nDo not attach a document that’s above OFFICIAL-SENSITIVE. "
         "\n\nThe file must be smaller than 50MB."

--- a/lite_content/lite_exporter_frontend/strings.py
+++ b/lite_content/lite_exporter_frontend/strings.py
@@ -15,6 +15,7 @@ from lite_content.lite_exporter_frontend import (  # noqa
     licences,  # noqa
     ecju_queries,  # noqa
 )  # noqa
+from exporter.core.constants import FileUploadFileTypes
 
 # Generic (used as defaults in forms)
 BACK_TO_APPLICATION = "Back to application"
@@ -160,8 +161,8 @@ class UltimateEndUser:
         class AttachDocuments:
             TITLE = "Attach a document (optional)"
             DESCRIPTION = (
-                "Upload a DOCX, DOC, PDF, PNG, JPEG or ODT file."
-                "\n\nDo not attach a document that's above OFFICIAL-SENSITIVE."
+                FileUploadFileTypes.UPLOAD_GUIDANCE_TEXT
+                + "\n\nDo not attach a document that's above OFFICIAL-SENSITIVE."
                 "\n\nThe file must be smaller than 50MB."
             )
             DESCRIPTION_FIELD_TITLE = "Description"
@@ -189,8 +190,8 @@ class Consignee:
         class AttachDocuments:
             TITLE = "Attach a document (optional)"
             DESCRIPTION = (
-                "Upload a DOCX, DOC, PDF, PNG, JPEG or ODT file."
-                "\n\nDo not attach a document that's above OFFICIAL-SENSITIVE."
+                FileUploadFileTypes.UPLOAD_GUIDANCE_TEXT
+                + "\n\nDo not attach a document that's above OFFICIAL-SENSITIVE."
                 "\n\nThe file must be smaller than 50MB."
             )
             DESCRIPTION_FIELD_TITLE = "Description"
@@ -221,8 +222,8 @@ class ThirdParties:
         class AttachDocuments:
             TITLE = "Attach a document (optional)"
             DESCRIPTION = (
-                "Upload a DOCX, DOC, PDF, PNG, JPEG or ODT file."
-                "\n\nDo not attach a document that's above OFFICIAL-SENSITIVE."
+                FileUploadFileTypes.UPLOAD_GUIDANCE_TEXT
+                + "\n\nDo not attach a document that's above OFFICIAL-SENSITIVE."
                 "\n\nThe file must be smaller than 50MB."
             )
             DESCRIPTION_FIELD_TITLE = "Description"
@@ -372,8 +373,8 @@ class AdditionalDocuments:
         class AttachDocuments:
             TITLE = "Attach a supporting document"
             DESCRIPTION = (
-                "Upload a DOCX, DOC, PDF, PNG, JPEG or ODT file."
-                "\n\nDo not attach a document that's above OFFICIAL-SENSITIVE."
+                FileUploadFileTypes.UPLOAD_GUIDANCE_TEXT
+                + "\n\nDo not attach a document that's above OFFICIAL-SENSITIVE."
                 "\n\nThe file must be smaller than 50MB."
             )
             DESCRIPTION_FIELD_TITLE = "Description"

--- a/lite_content/lite_exporter_frontend/strings.py
+++ b/lite_content/lite_exporter_frontend/strings.py
@@ -160,7 +160,7 @@ class UltimateEndUser:
         class AttachDocuments:
             TITLE = "Attach a document (optional)"
             DESCRIPTION = (
-                "Upload a DOCX, DOC, PDF or PNG file."
+                "Upload a DOCX, DOC, PDF, PNG, JPEG or ODT file."
                 "\n\nDo not attach a document that's above OFFICIAL-SENSITIVE."
                 "\n\nThe file must be smaller than 50MB."
             )
@@ -189,7 +189,7 @@ class Consignee:
         class AttachDocuments:
             TITLE = "Attach a document (optional)"
             DESCRIPTION = (
-                "Upload a DOCX, DOC, PDF or PNG file."
+                "Upload a DOCX, DOC, PDF, PNG, JPEG or ODT file."
                 "\n\nDo not attach a document that's above OFFICIAL-SENSITIVE."
                 "\n\nThe file must be smaller than 50MB."
             )
@@ -221,7 +221,7 @@ class ThirdParties:
         class AttachDocuments:
             TITLE = "Attach a document (optional)"
             DESCRIPTION = (
-                "Upload a DOCX, DOC, PDF or PNG file."
+                "Upload a DOCX, DOC, PDF, PNG, JPEG or ODT file."
                 "\n\nDo not attach a document that's above OFFICIAL-SENSITIVE."
                 "\n\nThe file must be smaller than 50MB."
             )
@@ -372,7 +372,7 @@ class AdditionalDocuments:
         class AttachDocuments:
             TITLE = "Attach a supporting document"
             DESCRIPTION = (
-                "Upload a DOCX, DOC, PDF or PNG file."
+                "Upload a DOCX, DOC, PDF, PNG, JPEG or ODT file."
                 "\n\nDo not attach a document that's above OFFICIAL-SENSITIVE."
                 "\n\nThe file must be smaller than 50MB."
             )

--- a/lite_forms/tests.py
+++ b/lite_forms/tests.py
@@ -302,6 +302,7 @@ class FileUploadTest(TestCase):
         assert accept == [
             "application/pdf",
             "application/msword",
+            "application/vnd.oasis.opendocument.text",
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
             "application/rtf",
             "application/xml",

--- a/unit_tests/exporter/applications/views/test_add_good.py
+++ b/unit_tests/exporter/applications/views/test_add_good.py
@@ -331,7 +331,7 @@ def test_add_good_attach_firearm_dealer_certificate(url, authorized_client):
     )
 
     title = b"Attach your registered firearms dealer certificate"
-    label = b"Upload a DOCX, DOC, PDF or PNG file."
+    label = b"Upload a DOCX, DOC, PDF, PNG, JPEG or ODT file."
     response = authorized_client.post(
         url, data={"wizard_goto_step": AddGoodFormSteps.ATTACH_FIREARM_DEALER_CERTIFICATE}
     )

--- a/unit_tests/exporter/applications/views/test_add_good.py
+++ b/unit_tests/exporter/applications/views/test_add_good.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 
 from core import client
 
-from exporter.core.constants import AddGoodFormSteps
+from exporter.core.constants import AddGoodFormSteps, FileUploadFileTypes
 from exporter.goods.forms import (
     AddGoodsQuestionsForm,
     AttachFirearmsDealerCertificateForm,
@@ -26,7 +26,6 @@ from exporter.goods.forms import (
     SoftwareTechnologyDetailsForm,
 )
 from lite_content.lite_exporter_frontend.goods import CreateGoodForm, GoodGradingForm
-
 
 ADD_GOOD_VIEW = "add_good"
 
@@ -331,7 +330,7 @@ def test_add_good_attach_firearm_dealer_certificate(url, authorized_client):
     )
 
     title = b"Attach your registered firearms dealer certificate"
-    label = b"Upload a DOCX, DOC, PDF, PNG, JPEG or ODT file."
+    label = FileUploadFileTypes.UPLOAD_GUIDANCE_TEXT.encode("utf-8")
     response = authorized_client.post(
         url, data={"wizard_goto_step": AddGoodFormSteps.ATTACH_FIREARM_DEALER_CERTIFICATE}
     )


### PR DESCRIPTION
### Aim

This updates the list of acceptable mime types in lite-frontend which is what is used to determine if an uploaded file is acceptable or not. This has been tested locally by uploading an odt document, and on the demo environment where I was able to upload an odt document as an exporter and then submit this application and see that the document can be downloaded from the caseworker side.

[LTD-4928](https://uktrade.atlassian.net/browse/LTD-4928)


[LTD-4928]: https://uktrade.atlassian.net/browse/LTD-4928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ