### PR TITLE
[LTD-5257] Conditionally show edit link in RFI response page.

### DIFF
--- a/exporter/ecju_queries/ecju_forms.py
+++ b/exporter/ecju_queries/ecju_forms.py
@@ -4,7 +4,6 @@ from django.template.loader import render_to_string
 
 from crispy_forms_gds.layout import HTML, Button
 from django.template.defaultfilters import linebreaksbr
-from django.urls import reverse
 
 
 class ECJUQueryRespondForm(BaseForm):
@@ -23,6 +22,7 @@ class ECJUQueryRespondForm(BaseForm):
         documents,
         case_id,
         ecju_response,
+        edit_url,
         *args,
         **kwargs,
     ):
@@ -31,6 +31,7 @@ class ECJUQueryRespondForm(BaseForm):
         self.case_id = case_id
         self.ecju_response = ecju_response
         self.documents = documents
+        self.edit_url = edit_url
 
         self.declared_fields["response"] = forms.CharField(
             initial=self.ecju_response,
@@ -42,15 +43,22 @@ class ECJUQueryRespondForm(BaseForm):
         super().__init__(*args, **kwargs)
 
     def get_layout_fields(self):
-        edit_type_url = reverse("applications:edit_type", kwargs={"pk": self.case_id})
+
+        reply_html = HTML(
+            "<ol><li>Write a response message below.</li>"
+            + "<li>Then select 'Continue' to notify the case worker that the query has been answered.</li></ol>"
+        )
+        if self.edit_url:
+            reply_html = HTML(
+                f'<ol><li><a class="govuk-link govuk-link--no-visited-state application-edit-link" href="{self.edit_url}">'
+                + "Edit and submit your application</a> as required, or send a written message below.</li>"
+                + "<li>Then select 'Continue' to notify the case worker that the query has been answered.</li></ol>"
+            )
+
         return [
             HTML.p(f'<div class="app-ecju-query__text"> {linebreaksbr(self.ecju_query["question"]) }</div>'),
             HTML.p("Your application will be paused until the case worker receives a response. To reply: "),
-            HTML(
-                f'<ol><li><a class="govuk-link govuk-link--no-visited-state" href="{edit_type_url}">'
-                + "Edit and submit your application</a> as required, or send a written message below.</li>"
-                + "<li>Then select 'Continue' to notify the case worker that the query has been answered.</li></ol>"
-            ),
+            reply_html,
             "response",
             HTML.p("<div class=" "govuk-hint" ">You can enter up to 2200 characters</div>"),
             HTML.h2("Documents"),

--- a/exporter/ecju_queries/ecju_views.py
+++ b/exporter/ecju_queries/ecju_views.py
@@ -1,5 +1,6 @@
 from functools import cached_property
 
+import rules
 from django.shortcuts import redirect
 from core.auth.views import LoginRequiredMixin
 from exporter.ecju_queries.ecju_forms import ECJUQueryRespondForm, ECJUQueryRespondConfirmForm
@@ -7,6 +8,7 @@ from exporter.ecju_queries.ecju_forms import ECJUQueryRespondForm, ECJUQueryResp
 from django.views.generic import FormView
 from django.urls import reverse_lazy, reverse
 
+from exporter.applications.services import get_application
 from exporter.ecju_queries.services import get_ecju_query, get_ecju_query_documents, put_ecju_query
 
 
@@ -14,6 +16,10 @@ class ECJURespondMixin:
     @cached_property
     def case_id(self):
         return str(self.kwargs["case_pk"])
+
+    @cached_property
+    def application(self):
+        return get_application(self.request, self.case_id)
 
     @cached_property
     def ecju_query_id(self):
@@ -56,12 +62,22 @@ class ECJURespondQueryView(LoginRequiredMixin, ECJURespondMixin, FormView):
     # This is required because of some legacy code that depends on object_type when adding a document
     OBJECT_TYPE = "application"
 
+    def get_edit_url(self):
+        if not rules.test_rule("can_invoke_major_editable", self.request, self.application):
+            return None
+
+        if rules.test_rule("can_amend_by_copy", self.request, self.application):
+            return reverse("applications:major_edit_confirm", kwargs={"pk": self.case_id})
+
+        return reverse("applications:edit_type", kwargs={"pk": self.case_id})
+
     def get_form_kwargs(self):
         form_kwargs = super().get_form_kwargs()
         form_kwargs["ecju_query"] = self.ecju_query
         form_kwargs["documents"] = self.ecju_query_documents
         form_kwargs["case_id"] = self.case_id
         form_kwargs["ecju_response"] = self.session_ecju_response
+        form_kwargs["edit_url"] = self.get_edit_url()
         return form_kwargs
 
     def get_success_url(self):

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -1665,6 +1665,19 @@ def mock_status_properties(requests_mock):
 
 
 @pytest.fixture
+def mock_status_properties_can_invoke_major_editable(requests_mock):
+    url = client._build_absolute_uri("/static/statuses/properties/")
+    data = {
+        "is_read_only": False,
+        "is_terminal": False,
+        "is_major_editable": False,
+        "can_invoke_major_editable": True,
+    }
+    requests_mock.get(url=re.compile(f"{url}.*/"), json=data)
+    return data
+
+
+@pytest.fixture
 def data_organisation():
     expiry_date = datetime.date.today() + datetime.timedelta(days=100)
 

--- a/unit_tests/exporter/applications/views/ecju_queries/test_ecju_query_respond.py
+++ b/unit_tests/exporter/applications/views/ecju_queries/test_ecju_query_respond.py
@@ -63,7 +63,7 @@ def mock_ecju_query_get_document(data_standard_case, data_ecju_queries, requests
     data = {
         "documents": [
             {
-                "id": "fa7fe703-a976-4b8f-8683-8676c1f5fe0a",
+                "id": "fa7fe703-a976-4b8f-8683-8676c1f5fe0a",  # /PS-IGNORE
                 "name": "sample.pdf",
                 "user": {"first_name": "Joe", "last_name": "bloggs"},
                 "description": "test sample",
@@ -85,13 +85,14 @@ def test_ecju_form(data_standard_case, data_ecju_queries):
         ecju_response="Test Response",
         documents={},
         data={},
+        edit_url=None,
     )
 
     assert ecju_respond_form.fields["response"].initial is "Test Response"
     assert ecju_respond_form.is_valid() == True
 
 
-def test_ecju_respond_query_view(authorized_client, data_standard_case, url):
+def test_ecju_respond_query_view_not_editable(authorized_client, mock_application_get, data_standard_case, url):
     response = authorized_client.get(url)
     assert response.status_code == 200
 
@@ -99,12 +100,52 @@ def test_ecju_respond_query_view(authorized_client, data_standard_case, url):
     assert response.context["back_link_url"] == f'/applications/{data_standard_case["case"]["id"]}/ecju-queries/'
     assert response.context["back_link_text"] == "back to ecju queries"
 
-    document_details = BeautifulSoup(response.content, "html.parser").find(class_="app-documents__item-details")
+    soup = BeautifulSoup(response.content, "html.parser")
+    document_details = soup.find(class_="app-documents__item-details")
     assert document_details.find(class_="govuk-link--no-visited-state").text == "sample.pdf"
     assert "Uploaded by Joe bloggs" in document_details.find(class_="govuk-hint").text
+    edit_link = soup.find(class_="application-edit-link")
+    assert edit_link == None
 
 
-def test_ecju_respond_query_view_add_document(authorized_client, data_standard_case_pk, data_ecju_query_pk, url):
+def test_ecju_respond_query_view_editable(
+    authorized_client, mock_application_get, mock_status_properties_can_invoke_major_editable, data_standard_case, url
+):
+    response = authorized_client.get(url)
+    assert response.status_code == 200
+
+    soup = BeautifulSoup(response.content, "html.parser")
+    edit_link = soup.find(class_="application-edit-link")
+    assert edit_link.text == "Edit and submit your application"
+    assert reverse(f"applications:edit_type", kwargs={"pk": data_standard_case["case"]["id"]}) == edit_link["href"]
+
+
+# TODO: After amend by copy is switched on, ensure this test is merged with the above
+def test_ecju_respond_query_view_editable_amend_by_copy_feature(
+    settings,
+    authorized_client,
+    mock_application_get,
+    mock_status_properties_can_invoke_major_editable,
+    data_organisation,
+    data_standard_case,
+    url,
+):
+    settings.FEATURE_AMENDMENT_BY_COPY_EXPORTER_IDS = [data_organisation["id"]]
+    response = authorized_client.get(url)
+    assert response.status_code == 200
+
+    soup = BeautifulSoup(response.content, "html.parser")
+    edit_link = soup.find(class_="application-edit-link")
+    assert edit_link.text == "Edit and submit your application"
+    assert (
+        reverse(f"applications:major_edit_confirm", kwargs={"pk": data_standard_case["case"]["id"]})
+        == edit_link["href"]
+    )
+
+
+def test_ecju_respond_query_view_add_document(
+    authorized_client, mock_application_get, data_standard_case_pk, data_ecju_query_pk, url
+):
     data = {"response": "session response", "add_document": ""}
     response_session_key = f"{data_ecju_query_pk}_response"
     response = authorized_client.post(url, data)
@@ -123,7 +164,7 @@ def test_ecju_respond_query_view_add_document(authorized_client, data_standard_c
 
 
 def test_ecju_respond_query_view_post_sucess(
-    authorized_client, data_standard_case_pk, data_ecju_query_pk, confirm_url, url
+    authorized_client, mock_application_get, data_standard_case_pk, data_ecju_query_pk, confirm_url, url
 ):
     data = {"response": "session response"}
     response_session_key = f"{data_ecju_query_pk}_response"
@@ -140,7 +181,12 @@ def test_ecju_respond_query_view_post_sucess(
 
 
 def test_ecju_respond_query_view_delete_document(
-    authorized_client, data_standard_case_pk, data_ecju_query_pk, mock_ecju_query_get_document, url
+    authorized_client,
+    mock_application_get,
+    data_standard_case_pk,
+    data_ecju_query_pk,
+    mock_ecju_query_get_document,
+    url,
 ):
     document_id = mock_ecju_query_get_document["documents"][0]["id"]
     response_session_key = f"{data_ecju_query_pk}_response"
@@ -162,7 +208,9 @@ def test_ecju_respond_query_view_delete_document(
     assert response_session_key in authorized_client.session.keys()
 
 
-def test_ecju_respond_query_view_cancel(authorized_client, data_standard_case_pk, data_ecju_query_pk, url):
+def test_ecju_respond_query_view_cancel(
+    authorized_client, mock_application_get, data_standard_case_pk, data_ecju_query_pk, url
+):
 
     data = {"response": "session response", "cancel": ""}
     response_session_key = f"{data_ecju_query_pk}_response"
@@ -193,7 +241,7 @@ def test_ecju_respond_query_confirm_view(authorized_client, confirm_url, url):
 
 
 def test_ecju_respond_query_confirm_view_cancel(
-    authorized_client, data_standard_case_pk, confirm_url, data_ecju_query_pk, url
+    authorized_client, mock_application_get, data_standard_case_pk, confirm_url, data_ecju_query_pk, url
 ):
 
     data = {"cancel": ""}
@@ -215,7 +263,7 @@ def test_ecju_respond_query_confirm_view_cancel(
 
 
 def test_ecju_respond_query_confirm_view_save_response(
-    authorized_client, data_standard_case_pk, confirm_url, data_ecju_query_pk, mock_put_ecju_query
+    authorized_client, mock_application_get, data_standard_case_pk, confirm_url, data_ecju_query_pk, mock_put_ecju_query
 ):
     response_session_key = f"{data_ecju_query_pk}_response"
 
@@ -233,7 +281,7 @@ def test_ecju_respond_query_confirm_view_save_response(
 
 
 def test_ecju_respond_query_confirm_view_save_with_no_response(
-    authorized_client, data_standard_case_pk, confirm_url, mock_put_ecju_query
+    authorized_client, mock_application_get, data_standard_case_pk, confirm_url, mock_put_ecju_query
 ):
 
     response = authorized_client.post(confirm_url, {})


### PR DESCRIPTION
### Aim

Ensure that the exporter RFI response page only shows a link to edit the application if the application itself is eligible for editing (e.g. a major edit can be invoked).
Additionally, this PR makes sure that the edit flow the exporter is taken to will be the "amend by copy" flow if the feature flag is switched on for the user.

[LTD-5257](https://uktrade.atlassian.net/browse/LTD-5257)


[LTD-5257]: https://uktrade.atlassian.net/browse/LTD-5257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ