### PR TITLE
[LTD-5216] Adjust caseworker amendment banner copy

### DIFF
--- a/caseworker/templates/layouts/case.html
+++ b/caseworker/templates/layouts/case.html
@@ -148,11 +148,10 @@
 				<div class="app-case-warning-banner__warning">
 					<span class="app-case-warning-banner__icon" aria-hidden="true">!</span>
 					<span class="app-case-warning-banner__text">
-                        This case has been amended by the exporter and is now superseded.<br/>
                         {% if case.superseded_by.reference_code %}
-                        The amendment case is <a class="govuk-link govuk-link--inverse" href="{% url 'cases:case' all_cases_queue_id case.superseded_by.id %}">{{case.superseded_by.reference_code}}</a>.
+                        The exporter edited this application and the case has been superseded by <a class="govuk-link govuk-link--inverse" href="{% url 'cases:case' all_cases_queue_id case.superseded_by.id %}">{{case.superseded_by.reference_code}}</a>.
                         {% else %}
-                        The exporter is still working on their amendments and will submit the amended case when they are finished.
+                        The exporter is editing their application. A new case will be created when they resubmit.
                         {% endif %}
 					</span>
 				</div>
@@ -163,8 +162,7 @@
 				<div class="app-case-warning-banner__warning">
 					<span class="app-case-warning-banner__icon" aria-hidden="true">!</span>
 					<span class="app-case-warning-banner__text">
-                        This case is an amendment.<br/>
-                        The original case is <a class="govuk-link govuk-link--inverse" href="{% url 'cases:case' "00000000-0000-0000-0000-000000000001" case.amendment_of.id %}">{{case.amendment_of.reference_code}}</a>.
+                        This case was created when the exporter edited the original application at <a class="govuk-link govuk-link--inverse" href="{% url 'cases:case' "00000000-0000-0000-0000-000000000001" case.amendment_of.id %}">{{case.amendment_of.reference_code}}</a>.
 					</span>
 				</div>
 			</div>

--- a/unit_tests/caseworker/cases/views/test_case_details.py
+++ b/unit_tests/caseworker/cases/views/test_case_details.py
@@ -1,7 +1,6 @@
 import pytest
 import re
 import uuid
-from unittest import mock
 
 from bs4 import BeautifulSoup
 
@@ -294,12 +293,12 @@ def test_case_details_sub_status_change_displayed(
     "reference_code,expected_banner_msg",
     (
         (
-            "GBSIEL/Blah",
-            "The amendment case is GBSIEL/Blah.",
+            "GBSIEL/2024/0000010/P",
+            "The exporter edited this application and the case has been superseded by GBSIEL/2024/0000010/P.",
         ),
         (
             None,
-            "The exporter is still working on their amendments and will submit the amended case when they are finished.",
+            "The exporter is editing their application. A new case will be created when they resubmit.",
         ),
     ),
 )
@@ -320,7 +319,6 @@ def test_case_superseded_warning(
     superseded_banner = html.find(id="superseded-warning")
     superseded_message = superseded_banner.find("span", attrs={"class": "app-case-warning-banner__text"})
 
-    assert "This case has been amended by the exporter and is now superseded." in superseded_message.text
     assert expected_banner_msg in superseded_message.text
 
 
@@ -331,7 +329,10 @@ def test_case_amendment_warning(
     mock_gov_user,
 ):
     synthetic_superseded_id = str(uuid.uuid4())
-    data_standard_case["case"]["amendment_of"] = {"id": synthetic_superseded_id, "reference_code": "GBSIEL/OLD"}
+    data_standard_case["case"]["amendment_of"] = {
+        "id": synthetic_superseded_id,
+        "reference_code": "GBSIEL/2024/0000002/P",
+    }
     case_url = reverse("cases:case", kwargs={"queue_pk": data_queue["id"], "pk": data_standard_case["case"]["id"]})
     response = authorized_client.get(case_url)
 
@@ -339,5 +340,7 @@ def test_case_amendment_warning(
     amendment_banner = html.find(id="amendment-warning")
     amendment_message = amendment_banner.find("span", attrs={"class": "app-case-warning-banner__text"})
 
-    assert "This case is an amendment." in amendment_message.text
-    assert "The original case is GBSIEL/OLD." in amendment_message.text
+    assert (
+        "This case was created when the exporter edited the original application at GBSIEL/2024/0000002/P."
+        in amendment_message.text
+    )


### PR DESCRIPTION
### Aim

Adjusts copy for orange amendment banner in the caseworker application.  This banner is displayed when a case is superseded or when a case is an amendment of another case.

[LTD-5216](https://uktrade.atlassian.net/browse/LTD-5216)


[LTD-5216]: https://uktrade.atlassian.net/browse/LTD-5216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ