### PR TITLE
Fix FOI answer shown in case details tab

### DIFF
--- a/caseworker/templates/case/slices/freedom-of-information.html
+++ b/caseworker/templates/case/slices/freedom-of-information.html
@@ -8,10 +8,10 @@
 	<tbody class="govuk-table__body">
 		<tr class="govuk-table__row">
 			<td class="govuk-table__cell govuk-!-font-weight-bold">
-				The disclosure of information on this application form would be harmful to my/our interests
+				Do you agree to make the application details publicly available?
 			</td>
 			<td class="govuk-table__cell">
-				<p id="agreed-to-foi-value" class="govuk-body govuk-!-margin-0">{{ case.data.agreed_to_foi|friendly_boolean }}</p>
+				<p id="agreed-to-foi-value" class="govuk-body govuk-!-margin-0">{{ case.data.agreed_to_foi|get_agreed_to_foi_value }}</p>
 				<p id="foi-reason-value" class="govuk-hint govuk-!-margin-0 govuk-!-margin-top-1" data-max-length="200">{{ case.data.foi_reason|default:"" }}</p>
 			</td>
 		</tr>

--- a/caseworker/templates/case/slices/freedom-of-information.html
+++ b/caseworker/templates/case/slices/freedom-of-information.html
@@ -11,7 +11,7 @@
 				Do you agree to make the application details publicly available?
 			</td>
 			<td class="govuk-table__cell">
-				<p id="agreed-to-foi-value" class="govuk-body govuk-!-margin-0">{{ case.data.agreed_to_foi|get_agreed_to_foi_value }}</p>
+				<p id="agreed-to-foi-value" class="govuk-body govuk-!-margin-0">{{ case.data.agreed_to_foi|get_agreed_to_foi_display_value }}</p>
 				<p id="foi-reason-value" class="govuk-hint govuk-!-margin-0 govuk-!-margin-top-1" data-max-length="200">{{ case.data.foi_reason|default:"" }}</p>
 			</td>
 		</tr>

--- a/core/builtins/custom_tags.py
+++ b/core/builtins/custom_tags.py
@@ -227,7 +227,10 @@ def default_na(value):
 @register.filter()
 def get_agreed_to_foi_value(boolean):
     """
-    Returns 'No' if the boolean is equal to True, else 'Yes'
+    Returns 'No' if the boolean is equal to some variant of True, else 'Yes'.
+    This is needed as long as the agreed_to_foi model field has yet to be
+    updated in lite-api. For more context see the agreed_to_foi question in
+    exporter: exporter/applications/forms/declaration.py
     """
     if boolean is True or boolean == "true" or boolean == "True" or boolean == "yes" or boolean == "Yes":
         return "No"

--- a/core/builtins/custom_tags.py
+++ b/core/builtins/custom_tags.py
@@ -225,14 +225,14 @@ def default_na(value):
 
 
 @register.filter()
-def get_agreed_to_foi_value(boolean):
+def get_agreed_to_foi_display_value(value):
     """
-    Returns 'No' if the boolean is True, else 'Yes'.
+    Returns 'No' if the boolean value is True, else 'Yes'.
     This is needed as long as the agreed_to_foi model field has yet to be
     updated in lite-api. For more context see the agreed_to_foi question in
     exporter: exporter/applications/forms/declaration.py
     """
-    return "No" if boolean is True else "Yes"
+    return "No" if value is True else "Yes"
 
 
 @register.filter()

--- a/core/builtins/custom_tags.py
+++ b/core/builtins/custom_tags.py
@@ -227,15 +227,12 @@ def default_na(value):
 @register.filter()
 def get_agreed_to_foi_value(boolean):
     """
-    Returns 'No' if the boolean is equal to some variant of True, else 'Yes'.
+    Returns 'No' if the boolean is True, else 'Yes'.
     This is needed as long as the agreed_to_foi model field has yet to be
     updated in lite-api. For more context see the agreed_to_foi question in
     exporter: exporter/applications/forms/declaration.py
     """
-    if boolean is True or boolean == "true" or boolean == "True" or boolean == "yes" or boolean == "Yes":
-        return "No"
-    else:
-        return "Yes"
+    return "No" if boolean is True else "Yes"
 
 
 @register.filter()

--- a/core/builtins/custom_tags.py
+++ b/core/builtins/custom_tags.py
@@ -225,6 +225,17 @@ def default_na(value):
 
 
 @register.filter()
+def get_agreed_to_foi_value(boolean):
+    """
+    Returns 'No' if the boolean is equal to True, else 'Yes'
+    """
+    if boolean is True or boolean == "true" or boolean == "True" or boolean == "yes" or boolean == "Yes":
+        return "No"
+    else:
+        return "Yes"
+
+
+@register.filter()
 def get_address(data):
     """
     Returns a correctly formatted address

--- a/unit_tests/caseworker/cases/test_templates.py
+++ b/unit_tests/caseworker/cases/test_templates.py
@@ -84,13 +84,13 @@ def test_good_on_application_display_quantity(data_good_on_application, quantity
 
 
 @pytest.mark.parametrize(
-    "agreed_to_foi,foi_reason",
+    ("agreed_to_foi", "agreed_to_foi_display_value", "foi_reason"),
     [
-        ("Yes", "internal details"),
-        ("No", ""),
+        ("True", "No", "internal details"),
+        ("False", "Yes", ""),
     ],
 )
-def test_foi_details_on_summary_page(data_standard_case, agreed_to_foi, foi_reason):
+def test_foi_details_on_summary_page(data_standard_case, agreed_to_foi, agreed_to_foi_display_value, foi_reason):
     case = data_standard_case["case"]
     case["data"]["agreed_to_foi"] = agreed_to_foi
     case["data"]["foi_reason"] = foi_reason
@@ -100,5 +100,5 @@ def test_foi_details_on_summary_page(data_standard_case, agreed_to_foi, foi_reas
     soup = BeautifulSoup(html, "html.parser")
     actual_foi_value = soup.find(id="agreed-to-foi-value").text
     actual_foi_reason_value = soup.find(id="foi-reason-value").text
-    assert agreed_to_foi == actual_foi_value
+    assert agreed_to_foi_display_value == actual_foi_value
     assert foi_reason == actual_foi_reason_value

--- a/unit_tests/caseworker/cases/test_templates.py
+++ b/unit_tests/caseworker/cases/test_templates.py
@@ -86,8 +86,8 @@ def test_good_on_application_display_quantity(data_good_on_application, quantity
 @pytest.mark.parametrize(
     ("agreed_to_foi", "agreed_to_foi_display_value", "foi_reason"),
     [
-        ("True", "No", "internal details"),
-        ("False", "Yes", ""),
+        (True, "No", "internal details"),
+        (False, "Yes", ""),
     ],
 )
 def test_foi_details_on_summary_page(data_standard_case, agreed_to_foi, agreed_to_foi_display_value, foi_reason):


### PR DESCRIPTION
### Aim

Updates the FOI question and answer shown in the case details tab in caseworker now that the SIEL declaration has been updated in exporter.

[LTD-906](https://uktrade.atlassian.net/browse/LTD-906)


[LTD-906]: https://uktrade.atlassian.net/browse/LTD-906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ