### PR TITLE
Update website field validation

### DIFF
--- a/exporter/core/organisation/validators.py
+++ b/exporter/core/organisation/validators.py
@@ -43,7 +43,10 @@ def validate_website(value):
             validator = URLValidator()
             validator(value)
         except ValidationError:
-            raise ValidationError("Enter a valid URL")
+            try:
+                validator("https://" + value)
+            except ValidationError:
+                raise ValidationError("Enter a valid URL")
     return value
 
 

--- a/unit_tests/exporter/core/organisation/test_validators.py
+++ b/unit_tests/exporter/core/organisation/test_validators.py
@@ -2,7 +2,7 @@ import pytest
 
 from django.core.exceptions import ValidationError
 
-from exporter.core.organisation.validators import validate_phone, validate_registration
+from exporter.core.organisation.validators import validate_phone, validate_registration, validate_website
 
 
 @pytest.mark.parametrize(
@@ -53,3 +53,14 @@ def test_validate_registration_number_valid_numbers(registration_number):
 def test_validate_registration_number_invalid_numbers(registration_number):
     with pytest.raises(ValidationError):
         validate_registration(registration_number)
+
+
+@pytest.mark.parametrize(("website"), ["https://www.example.com", "www.example.com", "example.com"])
+def test_validate_website(website):
+    assert validate_website(website) is website
+
+
+@pytest.mark.parametrize(("website"), ["example", "com", ".com"])
+def test_validate_website_invalid_url(website):
+    with pytest.raises(ValidationError):
+        validate_website(website)

--- a/unit_tests/exporter/core/organisation/test_validators.py
+++ b/unit_tests/exporter/core/organisation/test_validators.py
@@ -55,7 +55,7 @@ def test_validate_registration_number_invalid_numbers(registration_number):
         validate_registration(registration_number)
 
 
-@pytest.mark.parametrize(("website"), ["https://www.example.com", "www.example.com", "example.com"])
+@pytest.mark.parametrize(("website"), ["https://www.example.com", "www.example.com", "example.com", ""])
 def test_validate_website(website):
     assert validate_website(website) is website
 


### PR DESCRIPTION
### Aim

This updates the website validation for exporter organisation registration to allow website URLs that don't have a URL scheme prefix e.g. "https://". This is because user research has shown that exporters will often type a website address that looks like "www.example.com" and this would cause the Django URL validator to throw a ValidationError as it is expecting something like "https://www.example.com" which is a full URL including the scheme prefix. 

Rather than change the form data that is entered, the value stored in LITE is kept the same, but the validator function has an extra step to check if the entered website string is a valid URL with the "https://" prefix added. If so, then the value is considered valid and no error is raised.

[LTD-2285](https://uktrade.atlassian.net/browse/LTD-2285)


[LTD-2285]: https://uktrade.atlassian.net/browse/LTD-2285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ