### PR TITLE
Add autoflake unused imports pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,5 +57,10 @@ repos:
       - id: eslint
         files: "^(core|caseworker|exporter)/assets/javascripts"
         additional_dependencies:
-          - eslint@8.44.0
-          - eslint-plugin-jest@27.2.3
+          - eslint@8.44.0 # /PS-IGNORE
+          - eslint-plugin-jest@27.2.3 # /PS-IGNORE
+  - repo: https://github.com/PyCQA/autoflake
+    rev: v2.2.1
+    hooks:
+      - id: autoflake
+        args: [--remove-all-unused-imports, --in-place]


### PR DESCRIPTION
### Aim

This adds a pre-commit hook to check and remove unused imports using autoflake. The setup is identical to the example given in the README for autoflake here: https://github.com/PyCQA/autoflake

This isn't associated with a Jira ticket, this is just solving an annoyance that is quite common where you make a quick change on a PR and then the only CI check to fail is the unused imports check.