### PR TITLE
LTD-5153: Disable Good archive/restore temporarily

### DIFF
--- a/exporter/goods/rules.py
+++ b/exporter/goods/rules.py
@@ -27,7 +27,7 @@ rules.add_rule("can_delete_product", is_draft_product)
 
 rules.add_rule(
     "can_archive_product",
-    (is_submitted_product | is_verified_product) & ~is_archived_product,  # noqa
+    lambda _: False,  # noqa
 )
 
-rules.add_rule("can_restore_product", is_archived_product)  # noqa
+rules.add_rule("can_restore_product", lambda _: False)  # noqa

--- a/exporter/templates/goods/product-details.html
+++ b/exporter/templates/goods/product-details.html
@@ -70,9 +70,12 @@
         {% endfor %}
     </dl>
 
-    <div id="archive_history">
-        {% for item in archive_history %}
-            <p class="govuk-body govuk-!-font-size-12 govuk-!-margin-bottom-0 govuk-!-margin-top-0"> {{ item }} </p>
-        {% endfor %}
-    </div>
+    {% test_rule 'can_archive_product' request good as can_archive_product %}
+    {% if can_archive_product %}
+        <div id="archive_history">
+            {% for item in archive_history %}
+                <p class="govuk-body govuk-!-font-size-12 govuk-!-margin-bottom-0 govuk-!-margin-top-0"> {{ item }} </p>
+            {% endfor %}
+        </div>
+    {% endif %}
 {% endblock %}

--- a/unit_tests/exporter/goods/test_rules.py
+++ b/unit_tests/exporter/goods/test_rules.py
@@ -24,8 +24,8 @@ def test_can_user_delete_product_predicates(settings, rf, data_standard_case, st
     "status, is_archived, expected",
     (
         ({"key": GoodStatus.DRAFT, "value": GoodStatus.DRAFT.title()}, False, False),
-        ({"key": GoodStatus.SUBMITTED, "value": GoodStatus.SUBMITTED.title()}, False, True),
-        ({"key": GoodStatus.VERIFIED, "value": GoodStatus.VERIFIED.title()}, False, True),
+        ({"key": GoodStatus.SUBMITTED, "value": GoodStatus.SUBMITTED.title()}, False, False),
+        ({"key": GoodStatus.VERIFIED, "value": GoodStatus.VERIFIED.title()}, False, False),
         ({"key": GoodStatus.SUBMITTED, "value": GoodStatus.SUBMITTED.title()}, True, False),
         ({"key": GoodStatus.VERIFIED, "value": GoodStatus.VERIFIED.title()}, True, False),
     ),
@@ -45,8 +45,8 @@ def test_can_user_archive_product_predicates(settings, rf, data_standard_case, s
         ({"key": GoodStatus.DRAFT, "value": GoodStatus.DRAFT.title()}, False, False),
         ({"key": GoodStatus.SUBMITTED, "value": GoodStatus.SUBMITTED.title()}, False, False),
         ({"key": GoodStatus.VERIFIED, "value": GoodStatus.VERIFIED.title()}, False, False),
-        ({"key": GoodStatus.SUBMITTED, "value": GoodStatus.SUBMITTED.title()}, True, True),
-        ({"key": GoodStatus.VERIFIED, "value": GoodStatus.VERIFIED.title()}, True, True),
+        ({"key": GoodStatus.SUBMITTED, "value": GoodStatus.SUBMITTED.title()}, True, False),
+        ({"key": GoodStatus.VERIFIED, "value": GoodStatus.VERIFIED.title()}, True, False),
     ),
 )
 def test_can_user_restore_product_predicates(settings, rf, data_standard_case, status, is_archived, expected):

--- a/unit_tests/exporter/goods/views/test_archive_restore.py
+++ b/unit_tests/exporter/goods/views/test_archive_restore.py
@@ -138,7 +138,7 @@ def test_submitted_product_details_context(
     assert response.status_code == 200
     soup = BeautifulSoup(response.content, "html.parser")
 
-    assert "Archive product" in soup.find("a", {"id": "archive-good"}).text
+    assert soup.find("a", {"id": "archive-good"}) is None
     assert soup.find("a", {"id": "restore-good"}) is None
     assert soup.find("a", {"id": "delete-good"}) is None
 
@@ -153,12 +153,12 @@ def test_verified_product_details_context(
     assert response.status_code == 200
     soup = BeautifulSoup(response.content, "html.parser")
 
-    assert "Archive product" in soup.find("a", {"id": "archive-good"}).text
+    assert soup.find("a", {"id": "archive-good"}) is None
     assert soup.find("a", {"id": "restore-good"}) is None
     assert soup.find("a", {"id": "delete-good"}) is None
 
 
-def test_archive_product_asks_for_confirmation(
+def archive_product_asks_for_confirmation(
     authorized_client,
     firearm_product_details_url,
     archive_product_url,
@@ -183,7 +183,7 @@ def test_archive_product_asks_for_confirmation(
     assert soup.find("a", {"id": "cancel-id-cancel"})["href"] == firearm_product_details_url
 
 
-def test_restore_product_asks_for_confirmation(
+def restore_product_asks_for_confirmation(
     authorized_client,
     firearm_product_details_url,
     restore_product_url,
@@ -207,7 +207,7 @@ def test_restore_product_asks_for_confirmation(
     assert soup.find("a", {"id": "cancel-id-cancel"})["href"] == firearm_product_details_url
 
 
-def test_archived_product_details_context(
+def archived_product_details_context(
     authorized_client,
     firearm_product_details_url,
     mock_archived_good_with_history_get,


### PR DESCRIPTION
## Change description

Some of the recent changes breaks this feature.
This will be re-enabled after reworking all the changes (API and FE).

The options to archive/restore are linked to rules so we are just disabling the rules now.
