### PR TITLE
Ltd 5013 allow pagination to post as forms

### DIFF
--- a/caseworker/templates/case/denial-for-case.html
+++ b/caseworker/templates/case/denial-for-case.html
@@ -113,7 +113,7 @@
                     <div><p class="govuk-label">No matching denials</p></div>
                 {% endif %}
             </form>
-            {% pagination %}
+            {% pagination link_type="form" form_id="denials-search-form" %}
         </div>
     </div>
 {% endblock %}

--- a/caseworker/templates/case/slices/destinations.html
+++ b/caseworker/templates/case/slices/destinations.html
@@ -8,7 +8,6 @@
 				<div class="lite-buttons-row">
 
 					<button class="govuk-button" formaction="{% url 'cases:denials' queue_pk=queue.id pk=case.id %}" >View related denials</button>
-					<input type="hidden" id="search_id" name="search_id" value="{% now "U" %}">
 					<!--<button id="button-edit-destinations-flags" class="govuk-button govuk-button--secondary" data-module="govuk-button">
 						{% lcs 'cases.ApplicationPage.EDIT_DESTINATION_FLAGS' %}
 					</button>-->

--- a/core/assets/styles/components/_pagination.scss
+++ b/core/assets/styles/components/_pagination.scss
@@ -61,7 +61,6 @@ $item-size: govuk-spacing(7);
         justify-content: center;
         list-style-type: none;
         margin: 0;
-        margin-right: govuk-spacing(6);  // Visually center the list
         padding: 0;
 
         @include govuk-media-query($until: tablet) {
@@ -71,32 +70,12 @@ $item-size: govuk-spacing(7);
 
     &__list-item {
         @include govuk-font($size: 19);
+        display: flex;
+        justify-content: center;
         line-height: $item-size !important;
         position: relative;
         text-align: center;
         width: $item-size;
-
-        a {
-            @extend .govuk-link;
-            @extend .govuk-link--no-visited-state;
-            display: inline-block;
-            line-height: $item-size !important;
-            position: relative;
-            text-decoration: none;
-            width: $item-size;
-
-            &:hover {
-                &::after {
-                    background: currentColor;
-                    bottom: 0;
-                    content: "";
-                    height: 2px;
-                    left: govuk-spacing(1);
-                    position: absolute;
-                    right: govuk-spacing(1);
-                }
-            }
-        }
 
         &--selected {
             font-weight: bold;
@@ -111,6 +90,39 @@ $item-size: govuk-spacing(7);
                 right: govuk-spacing(1);
             }
         }
+
+        .lite-pagination__link {
+            width: 100%;
+        }
+    }
+
+    &__link {
+        @extend .govuk-link;
+        @extend .govuk-link--no-visited-state;
+        @include govuk-font($size: 19);
+        align-items: center;
+        background-color: inherit;
+        border: 0;
+        color: $govuk-link-colour;
+        cursor: pointer;
+        display: flex;
+        justify-content: center;
+        line-height: $item-size !important;
+        position: relative;
+        text-decoration: none;
+        white-space: nowrap;
+
+        &:hover {
+            &::after {
+                background: currentColor;
+                bottom: 0;
+                content: "";
+                position: absolute;
+                left: 0;
+                right: 0;
+                height: 2px;
+            }
+        }
     }
 
     &__list-ellipsis {
@@ -120,7 +132,7 @@ $item-size: govuk-spacing(7);
         display: flex;
         justify-content: center;
         letter-spacing: 3px;
-        line-height: $item-size!important;
+        line-height: $item-size !important;
         margin: 0 govuk-spacing(2);
         position: relative;
         text-align: center;

--- a/core/builtins/custom_tags.py
+++ b/core/builtins/custom_tags.py
@@ -1026,8 +1026,14 @@ def pagination_params(url, page):
     return urlparse.urlunparse(url_parts)
 
 
+PAGINATION_LINK_TYPES = ["anchor", "form"]
+
+
 @register.inclusion_tag("components/pagination.html", takes_context=True)
-def pagination(context, *args, **kwargs):
+def pagination(context, *args, link_type="anchor", form_id=None, **kwargs):
+    if link_type not in PAGINATION_LINK_TYPES:
+        raise ValueError(f"Incorrect `link_type`. Choose either {' or '.join(PAGINATION_LINK_TYPES)}.")
+
     class PageItem:
         def __init__(self, number, url, selected=False):
             self.number = number
@@ -1090,5 +1096,7 @@ def pagination(context, *args, **kwargs):
     context["pages"] = pages
     context["previous_page_number"] = current_page - 1
     context["next_page_number"] = current_page + 1
+    context["paging_link_type"] = link_type
+    context["paging_form_id"] = form_id
 
     return context

--- a/core/templates/components/pagination.html
+++ b/core/templates/components/pagination.html
@@ -4,10 +4,21 @@
 <nav role="navigation" aria-label="Pagination Navigation">
 	<div class="lite-pagination__container">
 		{% if previous_link_url %}
-			<a id="link-previous-page" href="{{ previous_link_url }}" id="link-previous-page" class="lite-pagination__navigation-link lite-pagination__link">
-				{% svg 'previous' %}
-				<span data-number="{{ previous_page_number }}">Previous page</span>
-			</a>
+			{% if paging_link_type == "anchor" %}
+				<a id="link-previous-page" href="{{ previous_link_url }}" id="link-previous-page" class="lite-pagination__navigation-link lite-pagination__link">
+					{% svg 'previous' %}
+					<span data-number="{{ previous_page_number }}">Previous page</span>
+				</a>
+			{% elif paging_link_type == "form" %}
+				<button
+					class="lite-pagination__navigation-link lite-pagination__link"
+					form="{{ paging_form_id }}"
+					formaction="{{ previous_link_url }}"
+				>
+					{% svg 'previous' %}
+					<span data-number="{{ previous_page_number }}">Previous page</span>
+				</button>
+			{% endif %}
 		{% else %}
 			<p id="link-previous-page" class="lite-pagination__navigation-link lite-pagination__navigation-link--disabled">
 				{% svg 'previous' %}
@@ -23,9 +34,19 @@
 						{% if item.selected %}
 							{{ item.number }}
 						{% else %}
-							<a href="{{ item.url }}" {% if not item.selected %}aria-label="Goto Page {{ item.number}}" {% endif %} class="lite-pagination__link" data-number="{{ item.number }}">
-								{{ item.number }}
-							</a>
+							{% if paging_link_type == "anchor" %}
+								<a href="{{ item.url }}" {% if not item.selected %}aria-label="Goto Page {{ item.number}}" {% endif %} class="lite-pagination__link" data-number="{{ item.number }}">
+									{{ item.number }}
+								</a>
+							{% elif paging_link_type == "form" %}
+								<button
+									class="lite-pagination__navigation-link lite-pagination__link"
+									form="{{ paging_form_id }}"
+									formaction="{{ item.url }}"
+								>
+									{{ item.number }}
+								</button>
+							{% endif %}
 						{% endif %}
 					</li>
 				{% elif item.type == 'page_ellipsis' %}
@@ -38,10 +59,21 @@
 		{% endif %}
 
 		{% if next_link_url %}
-			<a id="link-next-page" href="{{ next_link_url }}" id="link-next-page" class="lite-pagination__navigation-link lite-pagination__link" >
-				<span data-number="{{ next_page_number }}">Next page</span>
-				{% svg 'next' %}
-			</a>
+			{% if paging_link_type == "anchor" %}
+				<a id="link-next-page" href="{{ next_link_url }}" id="link-next-page" class="lite-pagination__navigation-link lite-pagination__link" >
+					<span data-number="{{ next_page_number }}">Next page</span>
+					{% svg 'next' %}
+				</a>
+			{% elif paging_link_type == "form" %}
+				<button
+					class="lite-pagination__navigation-link lite-pagination__link"
+					form="{{ paging_form_id }}"
+					formaction="{{ next_link_url }}"
+				>
+					<span data-number="{{ next_page_number }}">Next page</span>
+					{% svg 'next' %}
+				</button>
+			{% endif %}
 		{% else %}
 			<p id="link-next-page" class="lite-pagination__navigation-link lite-pagination__navigation-link--disabled">
 				<span>Next page</span>

--- a/unit_tests/caseworker/cases/test_denials_view.py
+++ b/unit_tests/caseworker/cases/test_denials_view.py
@@ -254,16 +254,21 @@ def test_search_denials(
     assert form["action"] == f"/queues/{queue_pk}/cases/{standard_case_pk}/denials/?page=1&end_user={end_user_id}"
 
     page_2 = soup.find(id="page-2")
-    assert page_2.a["href"] == f"/queues/{queue_pk}/cases/{standard_case_pk}/denials/?end_user={end_user_id}&page=2"
+    assert (
+        page_2.button["formaction"]
+        == f"/queues/{queue_pk}/cases/{standard_case_pk}/denials/?end_user={end_user_id}&page=2"
+    )
+    assert page_2.button["form"] == "denials-search-form"
 
 
 def test_search_denials_no_matches(authorized_client, requests_mock, queue_pk, standard_case_pk):
     requests_mock.get(
         client._build_absolute_uri(f"/external-data/denial-search/"),
+        json={"count": 0, "total_pages": 1, "results": []},
     )
 
     url = reverse("cases:denials", kwargs={"pk": standard_case_pk, "queue_pk": queue_pk})
-    response = authorized_client.get(f"{url}")
+    response = authorized_client.get(url)
 
     soup = BeautifulSoup(response.content, "html.parser")
     assert response.status_code == 200

--- a/unit_tests/caseworker/cases/test_denials_view.py
+++ b/unit_tests/caseworker/cases/test_denials_view.py
@@ -162,54 +162,6 @@ def test_search_denials_search_string(
     assert mock_denials_search.request_history[0].url == expected_url
 
 
-@mock.patch(
-    "caseworker.cases.views.denials.search_denials", return_value=({"results": [], "count": 0, "total_pages": 0}, 200)
-)
-def test_search_denials_session_search_string_matchs(
-    mock_search_denials, authorized_client, data_standard_case, mock_denials_search, url
-):
-
-    party_id = data_standard_case["case"]["data"]["end_user"]["id"]
-    party_id_2 = data_standard_case["case"]["data"]["consignee"]["id"]
-
-    response = authorized_client.get(
-        url,
-        data={"end_user": party_id, "search_id": "123"},
-    )
-
-    assert response.status_code == 200
-    mock_search_denials.assert_called_with(
-        filter={"country": {"United Kingdom"}},
-        request=mock.ANY,
-        search="name:(End User) address:(44)",
-    )
-
-    search_string = {"search_string": "name:(End User2) address:(23)"}
-    country_filter = {"country": {"United Kingdom"}}
-
-    authorized_client.post(
-        f"{url}?end_user={party_id}&search_id=123", data={**search_string, "country_filter": "United Kingdom"}
-    )
-
-    assert authorized_client.session["search_params"] == {
-        "123": ("name:(End User2) address:(23)", {"United Kingdom"}, ["United Kingdom"])
-    }
-    mock_search_denials.assert_called_with(
-        filter=country_filter, request=mock.ANY, search="name:(End User2) address:(23)"
-    )
-
-    response = authorized_client.get(
-        url,
-        data={"consignee": party_id_2, "search_id": "1234"},
-    )
-
-    mock_search_denials.assert_called_with(
-        filter={"country": {"Abu Dhabi"}},
-        request=mock.ANY,
-        search="name:(Consignee) address:(44)",
-    )
-
-
 def test_search_score_feature_flag_on(authorized_client, data_standard_case, url, denials_search_score_flag_on):
     end_user_id = data_standard_case["case"]["data"]["end_user"]["id"]
     response = authorized_client.get(f"{url}?end_user={end_user_id}")

--- a/unit_tests/core/builtins/test_custom_tags.py
+++ b/unit_tests/core/builtins/test_custom_tags.py
@@ -421,3 +421,8 @@ def test_get_parties_status_optional_documents(parties, expected_status):
 )
 def test_pagination_params(url, page, expected):
     assert custom_tags.pagination_params(url, page) == expected
+
+
+def test_pagination():
+    with pytest.raises(ValueError):
+        custom_tags.pagination({}, link_type="madeup")


### PR DESCRIPTION
### Aim

Allow pagination to work with forms that have to send their payload via a post.

This in cases where the payload itself shouldn't be shared in the URL, as it would with a `get`, so this provides the means to do this via the current `pagination` template tag.

[LTD-5013](https://uktrade.atlassian.net/browse/LTD-5013)

[LTD-5013]: https://uktrade.atlassian.net/browse/LTD-5013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ