### PR TITLE
Update party website forms to use same help text and validation

### DIFF
--- a/exporter/applications/forms/parties.py
+++ b/exporter/applications/forms/parties.py
@@ -14,15 +14,7 @@ from exporter.core.services import get_countries
 from lite_content.lite_exporter_frontend import strings
 from lite_content.lite_exporter_frontend.applications import PartyForm, PartyTypeForm
 from lite_forms.common import country_question
-from lite_forms.components import (
-    BackLink,
-    RadioButtons,
-    Form,
-    Option,
-    TextArea,
-    TextInput,
-    FormGroup,
-)
+from lite_forms.components import BackLink, RadioButtons, Form, Option, TextArea, TextInput, FormGroup, Label
 from lite_forms.generators import confirm_form
 
 
@@ -66,7 +58,7 @@ def party_name_form(title, button):
 def party_website_form(title, button):
     return Form(
         title=title,
-        questions=[TextInput("website")],
+        questions=[Label("Use the format https://www.example.com", classes=["govuk-hint"]), TextInput("website")],
         default_button_name=button,
     )
 

--- a/unit_tests/exporter/applications/forms/test_parties.py
+++ b/unit_tests/exporter/applications/forms/test_parties.py
@@ -64,7 +64,10 @@ def test_party_name_form(data, valid, errors):
 @pytest.mark.parametrize(
     "data, valid, errors",
     (
-        ({"website": "test"}, True, None),
+        ({"website": "test"}, False, {"website": ["Enter a valid URL."]}),
+        ({"website": "https://www.example.com"}, True, None),
+        ({"website": "www.example.com"}, True, None),
+        ({"website": "example.com"}, True, None),
         ({"website": ""}, True, None),
         ({}, True, None),
     ),


### PR DESCRIPTION
### Aim

Adds the same help text and validation to the end user website form and party website form (this means it will update for adding an ultimate end-user, third party, consignee) as was already done for the exporter org registration form. 

[LTD-5124](https://uktrade.atlassian.net/browse/LTD-5124)


[LTD-5124]: https://uktrade.atlassian.net/browse/LTD-5124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ