### PR TITLE
Remove link from exporter dashboard

### DIFF
--- a/exporter/templates/core/hub.html
+++ b/exporter/templates/core/hub.html
@@ -65,10 +65,6 @@
 		{% endif %}
 	</div>
 
-	<div class="govuk-hint govuk-!-font-size-19 govuk-!-margin-bottom-6">
-		<a href="{% url 'core:signature_help' %}" class="govuk-link govuk-link--no-visited-state">{% lcs 'hub.SIGNATURE_GUIDANCE' %}</a>
-	</div>
-
 	{% if organisation.type.key != 'hmrc' %}
 		<div class="app-tiles">
 			{# Apply tile #}

--- a/lite_content/lite_exporter_frontend/hub.py
+++ b/lite_content/lite_exporter_frontend/hub.py
@@ -2,7 +2,6 @@ TITLE = "Exporter hub"
 ACCOUNT = "Export control account"
 ACCOUNT_HOME = "Account home"
 SWITCH_ORG = "Switch organisation <!--from -->"
-SIGNATURE_GUIDANCE = "Guidance on LITE document digital signatures"
 
 
 class Navigation:


### PR DESCRIPTION
### Aim

Removes the old link for guidance on LITE document digital signatures that showed at the top of the exporter hub page. This is being replaced by the new link in the "Help and support" tile: https://github.com/uktrade/lite-frontend/blob/dev/exporter/templates/core/hub.html#L169 

[LTD-5018](https://uktrade.atlassian.net/browse/LTD-5018)


[LTD-5018]: https://uktrade.atlassian.net/browse/LTD-5018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ