### PR TITLE
Ensure api container logs are saved as artifacts to E2E circleci jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,6 +192,9 @@ commands:
       - cache_env_circleci_dir
       - store_artifacts:
           path: ui_tests/screenshots
+      - run: docker logs api > ui_tests/api_logs.txt
+      - store_artifacts:
+          path: ui_tests/api_logs.txt
       - store_test_results:
           path: test_results
 

--- a/docker-compose.api.yml
+++ b/docker-compose.api.yml
@@ -2,6 +2,7 @@ version: '3.2'
 
 services:
   api:
+    container_name: api
     image: liteapi
     environment:
       # Below values can be found in vault


### PR DESCRIPTION
### Aim

This change ensures that logs from the API container will be uploaded as a circleci artifact when running the E2E tests on circleci.

