### PR TITLE
LTD-5159: Fix back links on Archive/restore confirmation pages

### DIFF
--- a/exporter/goods/common/views.py
+++ b/exporter/goods/common/views.py
@@ -25,6 +25,13 @@ class GoodArchiveRestoreBaseView(LoginRequiredMixin, FormView):
         kwargs["cancel_url"] = self.get_good_detail_url()
         return kwargs
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        return {
+            **context,
+            "back_link_url": self.get_good_detail_url(),
+        }
+
     @expect_status(
         HTTPStatus.OK,
         "Error retrieving good",

--- a/unit_tests/exporter/goods/views/test_archive_restore.py
+++ b/unit_tests/exporter/goods/views/test_archive_restore.py
@@ -181,6 +181,7 @@ def test_archive_product_asks_for_confirmation(
     ]
     assert soup.find("input", {"id": "submit-id-submit"})["value"] == "Archive product"
     assert soup.find("a", {"id": "cancel-id-cancel"})["href"] == firearm_product_details_url
+    assert soup.find("a", {"id": "back-link"})["href"] == firearm_product_details_url
 
 
 def test_restore_product_asks_for_confirmation(
@@ -205,6 +206,7 @@ def test_restore_product_asks_for_confirmation(
     ]
     assert soup.find("input", {"id": "submit-id-submit"})["value"] == "Restore product"
     assert soup.find("a", {"id": "cancel-id-cancel"})["href"] == firearm_product_details_url
+    assert soup.find("a", {"id": "back-link"})["href"] == firearm_product_details_url
 
 
 def test_archived_product_details_context(


### PR DESCRIPTION
## Change description

Fix back links on the confirmation page to point to product detail page.

[LTD-5159](https://uktrade.atlassian.net/browse/LTD-5159)


[LTD-5159]: https://uktrade.atlassian.net/browse/LTD-5159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ