### PR TITLE
Add an explicit form action for denials search form

### DIFF
--- a/caseworker/cases/forms/denial_forms.py
+++ b/caseworker/cases/forms/denial_forms.py
@@ -14,7 +14,6 @@ from core.forms.layouts import RenderTemplate
 
 
 class DenialSearchForm(forms.Form):
-
     search_string = forms.CharField(
         widget=forms.Textarea(attrs={"rows": "2"}),
         label="",
@@ -28,13 +27,14 @@ class DenialSearchForm(forms.Form):
         required=False,
     )
 
-    def __init__(self, countries, *args, **kwargs):
+    def __init__(self, countries, form_action, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         self.fields["country_filter"].choices = [(c, c) for c in countries]
 
         self.helper = FormHelper()
-
+        self.helper.form_action = form_action
+        self.helper.form_id = "denials-search-form"
         self.helper.layout = Layout(
             HTML.p("Or manually edit the query."),
             Field("search_string"),

--- a/unit_tests/caseworker/cases/test_denials_view.py
+++ b/unit_tests/caseworker/cases/test_denials_view.py
@@ -140,9 +140,9 @@ def test_search_denials_party_type_ultimate_and_third_party(
     (
         ("name:(John Smith) address:(Studio 47v, ferry, town, DD1 4AA)", {"country": ["United Kingdom"]}),  # /PS-IGNORE
         (
-            "name:(John Smith) address:(Studio 47v, ferry, town, DD1 4AA) name:(time) address:(2 doc rd)",
+            "name:(John Smith) address:(Studio 47v, ferry, town, DD1 4AA) name:(time) address:(2 doc rd)",  # /PS-IGNORE
             {"country": ["United Kingdom"]},
-        ),  # /PS-IGNORE
+        ),
         ("name:(Smith)", {"country": []}),
     ),
 )
@@ -297,6 +297,9 @@ def test_search_denials(
 
     for i, value in enumerate(table_body_values):
         assert value == expected_table_values[data_key_map[i]]
+
+    form = soup.find(id="denials-search-form")
+    assert form["action"] == f"/queues/{queue_pk}/cases/{standard_case_pk}/denials/?page=1&end_user={end_user_id}"
 
     page_2 = soup.find(id="page-2")
     assert page_2.a["href"] == f"/queues/{queue_pk}/cases/{standard_case_pk}/denials/?end_user={end_user_id}&page=2"


### PR DESCRIPTION
### Aim

This ensures that we aren't using the current page URL as the submission action which allows us to reset the paging params

[LTD-5058](https://uktrade.atlassian.net/browse/LTD-5058)


[LTD-5058]: https://uktrade.atlassian.net/browse/LTD-5058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ