### PR TITLE
Update is_onward_exported question text

### DIFF
--- a/caseworker/tau/templates/tau/firearms_accessory_table.html
+++ b/caseworker/tau/templates/tau/firearms_accessory_table.html
@@ -91,7 +91,7 @@
           </td>
         </tr>
         <tr class="govuk-table__row">
-          <th class="govuk-table__header">Will the product be onward exported to any additional countries?</th>
+          <th class="govuk-table__header">Is the product going to any ultimate end-users?</th>
           <td class="govuk-table__cell">{{ case.destinations|is_ultimate_end_user|yesno|capfirst }}</td>
         </tr>
         <tr class="govuk-table__row">

--- a/core/summaries/formatters.py
+++ b/core/summaries/formatters.py
@@ -331,7 +331,7 @@ FIREARM_ON_APPLICATION_LABELS = {
     "shotgun-certificate-expiry-date": "Certificate date of expiry",
     "made-before-1938": "Was the product made before 1938?",
     "manufacture-year": "What year was it made?",
-    "is-onward-exported": "Will the product be onward exported to any additional countries?",
+    "is-onward-exported": "Is the product going to any ultimate end-users?",
     "is-altered": "Will the item be altered or processed before it is exported again?",
     "is-altered-comments": "Explain how the product will be processed or altered",
     "is-incorporated": "Will the product be incorporated into another item before it is onward exported?",
@@ -394,7 +394,7 @@ COMPLETE_ITEM_ON_APPLICATION_FORMATTERS = {
 }
 
 COMPLETE_ITEM_ON_APPLICATION_LABELS = {
-    "is-onward-exported": "Will the product be onward exported to any additional countries?",
+    "is-onward-exported": "Is the product going to any ultimate end-users?",
     "is-altered": "Will the item be altered or processed before it is exported again?",
     "is-altered-comments": "Explain how the product will be processed or altered",
     "is-incorporated": "Will the product be incorporated into another item before it is onward exported?",
@@ -434,7 +434,7 @@ MATERIAL_ON_APPLICATION_FORMATTERS = {
 }
 
 MATERIAL_ON_APPLICATION_LABELS = {
-    "is-onward-exported": "Will the product be onward exported to any additional countries?",
+    "is-onward-exported": "Is the product going to any ultimate end-users?",
     "is-altered": "Will the item be altered or processed before it is exported again?",
     "is-altered-comments": "Explain how the product will be processed or altered",
     "is-incorporated": "Will the product be incorporated into another item before it is onward exported?",
@@ -503,7 +503,7 @@ TECHNOLOGY_ON_APPLICATION_FORMATTERS = {
 }
 
 TECHNOLOGY_ON_APPLICATION_LABELS = {
-    "is-onward-exported": "Will the product be onward exported to any additional countries?",
+    "is-onward-exported": "Is the product going to any ultimate end-users?",
     "is-altered": "Will the item be altered or processed before it is exported again?",
     "is-altered-comments": "Explain how the product will be processed or altered",
     "is-incorporated": "Will the product be incorporated into another item before it is onward exported?",
@@ -545,7 +545,7 @@ COMPONENT_ACCESSORY_ON_APPLICATION_FORMATTERS = {
 }
 
 COMPONENT_ACCESSORY_ON_APPLICATION_LABELS = {
-    "is-onward-exported": "Will the product be onward exported to any additional countries?",
+    "is-onward-exported": "Is the product going to any ultimate end-users?",
     "is-altered": "Will the item be altered or processed before it is exported again?",
     "is-altered-comments": "Explain how the product will be processed or altered",
     "is-incorporated": "Will the product be incorporated into another item before it is onward exported?",

--- a/exporter/core/templates/goods/forms/common/help_with_ultimate_end-users.html
+++ b/exporter/core/templates/goods/forms/common/help_with_ultimate_end-users.html
@@ -1,0 +1,2 @@
+<p class="govuk-body">An ultimate end-user in either the destination country or a third country receives the products from the end-user, or occasionally via a consignee after the end-user. For example, after products have been altered, processed, or incorporated into a higher-level system.</p>
+<p class="govuk-body">Include all the potential ultimate end-users on your application.</p>

--- a/exporter/goods/forms/common.py
+++ b/exporter/goods/forms/common.py
@@ -406,7 +406,7 @@ class ProductDocumentUploadForm(BaseForm):
 
 class ProductOnwardExportedForm(BaseForm):
     class Layout:
-        TITLE = "Will the product be onward exported to any additional countries?"
+        TITLE = "Is the product going to any ultimate end-users?"
 
     is_onward_exported = forms.TypedChoiceField(
         choices=(
@@ -417,18 +417,16 @@ class ProductOnwardExportedForm(BaseForm):
         label="",
         widget=forms.RadioSelect,
         error_messages={
-            "required": "Select yes if the product will be onward exported to additional countries",
+            "required": "Select yes if the product is going to any ultimate end-users",
         },
     )
 
     def get_layout_fields(self):
         return (
-            HTML.p("Tell us if the item will be exported again, beyond its first destination."),
-            HTML.p("This includes when the product has been incorporated into another item."),
             "is_onward_exported",
             HTML.details(
-                "Help with incorporated products",
-                render_to_string("goods/forms/common/help_with_incorporated_products.html"),
+                "Help with ultimate end-users",
+                render_to_string("goods/forms/common/help_with_ultimate_end-users.html"),
             ),
         )
 

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -1798,7 +1798,7 @@ def standard_firearm_expected_product_summary():
 def standard_firearm_expected_product_on_application_summary():
     return (
         ("manufacture-year", "1990", "What year was it made?"),
-        ("is-onward-exported", "No", "Will the product be onward exported to any additional countries?"),
+        ("is-onward-exported", "No", "Is the product going to any ultimate end-users?"),
         ("is-deactivated", "No", "Has the product been deactivated?"),
         ("number-of-items", 2, "Number of items"),
         ("total-value", "£444.00", "Total value"),
@@ -1940,7 +1940,7 @@ def standard_complete_item_expected_product_on_application_summary():
         (
             "is-onward-exported",
             "Yes",
-            "Will the product be onward exported to any additional countries?",
+            "Is the product going to any ultimate end-users?",
         ),
         (
             "is-altered",
@@ -2083,7 +2083,7 @@ def standard_component_accessory_expected_product_on_application_summary():
         (
             "is-onward-exported",
             "Yes",
-            "Will the product be onward exported to any additional countries?",
+            "Is the product going to any ultimate end-users?",
         ),
         (
             "is-altered",
@@ -2213,7 +2213,7 @@ def standard_material_expected_product_on_application_summary():
         (
             "is-onward-exported",
             "Yes",
-            "Will the product be onward exported to any additional countries?",
+            "Is the product going to any ultimate end-users?",
         ),
         (
             "is-altered",
@@ -2370,7 +2370,7 @@ def standard_technology_expected_product_on_application_summary():
         (
             "is-onward-exported",
             "Yes",
-            "Will the product be onward exported to any additional countries?",
+            "Is the product going to any ultimate end-users?",
         ),
         (
             "is-altered",

--- a/unit_tests/exporter/applications/views/goods/component/test_summary_component.py
+++ b/unit_tests/exporter/applications/views/goods/component/test_summary_component.py
@@ -93,7 +93,7 @@ def test_component_accessory_product_on_application_summary_response_status_code
 @pytest.fixture
 def component_accessory_on_application_summary():
     return (
-        ("is-onward-exported", "Yes", "Will the product be onward exported to any additional countries?"),
+        ("is-onward-exported", "Yes", "Is the product going to any ultimate end-users?"),
         ("is-altered", "Yes", "Will the item be altered or processed before it is exported again?"),
         ("is-altered-comments", "I will alter it real good", "Explain how the product will be processed or altered"),
         ("is-incorporated", "Yes", "Will the product be incorporated into another item before it is onward exported?"),

--- a/unit_tests/exporter/applications/views/goods/firearm/test_summary_firearm.py
+++ b/unit_tests/exporter/applications/views/goods/firearm/test_summary_firearm.py
@@ -211,7 +211,7 @@ def product_on_application_summary():
     return (
         ("made-before-1938", "Yes", "Was the product made before 1938?"),
         ("manufacture-year", 1930, "What year was it made?"),
-        ("is-onward-exported", "Yes", "Will the product be onward exported to any additional countries?"),
+        ("is-onward-exported", "Yes", "Is the product going to any ultimate end-users?"),
         ("is-altered", "Yes", "Will the item be altered or processed before it is exported again?"),
         ("is-altered-comments", "I will alter it real good", "Explain how the product will be processed or altered"),
         ("is-incorporated", "Yes", "Will the product be incorporated into another item before it is onward exported?"),

--- a/unit_tests/exporter/applications/views/goods/material/test_summary_material.py
+++ b/unit_tests/exporter/applications/views/goods/material/test_summary_material.py
@@ -176,7 +176,7 @@ def test_material_product_on_application_summary_response_status_code(
 @pytest.fixture
 def material_on_application_summary():
     return (
-        ("is-onward-exported", "Yes", "Will the product be onward exported to any additional countries?"),
+        ("is-onward-exported", "Yes", "Is the product going to any ultimate end-users?"),
         ("is-altered", "Yes", "Will the item be altered or processed before it is exported again?"),
         ("is-altered-comments", "I will alter it real good", "Explain how the product will be processed or altered"),
         ("is-incorporated", "Yes", "Will the product be incorporated into another item before it is onward exported?"),

--- a/unit_tests/exporter/applications/views/goods/platform/test_summary_platform.py
+++ b/unit_tests/exporter/applications/views/goods/platform/test_summary_platform.py
@@ -90,7 +90,7 @@ def test_complete_item_product_on_application_summary_response_status_code(
 @pytest.fixture
 def complete_item_on_application_summary():
     return (
-        ("is-onward-exported", "Yes", "Will the product be onward exported to any additional countries?"),
+        ("is-onward-exported", "Yes", "Is the product going to any ultimate end-users?"),
         ("is-altered", "Yes", "Will the item be altered or processed before it is exported again?"),
         ("is-altered-comments", "I will alter it real good", "Explain how the product will be processed or altered"),
         ("is-incorporated", "Yes", "Will the product be incorporated into another item before it is onward exported?"),

--- a/unit_tests/exporter/applications/views/goods/software/test_summary_software.py
+++ b/unit_tests/exporter/applications/views/goods/software/test_summary_software.py
@@ -90,7 +90,7 @@ def test_technology_product_on_application_summary_response_status_code(
 @pytest.fixture
 def technology_on_application_summary():
     return (
-        ("is-onward-exported", "Yes", "Will the product be onward exported to any additional countries?"),
+        ("is-onward-exported", "Yes", "Is the product going to any ultimate end-users?"),
         ("is-altered", "Yes", "Will the item be altered or processed before it is exported again?"),
         ("is-altered-comments", "I will alter it real good", "Explain how the product will be processed or altered"),
         ("is-incorporated", "Yes", "Will the product be incorporated into another item before it is onward exported?"),

--- a/unit_tests/exporter/goods/forms/test_common.py
+++ b/unit_tests/exporter/goods/forms/test_common.py
@@ -453,7 +453,7 @@ def test_product_unit_quantity_and_value_form_validation(data, is_valid, errors,
         (
             {},
             False,
-            {"is_onward_exported": ["Select yes if the product will be onward exported to additional countries"]},
+            {"is_onward_exported": ["Select yes if the product is going to any ultimate end-users"]},
         ),
         (
             {"is_onward_exported": True},


### PR DESCRIPTION
### Aim

The onward exported question has been changed to ask about ultimate end-users instead, as this is more correct. There are sometimes cases where a good is onward exported to an ultimate end-user in the same country, and the existing question wording means exporters cannot answer properly if that is their situation.

Because the question is still asking about goods being onward exported just in a different way, it seems fine to keep the `is_onward_exported` variable the same and not change that in other places. 

[LTD-5053](https://uktrade.atlassian.net/browse/LTD-5053)


[LTD-5053]: https://uktrade.atlassian.net/browse/LTD-5053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ