### PR TITLE
Update exporter summary pages and button text

### DIFF
--- a/exporter/applications/forms/edit.py
+++ b/exporter/applications/forms/edit.py
@@ -13,7 +13,7 @@ def reference_name_form(application_id=None):
             TextInput(name="name"),
         ],
         back_link=back_to_task_list(application_id),
-        default_button_name=conditional(application_id, generic.SAVE_AND_RETURN, generic.CONTINUE),
+        default_button_name=conditional(application_id, generic.SAVE_AND_RETURN, generic.SAVE_AND_CONTINUE),
     )
 
 
@@ -60,5 +60,5 @@ def told_by_an_official_form(application_id=None):
             ),
         ],
         back_link=back_to_task_list(application_id),
-        default_button_name=conditional(application_id, generic.SAVE_AND_RETURN, generic.CONTINUE),
+        default_button_name=conditional(application_id, generic.SAVE_AND_RETURN, generic.SAVE_AND_CONTINUE),
     )

--- a/exporter/applications/views/end_use_details.py
+++ b/exporter/applications/views/end_use_details.py
@@ -63,7 +63,7 @@ class EndUseDetails(LoginRequiredMixin, TemplateView):
         summary_list_form_view.back_url = self.success_url
         summary_list_form_view.back_link_text = strings.EndUseDetailsSummaryList.BACK_LINK_TEXT
 
-        summary_list_form_view.instruction_text = "Review your answers below and make any amends you need to. Click 'Save and continue' to save your progress."
+        summary_list_form_view.instruction_text = strings.EndUseDetailsSummaryList.INSTRUCTION_TEXT
 
         summary_list_form_view.init = init
         summary_list_form_view.request = request

--- a/exporter/applications/views/end_use_details.py
+++ b/exporter/applications/views/end_use_details.py
@@ -60,8 +60,8 @@ class EndUseDetails(LoginRequiredMixin, TemplateView):
             pass
 
         summary_list_form_view = SummaryListFormView()
-        summary_list_form_view.cancel_link_text = "cancel"
-        summary_list_form_view.cancel_link_url = self.success_url
+        summary_list_form_view.back_url = self.success_url
+        summary_list_form_view.back_link_text = strings.EndUseDetailsSummaryList.BACK_LINK_TEXT
 
         summary_list_form_view.init = init
         summary_list_form_view.request = request

--- a/exporter/applications/views/end_use_details.py
+++ b/exporter/applications/views/end_use_details.py
@@ -61,9 +61,9 @@ class EndUseDetails(LoginRequiredMixin, TemplateView):
 
         summary_list_form_view = SummaryListFormView()
         summary_list_form_view.back_url = self.success_url
-        summary_list_form_view.back_link_text = strings.EndUseDetailsSummaryList.BACK_LINK_TEXT
+        summary_list_form_view.back_link_text = "Back to application overview"
 
-        summary_list_form_view.instruction_text = strings.EndUseDetailsSummaryList.INSTRUCTION_TEXT
+        summary_list_form_view.instruction_text = "Review your answers below and make any amends you need to. Click 'Save and continue' to save your progress."
 
         summary_list_form_view.init = init
         summary_list_form_view.request = request

--- a/exporter/applications/views/end_use_details.py
+++ b/exporter/applications/views/end_use_details.py
@@ -63,6 +63,8 @@ class EndUseDetails(LoginRequiredMixin, TemplateView):
         summary_list_form_view.back_url = self.success_url
         summary_list_form_view.back_link_text = strings.EndUseDetailsSummaryList.BACK_LINK_TEXT
 
+        summary_list_form_view.instruction_text = "Review your answers below and make any amends you need to. Click 'Save and continue' to save your progress."
+
         summary_list_form_view.init = init
         summary_list_form_view.request = request
         summary_list_form_view.kwargs = kwargs

--- a/exporter/applications/views/parties/consignees.py
+++ b/exporter/applications/views/parties/consignees.py
@@ -19,7 +19,6 @@ class Consignee(LoginRequiredMixin, TemplateView):
             kwargs = {"pk": application_id, "obj_pk": application["consignee"]["id"]}
             context = {
                 "application": application,
-                "title": ConsigneePage.TITLE,
                 "edit_url": reverse("applications:edit_consignee", kwargs=kwargs),
                 "remove_url": reverse("applications:remove_consignee", kwargs=kwargs),
                 "answers": convert_party(
@@ -28,7 +27,7 @@ class Consignee(LoginRequiredMixin, TemplateView):
                     editable=application["status"]["value"] == "draft",
                 ),
             }
-            return render(request, "applications/end-user.html", context)
+            return render(request, "applications/consignee.html", context)
         else:
             return redirect(reverse("applications:add_consignee", kwargs={"pk": application_id}))
 

--- a/exporter/applications/views/security_approvals/views.py
+++ b/exporter/applications/views/security_approvals/views.py
@@ -91,6 +91,6 @@ class SecurityApprovalsSummaryView(LoginRequiredMixin, ApplicationMixin, Templat
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
         context["application"] = self.application
-        context["back_link_url"] = reverse("applications:security_approvals", kwargs={"pk": self.kwargs["pk"]})
+        context["back_link_url"] = reverse("applications:task_list", kwargs={"pk": self.kwargs["pk"]})
         context["security_classified_approvals_types"] = SecurityClassifiedApprovalsType
         return context

--- a/exporter/templates/applications/consignee.html
+++ b/exporter/templates/applications/consignee.html
@@ -1,5 +1,64 @@
-{% extends 'applications/end-user.html' %}
+{% extends 'layouts/two-pane.html' %}
 
 {% block back_link %}
 	<a href="{% url 'applications:task_list' application.id %}#consignee" id="back-link" class="govuk-back-link">Back to application overview</a>
+{% endblock %}
+
+{% block two_thirds %}
+	{% if highlight %}
+		<div class="lite-warning-summary" role="alert" tabindex="-1" data-module="govuk-error-summary">
+			<div class="lite-error-summary__body">
+				<ul class="govuk-list lite-error-summary__list">
+					{% for item in highlight %}
+						<li>
+							<a href="#{{ item|idify }}">You need to attach a document</a>
+						</li>
+					{% endfor %}
+				</ul>
+			</div>
+		</div>
+	{% endif %}
+
+	<div class="lite-app-bar">
+		<div class="lite-app-bar__content">
+			<h1 class="govuk-heading-l">
+				{% block title %}
+					Consignee summary
+				{% endblock %}
+			</h1>
+		</div>
+		<div class="lite-app-bar__controls">
+			{% if remove_url %}
+				<a href="{{ remove_url }}" class="govuk-button govuk-button--secondary" draggable="false" role="button">
+					Remove consignee
+				</a>
+			{% endif %}
+			{% if edit_url %}
+				<a href="{{ edit_url }}" class="govuk-button" draggable="false" role="button">
+					Edit
+				</a>
+			{% endif %}
+		</div>
+	</div>
+
+	<p class="govuk-body">Review your answers below and make any amends you need to. Click 'Save and continue' to save your progress</p>
+
+	<dl class="govuk-summary-list">
+		{% for key, value in answers.items %}
+			<div class="govuk-summary-list__row">
+				<dt class="govuk-summary-list__key {% if key in highlight %}govuk-summary-list__key--highlight{% endif %}">
+					{{ key }}
+				</dt>
+				<dd id="{{ key|idify }}" class="govuk-summary-list__value">
+					{{ value|default_na|linebreaksbr }}
+				</dd>
+			</div>
+		{% endfor %}
+	</dl>
+
+	<div>
+        <a draggable="false" class="govuk-button govuk-button--primary" href="{% url 'applications:task_list' application.id %}">
+            Save and continue
+        </a>
+	</div>
 {% endblock %}

--- a/exporter/templates/applications/security-approvals/security-approvals-summary.html
+++ b/exporter/templates/applications/security-approvals/security-approvals-summary.html
@@ -1,7 +1,7 @@
 {% extends 'layouts/base.html' %}
 
 {% block back_link %}
-	<a href="{{ back_link_url }}" id="back-link" class="govuk-back-link">{% lcs 'generic.BACK' %}</a>
+	<a href="{{ back_link_url }}" id="back-link" class="govuk-back-link">{% lcs 'generic.BACK_TO_APPLICATION_OVERVIEW' %}</a>
 {% endblock %}
 
 {% block body %}
@@ -14,6 +14,8 @@
                 </h1>
             </div>
         </div>
+
+        <p class="govuk-body">Review your answers below and make any amends you need to. Click 'Save and continue' to save your progress.</p>
 
     <dl class="govuk-summary-list">
         <div class="govuk-summary-list__row">
@@ -89,6 +91,6 @@
     </div>
 </div>
     <div class="govuk-button-group">
-	<a id="submit" href="{% url 'applications:task_list' application.id %}" class="govuk-button" data-module="govuk-button">Continue</a>
+	<a id="submit" href="{% url 'applications:task_list' application.id %}" class="govuk-button" data-module="govuk-button">Save and continue</a>
 </div>
 {% endblock %}

--- a/lite_content/lite_exporter_frontend/applications.py
+++ b/lite_content/lite_exporter_frontend/applications.py
@@ -848,6 +848,7 @@ class EndUseDetails:
 
     class EndUseDetailsSummaryList:
         TITLE = "End use summary list"
+        BACK_LINK_TEXT = "Back to application overview"
         INTENDED_END_USE = "Intended end use of the products"
         INFORMED_TO_APPLY = "Informed by ECJU to apply for a licence"
         INFORMED_WMD = "Informed by ECJU that products may be used in WMD"

--- a/lite_content/lite_exporter_frontend/applications.py
+++ b/lite_content/lite_exporter_frontend/applications.py
@@ -849,6 +849,7 @@ class EndUseDetails:
     class EndUseDetailsSummaryList:
         TITLE = "End use summary list"
         BACK_LINK_TEXT = "Back to application overview"
+        INSTRUCTION_TEXT = "Review your answers below and make any amends you need to. Click 'Save and continue' to save your progress."
         INTENDED_END_USE = "Intended end use of the products"
         INFORMED_TO_APPLY = "Informed by ECJU to apply for a licence"
         INFORMED_WMD = "Informed by ECJU that products may be used in WMD"

--- a/lite_content/lite_exporter_frontend/applications.py
+++ b/lite_content/lite_exporter_frontend/applications.py
@@ -848,8 +848,6 @@ class EndUseDetails:
 
     class EndUseDetailsSummaryList:
         TITLE = "End use summary list"
-        BACK_LINK_TEXT = "Back to application overview"
-        INSTRUCTION_TEXT = "Review your answers below and make any amends you need to. Click 'Save and continue' to save your progress."
         INTENDED_END_USE = "Intended end use of the products"
         INFORMED_TO_APPLY = "Informed by ECJU to apply for a licence"
         INFORMED_WMD = "Informed by ECJU that products may be used in WMD"

--- a/lite_forms/templates/summary-list.html
+++ b/lite_forms/templates/summary-list.html
@@ -13,6 +13,10 @@
 		{% endblock %}
 	</h1>
 
+	{% if instruction_text %}
+		<p class="govuk-body">{{ instruction_text }}</p>
+	{% endif %}
+
 	{% for form in forms.forms %}
 		{% if not form.single_form_element and not hide_titles %}
 			<h2 class="govuk-heading-m">{{ form.title }}</h2>

--- a/lite_forms/templates/summary-list.html
+++ b/lite_forms/templates/summary-list.html
@@ -1,6 +1,10 @@
 {% extends 'layouts/two-pane.html' %}
 
-{% block back_link %}{% endblock %}
+{% block back_link %}
+	{% if back_url and back_link_text %}
+		<a href="{{ back_url }}" id="back-link" class="govuk-back-link">{{ back_link_text }}</a>
+	{% endif %}
+{% endblock %}
 
 {% block two_thirds %}
 	<h1 class="govuk-heading-xl {% if forms.forms.0.single_form_element %}govuk-!-margin-bottom-7{% endif %}">

--- a/lite_forms/views.py
+++ b/lite_forms/views.py
@@ -232,6 +232,8 @@ class SummaryListFormView(FormView):
     cancel_link_prefix = "or "
     cancel_link_text = ""
     cancel_link_url = ""
+    back_url = ""
+    back_link_text = ""
 
     def get_forms(self):
         if not self.forms:
@@ -272,6 +274,8 @@ class SummaryListFormView(FormView):
         data = self.clean_data(self.get_validated_data())
         context = {
             "forms": self.get_forms(),
+            "back_url": self.back_url,
+            "back_link_text": self.back_link_text,
             "data": data,
             "pretty_data": self.prettify_data(data.copy()),
             "title": self.summary_list_title,

--- a/lite_forms/views.py
+++ b/lite_forms/views.py
@@ -234,6 +234,7 @@ class SummaryListFormView(FormView):
     cancel_link_url = ""
     back_url = ""
     back_link_text = ""
+    instruction_text = ""
 
     def get_forms(self):
         if not self.forms:
@@ -276,6 +277,7 @@ class SummaryListFormView(FormView):
             "forms": self.get_forms(),
             "back_url": self.back_url,
             "back_link_text": self.back_link_text,
+            "instruction_text": self.instruction_text,
             "data": data,
             "pretty_data": self.prettify_data(data.copy()),
             "title": self.summary_list_title,

--- a/tests_common/functions.py
+++ b/tests_common/functions.py
@@ -29,6 +29,10 @@ def click_continue_link(driver: WebDriver):
     driver.find_element(by=By.LINK_TEXT, value="Continue").click()
 
 
+def click_save_and_continue_link(driver: WebDriver):
+    driver.find_element(by=By.LINK_TEXT, value="Save and continue").click()
+
+
 def element_with_css_selector_exists(driver: WebDriver, css_selector: str) -> bool:
     driver.implicitly_wait(0)
     return_value = len(driver.find_elements(by=By.CSS_SELECTOR, value=css_selector)) != 0

--- a/ui_tests/exporter/conftest.py
+++ b/ui_tests/exporter/conftest.py
@@ -444,6 +444,11 @@ def i_click_continue_link(driver):  # noqa
     functions.click_continue_link(driver)
 
 
+@when("I click save and continue link")  # noqa
+def i_click_save_and_continue_link(driver):  # noqa
+    functions.click_save_and_continue_link(driver)
+
+
 @when("I click the back link")  # noqa
 def click_back_link(driver):  # noqa
     functions.click_back_link(driver)

--- a/ui_tests/exporter/features/submit_standard_application.feature
+++ b/ui_tests/exporter/features/submit_standard_application.feature
@@ -90,7 +90,7 @@ Feature: I want to indicate the standard licence I want
     And I click on "Submit"
     And I click on "Do you have a security approval?"
     And I select "No" to if you are exporting classified products
-    And I click continue link
+    And I click save and continue link
     And I click on "End user"
     And I select "no" to reusing an existing party
     And I select "commercial organisation" as the type of end user
@@ -221,7 +221,7 @@ Feature: I want to indicate the standard licence I want
     And I click on "Submit"
     And I click on "Do you have a security approval?"
     And I select "No" to if you are exporting classified products
-    And I click continue link
+    And I click save and continue link
     And I click on "End user"
     And I select "no" to reusing an existing party
     And I select "commercial organisation" as the type of end user

--- a/unit_tests/exporter/applications/views/parties/test_consignees.py
+++ b/unit_tests/exporter/applications/views/parties/test_consignees.py
@@ -1,0 +1,27 @@
+import pytest
+from pytest_django.asserts import assertTemplateUsed
+
+from django.urls import reverse
+
+from core import client
+
+
+@pytest.fixture(autouse=True)
+def mock_get_application(requests_mock, data_standard_case):
+    applications_url = client._build_absolute_uri(f"/applications/{data_standard_case['case']['id']}/")
+    requests_mock.get(url=applications_url, json=data_standard_case["case"]["data"])
+
+
+@pytest.fixture
+def application_pk(data_standard_case):
+    return data_standard_case["case"]["id"]
+
+
+@pytest.fixture
+def application_parties_consignee_summary_url(application_pk):
+    return reverse("applications:consignee", kwargs={"pk": application_pk})
+
+
+def test_application_parties_consignee_summary(authorized_client, application_parties_consignee_summary_url):
+    response = authorized_client.get(application_parties_consignee_summary_url)
+    assertTemplateUsed(response, "applications/consignee.html")

--- a/unit_tests/exporter/applications/views/security_approvals/test_security_approvals_views.py
+++ b/unit_tests/exporter/applications/views/security_approvals/test_security_approvals_views.py
@@ -220,14 +220,24 @@ def test_application_security_approvals_short(
     )
 
 
+@pytest.fixture
+def task_list_url(application):
+    return reverse(
+        "applications:task_list",
+        kwargs={
+            "pk": application["id"],
+        },
+    )
+
+
 def test_application_summary(
     authorized_client,
     application_security_approvals_summary_url,
-    application_security_approvals_url,
+    task_list_url,
     mock_application_get,
 ):
 
     response = authorized_client.get(application_security_approvals_summary_url)
     assert response.context["security_classified_approvals_types"]
     assert response.context["application"]
-    assert response.context["back_link_url"] == application_security_approvals_url
+    assert response.context["back_link_url"] == task_list_url

--- a/unit_tests/exporter/applications/views/test_end_use_details.py
+++ b/unit_tests/exporter/applications/views/test_end_use_details.py
@@ -1,0 +1,34 @@
+import pytest
+
+from django.urls import reverse
+
+from lite_content.lite_exporter_frontend.applications import EndUseDetails
+
+
+@pytest.fixture
+def application_pk(data_standard_case):
+    return data_standard_case["case"]["data"]["id"]
+
+
+@pytest.fixture
+def application_end_use_summary_url(application_pk):
+    return reverse(
+        "applications:end_use_details",
+        kwargs={
+            "pk": application_pk,
+        },
+    )
+
+
+@pytest.fixture
+def application_task_list_url(application_pk):
+    return reverse("applications:task_list", kwargs={"pk": application_pk})
+
+
+def test_application_end_use_summary(
+    authorized_client, mock_application_get, application_end_use_summary_url, application_task_list_url
+):
+    response = authorized_client.get(application_end_use_summary_url)
+    assert response.context["back_url"] == application_task_list_url + "#end_use_details"
+    assert response.context["back_link_text"] == EndUseDetails.EndUseDetailsSummaryList.BACK_LINK_TEXT
+    assert response.context["instruction_text"] == EndUseDetails.EndUseDetailsSummaryList.INSTRUCTION_TEXT

--- a/unit_tests/exporter/applications/views/test_end_use_details.py
+++ b/unit_tests/exporter/applications/views/test_end_use_details.py
@@ -2,8 +2,6 @@ import pytest
 
 from django.urls import reverse
 
-from lite_content.lite_exporter_frontend.applications import EndUseDetails
-
 
 @pytest.fixture
 def application_pk(data_standard_case):
@@ -30,5 +28,8 @@ def test_application_end_use_summary(
 ):
     response = authorized_client.get(application_end_use_summary_url)
     assert response.context["back_url"] == application_task_list_url + "#end_use_details"
-    assert response.context["back_link_text"] == EndUseDetails.EndUseDetailsSummaryList.BACK_LINK_TEXT
-    assert response.context["instruction_text"] == EndUseDetails.EndUseDetailsSummaryList.INSTRUCTION_TEXT
+    assert response.context["back_link_text"] == "Back to application overview"
+    assert (
+        response.context["instruction_text"]
+        == "Review your answers below and make any amends you need to. Click 'Save and continue' to save your progress."
+    )


### PR DESCRIPTION
### Aim

These changes are part of the Assisted Digital work to make parts of LITE Exporter easier to understand. Screenshots of the changes have been added to the ticket.

[LTD-5042](https://uktrade.atlassian.net/browse/LTD-5042)


[LTD-5042]: https://uktrade.atlassian.net/browse/LTD-5042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ