### PR TITLE
LTD 5246 add license status change rules

### DIFF
--- a/caseworker/core/rules.py
+++ b/caseworker/core/rules.py
@@ -92,3 +92,4 @@ rules.add_rule("can_user_add_contact", is_user_allocated)
 rules.add_rule("can_user_change_sub_status", is_user_allocated & has_available_sub_statuses)
 rules.add_rule("can_user_search_products", is_user_in_admin_team | is_user_in_tau_team)  # noqa
 rules.add_rule("can_user_rerun_routing_rules", rules.always_deny)
+rules.add_rule("can_licence_status_be_changed", is_case_finalised & is_licence_status_able_to_be_changed)

--- a/caseworker/core/rules.py
+++ b/caseworker/core/rules.py
@@ -71,7 +71,7 @@ def case_is_nlr(request, case):
 
 
 @rules.predicate
-def is_case_finalised(request, case):
+def is_case_finalised_or_withdrawn(request, case):
     return case["status"] in ["finalised", "withdrawn"]
 
 
@@ -92,4 +92,5 @@ rules.add_rule("can_user_add_contact", is_user_allocated)
 rules.add_rule("can_user_change_sub_status", is_user_allocated & has_available_sub_statuses)
 rules.add_rule("can_user_search_products", is_user_in_admin_team | is_user_in_tau_team)  # noqa
 rules.add_rule("can_user_rerun_routing_rules", rules.always_deny)
-rules.add_rule("can_licence_status_be_changed", is_case_finalised & is_licence_status_able_to_be_changed)
+rules.add_rule("can_licence_status_be_changed_on_case", is_case_finalised_or_withdrawn)
+rules.add_rule("can_licence_status_be_changed", is_licence_status_able_to_be_changed)

--- a/caseworker/core/rules.py
+++ b/caseworker/core/rules.py
@@ -70,6 +70,16 @@ def case_is_nlr(request, case):
     return has_flag(case, GOODS_NOT_LISTED_ID)
 
 
+@rules.predicate
+def is_case_finalised(request, case):
+    return case["status"] in ["finalised", "withdrawn"]
+
+
+@rules.predicate
+def is_licence_status_able_to_be_changed(request, licence):
+    return licence["status"] in ["issued", "reinstated", "suspended"]
+
+
 rules.add_rule("can_user_change_case", is_user_allocated)
 rules.add_rule("can_user_move_case_forward", is_user_allocated)
 rules.add_rule("can_user_review_and_countersign", is_user_allocated)

--- a/unit_tests/caseworker/core/test_rules.py
+++ b/unit_tests/caseworker/core/test_rules.py
@@ -67,7 +67,7 @@ def get_mock_request(client):
 )
 def test_is_user_assigned(data, mock_gov_user, get_mock_request, expected_result):
     assigned_users = {"assigned_users": data}
-    assert caseworker_rules.is_user_assigned(get_mock_request(mock_gov_user["user"]), assigned_users) == expected_result
+    assert caseworker_rules.is_user_assigned(get_mock_request(mock_gov_user["user"]), assigned_users) is expected_result
 
 
 def test_is_user_assigned_request_missing_attribute():
@@ -97,7 +97,7 @@ def test_is_user_case_officer_none(get_mock_request):
     ),
 )
 def test_is_user_case_officer(data, mock_gov_user, get_mock_request, expected_result):
-    assert caseworker_rules.is_user_case_officer(get_mock_request(mock_gov_user["user"]), data) == expected_result
+    assert caseworker_rules.is_user_case_officer(get_mock_request(mock_gov_user["user"]), data) is expected_result
 
 
 def test_is_user_case_officer_request_missing_attribute():
@@ -167,7 +167,7 @@ def test_user_assignment_based_rules(data, mock_gov_user, get_mock_request, expe
         "can_user_add_contact",
         "can_user_change_sub_status",
     ):
-        assert rules.test_rule(rule_name, get_mock_request(mock_gov_user["user"]), data) == expected_result
+        assert rules.test_rule(rule_name, get_mock_request(mock_gov_user["user"]), data) is expected_result
 
 
 @pytest.mark.parametrize(
@@ -270,7 +270,7 @@ def test_can_user_search_products(mock_gov_user, get_mock_request, mock_gov_user
 
     request = get_mock_request(user)
 
-    assert rules.test_rule("can_user_search_products", request) == expected
+    assert rules.test_rule("can_user_search_products", request) is expected
 
 
 @pytest.mark.parametrize(
@@ -297,7 +297,7 @@ def test_can_assigned_user_assess_products(mock_gov_user, get_mock_request, mock
 
     request = get_mock_request(user)
 
-    assert rules.test_rule("can_user_assess_products", request, case) == expected
+    assert rules.test_rule("can_user_assess_products", request, case) is expected
 
 
 @pytest.mark.parametrize(
@@ -324,7 +324,7 @@ def test_can_unassigned_user_assess_products(mock_gov_user, get_mock_request, mo
 
     request = get_mock_request(user)
 
-    assert rules.test_rule("can_user_assess_products", request, case) == expected
+    assert rules.test_rule("can_user_assess_products", request, case) is expected
 
 
 @pytest.mark.parametrize(
@@ -391,7 +391,7 @@ def test_can_user_review_and_combine_based_on_allocation(mock_gov_user, get_mock
     user = mock_gov_user["user"]
     request = get_mock_request(user)
 
-    assert rules.test_rule("can_user_review_and_combine", request, case) == expected_result
+    assert rules.test_rule("can_user_review_and_combine", request, case) is expected_result
 
 
 @pytest.mark.parametrize(
@@ -427,7 +427,7 @@ def test_can_user_review_and_combine_based_on_advice(mock_gov_user, get_mock_req
     user = mock_gov_user["user"]
     request = get_mock_request(user)
 
-    assert rules.test_rule("can_user_review_and_combine", request, case) == expected
+    assert rules.test_rule("can_user_review_and_combine", request, case) is expected
 
 
 def test_can_user_rerun_routing_rules(get_mock_request):
@@ -435,3 +435,45 @@ def test_can_user_rerun_routing_rules(get_mock_request):
     user = {}
     request = get_mock_request(user)
     assert not rules.test_rule("can_user_rerun_routing_rules", request, case)
+
+
+@pytest.mark.parametrize(
+    ("case_status", "expected"),
+    (
+        ("finalised", True),
+        ("withdrawn", True),
+        ("under_review", False),
+        ("revoked", False),
+        ("open", False),
+        ("draft", False),
+    ),
+)
+def test_can_licence_status_be_changed_on_case(mock_gov_user, get_mock_request, case_status, expected):
+    case = {
+        "status": case_status,
+    }
+    user = mock_gov_user["user"]
+    request = get_mock_request(user)
+
+    assert rules.test_rule("can_licence_status_be_changed_on_case", request, case) is expected
+
+
+@pytest.mark.parametrize(
+    ("licence_status", "expected"),
+    (
+        ("issued", True),
+        ("reinstated", True),
+        ("suspended", True),
+        ("expired", False),
+        ("exhausted", False),
+        ("cancelled", False),
+    ),
+)
+def test_can_licence_status_be_changed(mock_gov_user, get_mock_request, licence_status, expected):
+    licence = {
+        "status": licence_status,
+    }
+    user = mock_gov_user["user"]
+    request = get_mock_request(user)
+
+    assert rules.test_rule("can_licence_status_be_changed", request, licence) is expected


### PR DESCRIPTION
### Aim

Add rules to check whether a case in in the correct state to allow a licence status to be changed and to check whether licence status can be changed so that this maybe be checked in views/forms to only those licences and cases that we want will be impacted.

Original ticket mentions 'a permission' but thought it better to check each object separately and then the rules can be checked in the views as needed.

[LTD-5246](https://uktrade.atlassian.net/browse/LTD-5246)
