### PR TITLE
Update SIC code text

### DIFF
--- a/exporter/core/organisation/forms.py
+++ b/exporter/core/organisation/forms.py
@@ -80,7 +80,7 @@ class RegisterDetailsBaseForm(BaseForm):
 
     VAT_LABEL = "UK VAT number"
     EORI_LABEL = "European Union registration and identification number (EORI)"
-    SIC_CODE_LABEL = "SIC Code"
+    SIC_CODE_LABEL = "Standard industrial classification (SIC code)"
     REGISTRATION_LABEL = "Companies House registration number (CRN)"
 
     class Layout:


### PR DESCRIPTION
### Aim

Updates the field label for SIC code as this should be spelled out in full on its first usage in LITE.

[LTD-5123](https://uktrade.atlassian.net/browse/LTD-5123)


[LTD-5123]: https://uktrade.atlassian.net/browse/LTD-5123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ