### PR TITLE
Update org website field hint text

### DIFF
--- a/exporter/core/organisation/forms.py
+++ b/exporter/core/organisation/forms.py
@@ -215,7 +215,7 @@ class RegisterAddressDetailsBaseForm(BaseForm):
         validators=[validate_phone],
     )
 
-    website = forms.CharField(label="Website", required=False)
+    website = forms.CharField(label="Website", help_text="Use the format https://www.example.com", required=False)
 
     def clean_website(self):
         website = self.cleaned_data.get("website")


### PR DESCRIPTION
### Aim

This adds hint text to the website field in the exporter organisation registration form.

[LTD-5101](https://uktrade.atlassian.net/browse/LTD-5101)


[LTD-5101]: https://uktrade.atlassian.net/browse/LTD-5101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ