### PR TITLE
LTD-5083: Use exporter specific endpoint to update quantity/value of existing goods on application

### DIFF
--- a/exporter/applications/services.py
+++ b/exporter/applications/services.py
@@ -212,6 +212,16 @@ def edit_good_on_application(request, pk, json):
     return response.json(), response.status_code
 
 
+def edit_quantity_value(request, pk, good_on_application_pk, json):
+    response = client.patch(
+        request,
+        f"/applications/{pk}/good-on-application/{good_on_application_pk}/quantity-value/",
+        json,
+    )
+    response.raise_for_status()
+    return response.json(), response.status_code
+
+
 def post_good_on_application(request, pk, json):
     good = None
     preexisting = str_to_bool(request.GET.get("preexisting"))

--- a/exporter/applications/urls.py
+++ b/exporter/applications/urls.py
@@ -169,7 +169,7 @@ urlpatterns = [
     path("<uuid:pk>/goods/add-preexisting/", goods.ExistingGoodsList.as_view(), name="preexisting_good"),
     path("<uuid:pk>/goods/<uuid:good_pk>/add/", goods.AddGoodToApplication.as_view(), name="add_good_to_application"),
     path(
-        "<uuid:pk>/good-on-application/<uuid:good_on_application_pk>/edit/",
+        "<uuid:pk>/good-on-application/<uuid:good_on_application_pk>/edit-quantity-value/",
         goods.EditQuantityValueExistingGood.as_view(),
         name="edit_preexisting_good",
     ),

--- a/exporter/applications/views/goods/common/edit.py
+++ b/exporter/applications/views/goods/common/edit.py
@@ -19,7 +19,7 @@ from exporter.goods.forms.common import (
     ProductDocumentUploadForm,
     ProductQuantityAndValueForm,
 )
-from exporter.applications.services import edit_good_on_application
+from exporter.applications.services import edit_good_on_application, edit_quantity_value
 from exporter.applications.views.goods.common.initial import get_quantity_and_value_initial_data
 from exporter.applications.views.goods.common.payloads import get_quantity_and_value_payload
 from exporter.goods.services import (
@@ -389,3 +389,24 @@ class ProductQuantityValueEdit(BaseGoodOnApplicationEditView):
 
     def get_edit_payload(self, form):
         return get_quantity_and_value_payload(form)
+
+    @expect_status(
+        HTTPStatus.OK,
+        "Error updating quantity/value of good on application",
+        "Unexpected error updating quantity/value of good on application",
+    )
+    def edit_quantity_value(self, request, pk, good_on_application_id, payload):
+        return edit_quantity_value(
+            request,
+            pk,
+            good_on_application_id,
+            payload,
+        )
+
+    def perform_actions(self, form):
+        self.edit_quantity_value(
+            self.request,
+            self.application["id"],
+            self.good_on_application["id"],
+            self.get_edit_payload(form),
+        )

--- a/unit_tests/exporter/applications/views/goods/common/test_edit_existing_goods_on_application.py
+++ b/unit_tests/exporter/applications/views/goods/common/test_edit_existing_goods_on_application.py
@@ -22,11 +22,18 @@ def edit_quantity_value_url(application, good_on_application):
     return url
 
 
+@pytest.fixture
+def mock_good_on_application_edit_quantity_value(requests_mock, data_standard_case, good_on_application):
+    application_id = data_standard_case["case"]["id"]
+    url = f"/applications/{application_id}/good-on-application/{good_on_application['id']}/quantity-value/"
+    return requests_mock.patch(url, json={})
+
+
 def test_edit_quantity_value_existing_good(
     authorized_client,
     edit_quantity_value_url,
     application_products_url,
-    mock_good_on_application_put,
+    mock_good_on_application_edit_quantity_value,
 ):
     response = authorized_client.get(edit_quantity_value_url)
     assert response.status_code == 200
@@ -47,8 +54,9 @@ def test_edit_quantity_value_existing_good(
     )
     assert response.status_code == 302
     assert response.url == application_products_url
-    assert mock_good_on_application_put.called_once
-    assert mock_good_on_application_put.last_request.json() == {
+    assert mock_good_on_application_edit_quantity_value.called_once
+    assert mock_good_on_application_edit_quantity_value.last_request.method == "PATCH"
+    assert mock_good_on_application_edit_quantity_value.last_request.json() == {
         "quantity": "20",
         "unit": "NAR",
         "value": "20.22",


### PR DESCRIPTION
## Change description

A new endpoint is added that allows only updating of quantity/value of goods that are already added to an application.

Previously we were using a common url using which other fields can also be updated.

API PR: https://github.com/uktrade/lite-api/pull/2121

[LTD-5083](https://uktrade.atlassian.net/browse/LTD-5083)


[LTD-5083]: https://uktrade.atlassian.net/browse/LTD-5083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ