### PR TITLE
Amend control list entry question

### DIFF
--- a/exporter/core/templates/goods/forms/common/help_with_control_list_entries.html
+++ b/exporter/core/templates/goods/forms/common/help_with_control_list_entries.html
@@ -1,7 +1,2 @@
-<p class="govuk-body">
-    Control lists determine whether a product is controlled and requires a licence to export.
-</p>
-
-<a class="govuk-link" href="https://www.gov.uk/guidance/uk-strategic-export-control-lists-the-consolidated-list-of-strategic-military-and-dual-use-items" target="_blank">
-    Guidance - control lists (opens in new tab)
-</a>
+<p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/government/publications/uk-strategic-export-control-lists-the-consolidated-list-of-strategic-military-and-dual-use-items-that-require-export-authorisation" target="_blank">Control lists</a> (opens in new tab) determine whether a product is controlled and requires a licence to export.</p>
+<p class="govuk-body">If the product is not subject to any controls, you'll be issued with a 'no licence required' document.</p>

--- a/exporter/goods/forms/common.py
+++ b/exporter/goods/forms/common.py
@@ -82,6 +82,9 @@ class ProductControlListEntryForm(BaseForm):
 
     def get_layout_fields(self):
         return (
+            HTML.p(
+                '<div class="govuk-hint">We will assess it and assign a control list entry if it is subject to controls.</div>'
+            ),
             ConditionalRadios(
                 "is_good_controlled",
                 ConditionalRadiosQuestion(
@@ -95,9 +98,7 @@ class ProductControlListEntryForm(BaseForm):
                 ConditionalRadiosQuestion(
                     "No",
                     HTML.p(
-                        "The product will be assessed and given a control list entry. "
-                        "If the product isn't subject to any controls, you'll be issued "
-                        "with a 'no licence required' document."
+                        "Select this answer if you do not know the control list entry or if your product does not have one."
                     ),
                 ),
             ),


### PR DESCRIPTION
### Aim

Adds hint text and updates the help text for the control list entry question in exporter to make it clearer to exporters what to do if their product does not have a control list entry.

[LTD-4987](https://uktrade.atlassian.net/browse/LTD-4987)


[LTD-4987]: https://uktrade.atlassian.net/browse/LTD-4987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ