### PR TITLE
LTD-5136: Add confirmation page when major edit is selected

### DIFF
--- a/exporter/applications/forms/common.py
+++ b/exporter/applications/forms/common.py
@@ -82,7 +82,7 @@ class ApplicationMajorEditConfirmationForm(BaseForm):
     def get_layout_fields(self):
         return [
             HTML.p(
-                "Progress on the case will stop while you are making changes. The application will appear in your draft until you re-submit."
+                "Progress on the case will stop while you are making changes. The application will appear in your drafts until you re-submit."
             ),
             HTML.p(
                 "Re-submitting the application with changes means it will take longer to process and will have a new ECJU case reference."

--- a/exporter/applications/forms/common.py
+++ b/exporter/applications/forms/common.py
@@ -1,10 +1,11 @@
 from django import forms
 
 from crispy_forms_gds.helper import FormHelper
-from crispy_forms_gds.layout import Submit
+from crispy_forms_gds.layout import HTML, Submit
 
 from django.urls import reverse_lazy
 
+from core.common.forms import BaseForm
 from exporter.applications.forms.edit import told_by_an_official_form, reference_name_form
 from exporter.core.constants import STANDARD
 from lite_content.lite_exporter_frontend import strings
@@ -77,3 +78,35 @@ class EditApplicationForm(forms.Form):
         super().__init__(*args, **kwargs)
         self.helper = FormHelper()
         self.helper.add_input(Submit("submit", "Continue"))
+
+
+class ApplicationMajorEditConfirmationForm(BaseForm):
+    class Layout:
+        TITLE = "Are you sure you want to open your application for editing?"
+
+    def __init__(self, *args, application_reference, cancel_url, **kwargs):
+        self.application_reference = application_reference
+        self.cancel_url = cancel_url
+        super().__init__(*args, **kwargs)
+
+    def get_layout_fields(self):
+        return [
+            HTML.p(
+                "Progress on the case will stop while you are making changes. The application will appear in your draft until you re-submit."
+            ),
+            HTML.p(
+                "Re-submitting the application with changes means it will take longer to process and will have a new ECJU case reference."
+            ),
+            HTML.p(f"Your own application reference '{self.application_reference}' will remain the same."),
+        ]
+
+    def get_layout_actions(self):
+        layout_actions = super().get_layout_actions()
+
+        layout_actions.append(
+            HTML(
+                f'<a class="govuk-button govuk-button--secondary" href="{self.cancel_url}" id="cancel-id-cancel">Cancel</a>'
+            ),
+        )
+
+        return layout_actions

--- a/exporter/applications/rules.py
+++ b/exporter/applications/rules.py
@@ -2,6 +2,7 @@ import dateparser
 import rules
 
 from datetime import datetime
+from django.conf import settings
 
 from exporter.applications.services import get_status_properties
 from exporter.applications.constants import ApplicationStatus
@@ -59,6 +60,11 @@ def can_invoke_major_editable(request, application):
     return application and status_props["can_invoke_major_editable"]
 
 
+@rules.predicate
+def is_major_edit_whitelisted_organisation(request, application):
+    return application and application["organisation"]["id"] in settings.FEATURE_AMENDMENT_BY_COPY_EXPORTER_IDS
+
+
 rules.add_rule(
     "can_user_appeal_case",
     is_application_finalised & is_application_refused & appeal_within_deadline & ~is_application_appealed,  # noqa
@@ -74,4 +80,9 @@ rules.add_rule("can_edit_quantity_value", is_application_in_draft | is_applicati
 rules.add_rule(
     "can_invoke_major_editable",
     can_invoke_major_editable,
+)
+
+rules.add_rule(
+    "is_major_edit_whitelisted_organisation",
+    is_major_edit_whitelisted_organisation,
 )

--- a/exporter/applications/rules.py
+++ b/exporter/applications/rules.py
@@ -61,7 +61,7 @@ def can_invoke_major_editable(request, application):
 
 
 @rules.predicate
-def is_major_edit_whitelisted_organisation(request, application):
+def can_amend_by_copy(request, application):
     return application and application["organisation"]["id"] in settings.FEATURE_AMENDMENT_BY_COPY_EXPORTER_IDS
 
 
@@ -83,6 +83,6 @@ rules.add_rule(
 )
 
 rules.add_rule(
-    "is_major_edit_whitelisted_organisation",
-    is_major_edit_whitelisted_organisation,
+    "can_amend_by_copy",
+    can_amend_by_copy,
 )

--- a/exporter/applications/templates/edit_application_form.html
+++ b/exporter/applications/templates/edit_application_form.html
@@ -13,7 +13,6 @@
 
   <h1 class="govuk-heading-l">How do you want to edit the application?</h1>
   <p class="govuk-hint">
-    If you make changes, it will take longer to process your application.<br>
     You cannot edit a product, only add a new one or remove an existing one.
   </p>
   <div class="govuk-body govuk-!-margin-bottom-4">

--- a/exporter/applications/urls.py
+++ b/exporter/applications/urls.py
@@ -64,6 +64,7 @@ urlpatterns = [
     path("<uuid:pk>/submit-success/", common.ApplicationSubmitSuccessPage.as_view(), name="success_page"),
     path("<uuid:pk>/hcsat/<uuid:sid>/", HCSATApplicationPage.as_view(), name="application-hcsat"),
     path("<uuid:pk>/edit-type/", common.ApplicationEditType.as_view(), name="edit_type"),
+    path("<uuid:pk>/major-edit-confirm/", common.ApplicationMajorEditConfirmView.as_view(), name="major_edit_confirm"),
     path("<uuid:pk>/check-your-answers/", common.CheckYourAnswers.as_view(), name="check_your_answers"),
     path("<uuid:pk>/submit/", common.Submit.as_view(), name="submit"),
     path("<uuid:pk>/copy/", common.ApplicationCopy.as_view(), name="copy"),

--- a/exporter/applications/views/common.py
+++ b/exporter/applications/views/common.py
@@ -177,6 +177,12 @@ class ApplicationMajorEditConfirmView(ApplicationMixin, FormView):
     template_name = "core/form.html"
     amended_application_id = None
 
+    def dispatch(self, request, **kwargs):
+        if not can_amend_by_copy(request, self.application):
+            raise Http404()
+
+        return super().dispatch(request, **kwargs)
+
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
         kwargs["application_reference"] = self.application["name"]
@@ -202,8 +208,6 @@ class ApplicationMajorEditConfirmView(ApplicationMixin, FormView):
         return create_application_amendment(self.request, self.application_id)
 
     def handle_major_edit(self):
-        if not can_amend_by_copy(self.request, self.application):
-            raise ValueError
 
         data, _ = self.create_amendment()
         self.amended_application_id = data["id"]

--- a/exporter/applications/views/common.py
+++ b/exporter/applications/views/common.py
@@ -152,8 +152,13 @@ class ApplicationEditType(ApplicationMixin, FormView):
     def get_success_url(self):
         return self.get_application_task_list_url(self.application_id)
 
+    @expect_status(
+        HTTPStatus.OK,
+        "Error updating status",
+        "Unexpected error changing application status to APPLICANT_EDITING",
+    )
     def handle_major_edit(self):
-        set_application_status(self.request, self.application_id, APPLICANT_EDITING)
+        return set_application_status(self.request, self.application_id, APPLICANT_EDITING)
 
     def form_valid(self, form):
 

--- a/exporter/applications/views/common.py
+++ b/exporter/applications/views/common.py
@@ -33,7 +33,7 @@ from exporter.applications.helpers.validators import (
     validate_delete_draft,
     validate_surrender_application_and_update_case_status,
 )
-from exporter.applications.rules import is_major_edit_whitelisted_organisation
+from exporter.applications.rules import can_amend_by_copy
 from exporter.applications.services import (
     get_activity,
     get_applications,
@@ -197,7 +197,7 @@ class ApplicationMajorEditConfirmView(ApplicationMixin, FormView):
         return create_application_amendment(self.request, self.application_id)
 
     def handle_major_edit(self):
-        if not is_major_edit_whitelisted_organisation(self.request, self.application):
+        if not can_amend_by_copy(self.request, self.application):
             raise ValueError
 
         data, _ = self.create_amendment()

--- a/exporter/templates/applications/application.html
+++ b/exporter/templates/applications/application.html
@@ -37,9 +37,16 @@
 					{% endif %}
 					{% test_rule 'can_invoke_major_editable' request application as can_invoke_major_editable %}
 					{% if can_invoke_major_editable %}
-						<a href="{% url 'applications:edit_type' application.id %}" id="button-edit-application" class="govuk-button govuk-button--secondary">
-							{% lcs 'applications.ApplicationSummaryPage.Buttons.EDIT_APPLICATION_BUTTON' %}
-						</a>
+						{% test_rule 'is_major_edit_whitelisted_organisation' request application as is_major_edit_whitelisted_organisation %}
+						{% if is_major_edit_whitelisted_organisation %}
+							<a href="{% url 'applications:major_edit_confirm' application.id %}" id="button-edit-application" class="govuk-button govuk-button--secondary">
+								{% lcs 'applications.ApplicationSummaryPage.Buttons.EDIT_APPLICATION_BUTTON' %}
+							</a>
+						{% else %}
+							<a href="{% url 'applications:edit_type' application.id %}" id="button-edit-application" class="govuk-button govuk-button--secondary">
+								{% lcs 'applications.ApplicationSummaryPage.Buttons.EDIT_APPLICATION_BUTTON' %}
+							</a>
+						{% endif %}
 					{% endif %}
 					{# Using licence_duration to check that there is a licence to surrender #}
 					{% if application.licence and application.licence.status.key != "surrendered" %}

--- a/exporter/templates/applications/application.html
+++ b/exporter/templates/applications/application.html
@@ -37,8 +37,8 @@
 					{% endif %}
 					{% test_rule 'can_invoke_major_editable' request application as can_invoke_major_editable %}
 					{% if can_invoke_major_editable %}
-						{% test_rule 'is_major_edit_whitelisted_organisation' request application as is_major_edit_whitelisted_organisation %}
-						{% if is_major_edit_whitelisted_organisation %}
+						{% test_rule 'can_amend_by_copy' request application as can_amend_by_copy %}
+						{% if can_amend_by_copy %}
 							<a href="{% url 'applications:major_edit_confirm' application.id %}" id="button-edit-application" class="govuk-button govuk-button--secondary">
 								{% lcs 'applications.ApplicationSummaryPage.Buttons.EDIT_APPLICATION_BUTTON' %}
 							</a>

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -559,6 +559,7 @@ def data_open_case():
 
 @pytest.fixture
 def data_standard_case(
+    data_organisation,
     wassenaar_regime_entry,
     mtcr_regime_entry,
     nsg_regime_entry,
@@ -659,7 +660,7 @@ def data_standard_case(
                 "id": "8fb76bed-fd45-4293-95b8-eda9468aa254",
                 "name": "444",
                 "organisation": {
-                    "id": "b7175103-d0ae-4b59-9c6a-190a2ed7f5e7",
+                    "id": data_organisation["id"],
                     "documents": [],
                     "primary_site": {
                         "id": "c86d3df2-5f48-40cd-a720-e76322df71a9",

--- a/unit_tests/exporter/applications/forms/test_amendments.py
+++ b/unit_tests/exporter/applications/forms/test_amendments.py
@@ -1,0 +1,11 @@
+from exporter.applications.forms.common import ApplicationMajorEditConfirmationForm
+
+
+def test_application_major_edit_confirm_form():
+    form = ApplicationMajorEditConfirmationForm(
+        data={},
+        application_reference="your reference",
+        cancel_url="",
+    )
+    assert form.is_valid() is True
+    assert form.errors == {}

--- a/unit_tests/exporter/applications/test_rules.py
+++ b/unit_tests/exporter/applications/test_rules.py
@@ -90,17 +90,17 @@ def test_user_can_edit_quantity_value(settings, rf, data_standard_case, status, 
     assert rules.test_rule("can_edit_quantity_value", request, application) is expected
 
 
-def test_is_major_edit_whitelisted_organisation_success(settings, rf, data_standard_case, data_organisation):
+def test_can_amend_by_copy_organisation_success(settings, rf, data_standard_case, data_organisation):
     settings.FEATURE_AMENDMENT_BY_COPY_EXPORTER_IDS = [data_organisation["id"]]
 
     application = Application(data_standard_case["case"]["data"])
 
     request = rf.get("/")
-    assert rules.test_rule("is_major_edit_whitelisted_organisation", request, application)
+    assert rules.test_rule("can_amend_by_copy", request, application)
 
 
-def test_is_major_edit_whitelisted_organisation_fail(settings, rf, data_standard_case):
+def test_can_amend_by_copy_organisation_fail(settings, rf, data_standard_case):
     application = Application(data_standard_case["case"]["data"])
 
     request = rf.get("/")
-    assert not rules.test_rule("is_major_edit_whitelisted_organisation", request, application)
+    assert not rules.test_rule("can_amend_by_copy", request, application)

--- a/unit_tests/exporter/applications/test_rules.py
+++ b/unit_tests/exporter/applications/test_rules.py
@@ -3,6 +3,7 @@ import rules
 
 from datetime import timedelta
 
+from django.conf import settings
 from django.utils import timezone
 
 from exporter.applications import rules as appeal_rules
@@ -88,3 +89,19 @@ def test_user_can_edit_quantity_value(settings, rf, data_standard_case, status, 
 
     request = rf.get("/")
     assert rules.test_rule("can_edit_quantity_value", request, application) is expected
+
+
+def test_is_major_edit_whitelisted_organisation_success(settings, rf, data_standard_case, data_organisation):
+    settings.FEATURE_AMENDMENT_BY_COPY_EXPORTER_IDS = [data_organisation["id"]]
+
+    application = Application(data_standard_case["case"]["data"])
+
+    request = rf.get("/")
+    assert rules.test_rule("is_major_edit_whitelisted_organisation", request, application)
+
+
+def test_is_major_edit_whitelisted_organisation_fail(settings, rf, data_standard_case):
+    application = Application(data_standard_case["case"]["data"])
+
+    request = rf.get("/")
+    assert not rules.test_rule("is_major_edit_whitelisted_organisation", request, application)

--- a/unit_tests/exporter/applications/views/conftest.py
+++ b/unit_tests/exporter/applications/views/conftest.py
@@ -56,6 +56,12 @@ def mock_application_status_put(requests_mock, application_id):
 
 
 @pytest.fixture
+def mock_application_status_put_failure(requests_mock, application_id):
+    url = client._build_absolute_uri(f"/applications/{application_id}/status/")
+    return requests_mock.put(url=url, json={"error": "unexpected error"}, status_code=500)
+
+
+@pytest.fixture
 def mock_good_get(requests_mock, data_standard_case):
     good = data_standard_case["case"]["data"]["goods"][0]
     good["good"].update(

--- a/unit_tests/exporter/applications/views/conftest.py
+++ b/unit_tests/exporter/applications/views/conftest.py
@@ -595,5 +595,10 @@ def application_task_list_url(application_id):
 
 
 @pytest.fixture
+def application_major_edit_existing_confirm_url(application_id):
+    return reverse(f"applications:edit_type", kwargs={"pk": application_id})
+
+
+@pytest.fixture
 def application_major_edit_confirm_url(application_id):
     return reverse(f"applications:major_edit_confirm", kwargs={"pk": application_id})

--- a/unit_tests/exporter/applications/views/conftest.py
+++ b/unit_tests/exporter/applications/views/conftest.py
@@ -13,6 +13,11 @@ from core.constants import (
 
 
 @pytest.fixture
+def application_id(data_standard_case):
+    return data_standard_case["case"]["data"]["id"]
+
+
+@pytest.fixture
 def application(data_standard_case):
     return data_standard_case["case"]["data"]
 
@@ -42,6 +47,12 @@ def mock_application_put(requests_mock, data_standard_case):
     application = data_standard_case["case"]["data"]
     url = client._build_absolute_uri(f'/applications/{application["id"]}/')
     return requests_mock.put(url=url, json=application)
+
+
+@pytest.fixture
+def mock_application_status_put(requests_mock, application_id):
+    url = client._build_absolute_uri(f"/applications/{application_id}/status/")
+    return requests_mock.put(url=url, json={})
 
 
 @pytest.fixture
@@ -571,3 +582,18 @@ def technology_on_application_summary_url_factory(application, good_on_applicati
 @pytest.fixture
 def technology_on_application_summary_url(technology_on_application_summary_url_factory):
     return technology_on_application_summary_url_factory("technology-on-application-summary")
+
+
+@pytest.fixture
+def application_edit_type_url(application_id):
+    return reverse(f"applications:edit_type", kwargs={"pk": application_id})
+
+
+@pytest.fixture
+def application_task_list_url(application_id):
+    return reverse("applications:task_list", kwargs={"pk": application_id})
+
+
+@pytest.fixture
+def application_major_edit_confirm_url(application_id):
+    return reverse(f"applications:major_edit_confirm", kwargs={"pk": application_id})

--- a/unit_tests/exporter/applications/views/test_amendments.py
+++ b/unit_tests/exporter/applications/views/test_amendments.py
@@ -1,0 +1,115 @@
+import pytest
+import uuid
+
+from bs4 import BeautifulSoup
+from django.conf import settings
+from django.urls import reverse
+
+from core import client
+from exporter.applications.forms.common import EditApplicationForm
+
+amended_application_id = str(uuid.uuid4())
+
+
+@pytest.fixture
+def application_major_edit_cancel_url(application_id):
+    return reverse("applications:edit_type", kwargs={"pk": application_id})
+
+
+@pytest.fixture
+def application_amendment_create_url(application_id):
+    return client._build_absolute_uri(f"/applications/{application_id}/amendment/")
+
+
+@pytest.fixture
+def amended_application_task_list_url():
+    return reverse("applications:task_list", kwargs={"pk": amended_application_id})
+
+
+@pytest.fixture
+def mock_application_amendment_post(requests_mock, application_id):
+    url = client._build_absolute_uri(f"/applications/{application_id}/amendment/")
+    return requests_mock.post(url, json={"id": amended_application_id}, status_code=201)
+
+
+@pytest.fixture
+def mock_application_amendment_post_failure(requests_mock, application_id):
+    url = client._build_absolute_uri(f"/applications/{application_id}/amendment/")
+    return requests_mock.post(url, json={"error": "not allowed"}, status_code=500)
+
+
+def test_major_edit_redirects_to_confirm_page_for_whitelisted_organisation(
+    authorized_client,
+    data_organisation,
+    application_edit_type_url,
+    application_major_edit_confirm_url,
+):
+    settings.FEATURE_AMENDMENT_BY_COPY_EXPORTER_IDS = [data_organisation["id"]]
+    response = authorized_client.post(application_edit_type_url, {"edit_type": "major"})
+    assert response.status_code == 302
+    assert response.url == application_major_edit_confirm_url
+
+
+def test_major_edit_cancel_redirects_to_edit_type_page(
+    authorized_client,
+    mock_application_get,
+    application_major_edit_cancel_url,
+):
+    response = authorized_client.get(application_major_edit_cancel_url)
+    assert response.status_code == 200
+    assert isinstance(response.context["form"], EditApplicationForm)
+
+
+def test_major_edit_confirmation_from_whitelisted_exporter_goes_to_task_list(
+    authorized_client,
+    data_organisation,
+    application_major_edit_confirm_url,
+    amended_application_task_list_url,
+    mock_application_get,
+    mock_application_amendment_post,
+):
+    settings.FEATURE_AMENDMENT_BY_COPY_EXPORTER_IDS = [data_organisation["id"]]
+    response = authorized_client.post(application_major_edit_confirm_url)
+    assert response.status_code == 302
+    assert response.url == amended_application_task_list_url
+
+
+def test_whitelisted_organisation_creates_amendment_by_copy(
+    authorized_client,
+    requests_mock,
+    data_organisation,
+    mock_application_get,
+    mock_application_amendment_post,
+    application_major_edit_confirm_url,
+    application_amendment_create_url,
+    amended_application_task_list_url,
+):
+    settings.FEATURE_AMENDMENT_BY_COPY_EXPORTER_IDS = [data_organisation["id"]]
+    response = authorized_client.post(application_major_edit_confirm_url)
+    assert response.status_code == 302
+    assert response.url == amended_application_task_list_url
+    history = requests_mock.request_history[-2]
+    assert history.method == "POST"
+    assert history.url == application_amendment_create_url
+
+
+def test_whitelisted_organisation_creates_amendment_by_copy_bad_response(
+    settings,
+    requests_mock,
+    authorized_client,
+    data_organisation,
+    application_major_edit_confirm_url,
+    application_amendment_create_url,
+    mock_application_get,
+    mock_application_amendment_post_failure,
+):
+    settings.FEATURE_AMENDMENT_BY_COPY_EXPORTER_IDS = [data_organisation["id"]]
+    response = authorized_client.post(application_major_edit_confirm_url)
+    assert response.status_code == 200
+
+    response_body = BeautifulSoup(response.content, "html.parser")
+    assert "Unexpected error creating amendment" in response_body.text
+
+    history = requests_mock.request_history.pop()
+    assert history.method == "POST"
+    assert history.url == application_amendment_create_url

--- a/unit_tests/exporter/applications/views/test_amendments.py
+++ b/unit_tests/exporter/applications/views/test_amendments.py
@@ -179,5 +179,5 @@ def test_regular_organisation_creates_amendment_by_copy_failure(
     authorized_client,
     application_major_edit_confirm_url,
 ):
-    with pytest.raises(ValueError):
-        authorized_client.post(application_major_edit_confirm_url)
+    response = authorized_client.post(application_major_edit_confirm_url)
+    assert response.status_code == 404

--- a/unit_tests/exporter/applications/views/test_edit_application.py
+++ b/unit_tests/exporter/applications/views/test_edit_application.py
@@ -1,13 +1,9 @@
-from bs4 import BeautifulSoup
-import uuid
 import pytest
 
-
 from django.urls import reverse
-from core import client
 
-from exporter.applications.forms.common import EditApplicationForm
 from exporter.core.constants import APPLICANT_EDITING
+from exporter.applications.forms.common import EditApplicationForm
 
 
 @pytest.mark.parametrize(
@@ -15,10 +11,8 @@ from exporter.core.constants import APPLICANT_EDITING
     (("edit_type", EditApplicationForm),),
 )
 def test_edit_application_view_exists(
-    data_standard_case, mock_application_get, authorized_client, url_name, form_class, requests_mock
+    application_id, mock_application_get, authorized_client, url_name, form_class, requests_mock
 ):
-    application_id = data_standard_case["case"]["data"]["id"]
-
     url = reverse(f"applications:{url_name}", kwargs={"pk": application_id})
     response = authorized_client.get(url)
     assert response.status_code == 200
@@ -27,58 +21,31 @@ def test_edit_application_view_exists(
     assert isinstance(form, form_class)
 
 
-def test_edit_application_form_valid_major_edit(requests_mock, authorized_client, data_standard_case):
-    application_id = data_standard_case["case"]["data"]["id"]
+def test_edit_application_form_valid_major_edit(
+    requests_mock, authorized_client, application_id, application_task_list_url, mock_application_status_put
+):
     url = reverse("applications:edit_type", kwargs={"pk": application_id})
-
-    status_url = f"/applications/{application_id}/status/"
-    requests_mock.put(status_url, json={}, status_code=200)
     form_data = {"edit_type": "major"}
     response = authorized_client.post(url, form_data)
 
     assert response.status_code == 302
-    assert response.url == reverse("applications:task_list", kwargs={"pk": application_id})
+    assert response.url == application_task_list_url
 
-    assert requests_mock.last_request.json() == {"status": "applicant_editing"}
+    history = requests_mock.request_history[-2]
+    assert history.method == "PUT"
+    assert history.json() == {"status": APPLICANT_EDITING}
 
 
 def test_edit_application_form_valid_major_edit_by_copy(
     settings,
-    requests_mock,
     authorized_client,
-    data_standard_case,
+    application_id,
     data_organisation,
+    application_major_edit_confirm_url,
 ):
     settings.FEATURE_AMENDMENT_BY_COPY_EXPORTER_IDS = [data_organisation["id"]]
-    application_id = data_standard_case["case"]["data"]["id"]
     url = reverse("applications:edit_type", kwargs={"pk": application_id})
-
-    amendment_url = f"/applications/{application_id}/amendment/"
-    synthetic_amendment_id = str(uuid.uuid4())
-    requests_mock.post(amendment_url, json={"id": synthetic_amendment_id}, status_code=201)
     response = authorized_client.post(url, {"edit_type": "major"})
 
     assert response.status_code == 302
-    assert response.url == reverse("applications:task_list", kwargs={"pk": synthetic_amendment_id})
-    assert requests_mock.last_request.json() == {}
-
-
-def test_edit_application_form_valid_major_edit_by_copy_bad_api_response(
-    settings,
-    requests_mock,
-    authorized_client,
-    data_standard_case,
-    data_organisation,
-):
-    settings.FEATURE_AMENDMENT_BY_COPY_EXPORTER_IDS = [data_organisation["id"]]
-    application_id = data_standard_case["case"]["data"]["id"]
-    url = reverse("applications:edit_type", kwargs={"pk": application_id})
-
-    amendment_url = f"/applications/{application_id}/amendment/"
-    synthetic_amendment_id = str(uuid.uuid4())
-    requests_mock.post(amendment_url, json={"error": "some whoops"}, status_code=500)
-    response = authorized_client.post(url, {"edit_type": "major"})
-    response_body = BeautifulSoup(response.content, "html.parser")
-
-    assert response.status_code == 200
-    assert "An error occurred" in response_body.text
+    assert response.url == application_major_edit_confirm_url

--- a/unit_tests/exporter/applications/views/test_edit_application.py
+++ b/unit_tests/exporter/applications/views/test_edit_application.py
@@ -25,13 +25,12 @@ def test_edit_application_form_valid_major_edit(
     requests_mock, authorized_client, application_id, application_task_list_url, mock_application_status_put
 ):
     url = reverse("applications:edit_type", kwargs={"pk": application_id})
-    form_data = {"edit_type": "major"}
-    response = authorized_client.post(url, form_data)
+    response = authorized_client.post(url, {})
 
     assert response.status_code == 302
     assert response.url == application_task_list_url
 
-    history = requests_mock.request_history[-2]
+    history = requests_mock.request_history.pop()
     assert history.method == "PUT"
     assert history.json() == {"status": APPLICANT_EDITING}
 
@@ -41,11 +40,12 @@ def test_edit_application_form_valid_major_edit_by_copy(
     authorized_client,
     application_id,
     data_organisation,
-    application_major_edit_confirm_url,
+    application_task_list_url,
+    mock_application_status_put,
 ):
     settings.FEATURE_AMENDMENT_BY_COPY_EXPORTER_IDS = [data_organisation["id"]]
     url = reverse("applications:edit_type", kwargs={"pk": application_id})
-    response = authorized_client.post(url, {"edit_type": "major"})
+    response = authorized_client.post(url, {})
 
     assert response.status_code == 302
-    assert response.url == application_major_edit_confirm_url
+    assert response.url == application_task_list_url


### PR DESCRIPTION
## Change description

Major edit creates a new application by copying the current application. This is enabled for specific exporters and in such cases we ask for their confirmation before creating amendment. This PR adds this new confirmation page for these exporters.

All other exporters see existing confirmation page which follows existing way of doing major edits.

Add tests that check for each category and ensure they redirect to correct success urls in each case.

[LTD-5136](https://uktrade.atlassian.net/browse/LTD-5136)


[LTD-5136]: https://uktrade.atlassian.net/browse/LTD-5136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ