### PR TITLE
Add https to incomplete URLs in org registration

### DIFF
--- a/exporter/core/organisation/forms.py
+++ b/exporter/core/organisation/forms.py
@@ -226,12 +226,15 @@ class RegisterAddressDetailsBaseForm(BaseForm):
             try:
                 validator(website)
             except ValidationError:
-                if not website.startswith("http://") or website.startswith("https://"):
-                    website = "https://" + website
-                    try:
-                        validator(website)
-                    except ValidationError:
-                        raise ValidationError("Enter a valid URL.")
+                website = "https://" + website
+                try:
+                    validator(website)
+                except ValidationError:
+                    raise ValidationError("Enter a valid URL.")
+                else:
+                    return website
+            else:
+                return website
 
         return website
 

--- a/exporter/core/organisation/forms.py
+++ b/exporter/core/organisation/forms.py
@@ -1,5 +1,7 @@
 from django import forms
 from django.db import models
+from django.core.validators import URLValidator
+from django.core.exceptions import ValidationError
 
 from crispy_forms_gds.layout import HTML
 
@@ -9,7 +11,6 @@ from .validators import (
     validate_vat,
     validate_eori,
     validate_phone,
-    validate_website,
     validate_registration,
     validate_sic_number,
 )
@@ -214,7 +215,25 @@ class RegisterAddressDetailsBaseForm(BaseForm):
         validators=[validate_phone],
     )
 
-    website = forms.CharField(label="Website", required=False, validators=[validate_website])
+    website = forms.CharField(label="Website", required=False)
+
+    def clean_website(self):
+        website = self.cleaned_data.get("website")
+
+        validator = URLValidator()
+
+        if website:
+            try:
+                validator(website)
+            except ValidationError:
+                if not website.startswith("http://") or website.startswith("https://"):
+                    website = "https://" + website
+                    try:
+                        validator(website)
+                    except ValidationError:
+                        raise ValidationError("Enter a valid URL.")
+
+        return website
 
 
 class RegisterAddressDetailsUKForm(RegisterAddressDetailsBaseForm):

--- a/exporter/core/organisation/validators.py
+++ b/exporter/core/organisation/validators.py
@@ -2,7 +2,6 @@ import re
 import phonenumbers
 
 from django.core.exceptions import ValidationError
-from django.core.validators import URLValidator
 
 from .constants import Validation
 

--- a/exporter/core/organisation/validators.py
+++ b/exporter/core/organisation/validators.py
@@ -37,19 +37,6 @@ def validate_phone(value):
         raise ValidationError("Invalid telephone number")
 
 
-def validate_website(value):
-    if value:
-        try:
-            validator = URLValidator()
-            validator(value)
-        except ValidationError:
-            try:
-                validator("https://" + value)
-            except ValidationError:
-                raise ValidationError("Enter a valid URL")
-    return value
-
-
 def validate_sic_number(value):
     if value:
         if not value.isdigit():

--- a/unit_tests/exporter/core/organisation/test_forms.py
+++ b/unit_tests/exporter/core/organisation/test_forms.py
@@ -305,16 +305,21 @@ def test_select_organisation_form_valid(data_organisations):
     assert form.is_valid()
 
 
+register_address_details_website_test_cases = [
+    ("https://www.example.com", True, {}),
+    ("http://www.example.com", True, {}),
+    ("www.example.com", True, {}),
+    ("example.com", True, {}),
+    ("example", False, {"website": ["Enter a valid URL."]}),
+    (".com", False, {"website": ["Enter a valid URL."]}),
+    ("https://", False, {"website": ["Enter a valid URL."]}),
+    ("http://", False, {"website": ["Enter a valid URL."]}),
+]
+
+
 @pytest.mark.parametrize(
     ("website", "is_valid", "errors"),
-    [
-        ("https://www.example.com", True, {}),
-        ("http://www.example.com", True, {}),
-        ("www.example.com", True, {}),
-        ("example.com", True, {}),
-        ("example", False, {"website": ["Enter a valid URL."]}),
-        (".com", False, {"website": ["Enter a valid URL."]}),
-    ],
+    register_address_details_website_test_cases,
 )
 def test_register_address_details_website_uk(website, is_valid, errors):
     data = {
@@ -334,14 +339,7 @@ def test_register_address_details_website_uk(website, is_valid, errors):
 
 @pytest.mark.parametrize(
     ("website", "is_valid", "errors"),
-    [
-        ("https://www.example.com", True, {}),
-        ("http://www.example.com", True, {}),
-        ("www.example.com", True, {}),
-        ("example.com", True, {}),
-        ("example", False, {"website": ["Enter a valid URL."]}),
-        (".com", False, {"website": ["Enter a valid URL."]}),
-    ],
+    register_address_details_website_test_cases,
 )
 def test_register_address_details_website_overseas(website, is_valid, errors, mock_request, mock_get_countries):
     data = {

--- a/unit_tests/exporter/core/organisation/test_forms.py
+++ b/unit_tests/exporter/core/organisation/test_forms.py
@@ -303,3 +303,55 @@ def test_select_organisation_form_valid(data_organisations):
         organisations=data_organisations, data={"organisation": data_organisations[0]["id"]}
     )
     assert form.is_valid()
+
+
+@pytest.mark.parametrize(
+    ("website", "is_valid", "errors"),
+    [
+        ("https://www.example.com", True, {}),
+        ("http://www.example.com", True, {}),
+        ("www.example.com", True, {}),
+        ("example.com", True, {}),
+        ("example", False, {"website": ["Enter a valid URL."]}),
+        (".com", False, {"website": ["Enter a valid URL."]}),
+    ],
+)
+def test_register_address_details_website_uk(website, is_valid, errors):
+    data = {
+        "name": "Tokugawa Building",
+        "address_line_1": "1 Example Street",
+        "city": "Example City",
+        "region": "Example County",
+        "postcode": "SW1A 1AA",  # /PS-IGNORE
+        "phone_number": "07890123456",
+    }
+    data["website"] = website
+
+    form = forms.RegisterAddressDetailsUKForm(is_individual=False, data=data)
+    assert form.is_valid() == is_valid
+    assert form.errors == errors
+
+
+@pytest.mark.parametrize(
+    ("website", "is_valid", "errors"),
+    [
+        ("https://www.example.com", True, {}),
+        ("http://www.example.com", True, {}),
+        ("www.example.com", True, {}),
+        ("example.com", True, {}),
+        ("example", False, {"website": ["Enter a valid URL."]}),
+        (".com", False, {"website": ["Enter a valid URL."]}),
+    ],
+)
+def test_register_address_details_website_overseas(website, is_valid, errors, mock_request, mock_get_countries):
+    data = {
+        "name": "Tokugawa Building",
+        "address": "1 Example Street, Example City",
+        "country": "JP",
+        "phone_number": "+447890123456",
+    }
+    data["website"] = website
+
+    form = forms.RegisterAddressDetailsOverseasForm(is_individual=False, data=data, request=mock_request)
+    assert form.is_valid() == is_valid
+    assert form.errors == errors

--- a/unit_tests/exporter/core/organisation/test_validators.py
+++ b/unit_tests/exporter/core/organisation/test_validators.py
@@ -2,7 +2,7 @@ import pytest
 
 from django.core.exceptions import ValidationError
 
-from exporter.core.organisation.validators import validate_phone, validate_registration, validate_website
+from exporter.core.organisation.validators import validate_phone, validate_registration
 
 
 @pytest.mark.parametrize(
@@ -53,14 +53,3 @@ def test_validate_registration_number_valid_numbers(registration_number):
 def test_validate_registration_number_invalid_numbers(registration_number):
     with pytest.raises(ValidationError):
         validate_registration(registration_number)
-
-
-@pytest.mark.parametrize(("website"), ["https://www.example.com", "www.example.com", "example.com", ""])
-def test_validate_website(website):
-    assert validate_website(website) is website
-
-
-@pytest.mark.parametrize(("website"), ["example", "com", ".com"])
-def test_validate_website_invalid_url(website):
-    with pytest.raises(ValidationError):
-        validate_website(website)


### PR DESCRIPTION
### Aim

Previously the exporter organisation registration form was changed to allow incomplete URLs such as `example.com` to pass a custom validator used for the `website` field. However this still causes a problem when the data reaches the backend as the model and db uses `URLField` and so an error just appears in the backend instead.

With this change the custom validator is no longer used and instead a `clean_website` method does something similar for the `RegisterAddressDetailsBaseForm`, including that when a URL does not have a scheme prefix such as `https://`, the `clean_website` method prepends this to the form data and then this is checked using the standard Django URL validator, raising a `ValidationError` if it fails that validator. 

This is probably better than changing the backend and database to treat the website field as plain text. HTTPS has been the default for a few years now and it is unlikely to cause problems if we add `https://` to all incomplete URLs submitted through the exporter org forms.

[LTD-5068](https://uktrade.atlassian.net/browse/LTD-5068)


[LTD-5068]: https://uktrade.atlassian.net/browse/LTD-5068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ