### PR TITLE
LTD-5161: Update breadcrumbs on product details page if it is an archived product

### DIFF
--- a/exporter/goods/common/base.py
+++ b/exporter/goods/common/base.py
@@ -13,21 +13,25 @@ from exporter.core.services import get_organisation
 from exporter.goods.services import get_good
 
 
+def product_detail_breadcrumbs():
+    return [
+        {
+            "title": "Account home",
+            "url": reverse("core:home"),
+        },
+        {
+            "title": "Product list",
+            "url": reverse("goods:goods"),
+        },
+    ]
+
+
 class BaseProductDetails(LoginRequiredMixin, TemplateView):
     template_name = "goods/product-details.html"
     summary_type = None
 
     def get_breadcrumbs(self):
-        breadcrumbs = [
-            {
-                "title": "Account home",
-                "url": reverse("core:home"),
-            },
-            {
-                "title": "Product list",
-                "url": reverse("goods:goods"),
-            },
-        ]
+        breadcrumbs = product_detail_breadcrumbs()
 
         if reverse("goods:archived_goods") in self.request.META.get("HTTP_REFERER", ""):
             breadcrumbs.append(

--- a/exporter/goods/common/base.py
+++ b/exporter/goods/common/base.py
@@ -1,4 +1,5 @@
 from dateutil.parser import parse
+from django.urls import reverse
 from http import HTTPStatus
 
 from django.http import Http404
@@ -15,6 +16,28 @@ from exporter.goods.services import get_good
 class BaseProductDetails(LoginRequiredMixin, TemplateView):
     template_name = "goods/product-details.html"
     summary_type = None
+
+    def get_breadcrumbs(self):
+        breadcrumbs = [
+            {
+                "title": "Account home",
+                "url": reverse("core:home"),
+            },
+            {
+                "title": "Product list",
+                "url": reverse("goods:goods"),
+            },
+        ]
+
+        if reverse("goods:archived_goods") in self.request.META.get("HTTP_REFERER", ""):
+            breadcrumbs.append(
+                {
+                    "title": "Archived products",
+                    "url": reverse("goods:archived_goods"),
+                },
+            )
+
+        return breadcrumbs
 
     @expect_status(
         HTTPStatus.OK,
@@ -65,5 +88,6 @@ class BaseProductDetails(LoginRequiredMixin, TemplateView):
         context["good"] = self.good
         context["summary"] = self.get_summary()
         context["archive_history"] = self.get_archive_history()
+        context["breadcrumbs"] = self.get_breadcrumbs()
 
         return context

--- a/exporter/goods/views.py
+++ b/exporter/goods/views.py
@@ -160,20 +160,6 @@ class Goods(LoginRequiredMixin, TemplateView):
 
 class ArchivedGoods(LoginRequiredMixin, TemplateView):
 
-    def get_breadcrumbs(self):
-        breadcrumbs = [
-            {
-                "title": "Account home",
-                "url": reverse("core:home"),
-            },
-            {
-                "title": "Product list",
-                "url": reverse("goods:goods"),
-            },
-        ]
-
-        return breadcrumbs
-
     def get(self, request, **kwargs):
         name = request.GET.get("name", "").strip()
         part_number = request.GET.get("part_number", "").strip()

--- a/exporter/goods/views.py
+++ b/exporter/goods/views.py
@@ -37,6 +37,7 @@ from exporter.core.helpers import (
     has_valid_rfd_certificate,
     str_to_bool,
 )
+from exporter.goods.common.base import product_detail_breadcrumbs
 from exporter.goods.forms import (
     FirearmsActConfirmationForm,
     FirearmsCalibreDetailsForm,
@@ -199,7 +200,7 @@ class ArchivedGoods(LoginRequiredMixin, TemplateView):
             "part_number": part_number,
             "control_list_entry": control_list_entry,
             "filters": filters,
-            "breadcrumbs": self.get_breadcrumbs(),
+            "breadcrumbs": product_detail_breadcrumbs(),
         }
         return render(request, "goods/archived_goods.html", context)
 

--- a/exporter/goods/views.py
+++ b/exporter/goods/views.py
@@ -158,6 +158,21 @@ class Goods(LoginRequiredMixin, TemplateView):
 
 
 class ArchivedGoods(LoginRequiredMixin, TemplateView):
+
+    def get_breadcrumbs(self):
+        breadcrumbs = [
+            {
+                "title": "Account home",
+                "url": reverse("core:home"),
+            },
+            {
+                "title": "Product list",
+                "url": reverse("goods:goods"),
+            },
+        ]
+
+        return breadcrumbs
+
     def get(self, request, **kwargs):
         name = request.GET.get("name", "").strip()
         part_number = request.GET.get("part_number", "").strip()
@@ -184,6 +199,7 @@ class ArchivedGoods(LoginRequiredMixin, TemplateView):
             "part_number": part_number,
             "control_list_entry": control_list_entry,
             "filters": filters,
+            "breadcrumbs": self.get_breadcrumbs(),
         }
         return render(request, "goods/archived_goods.html", context)
 

--- a/exporter/templates/goods/archived_goods.html
+++ b/exporter/templates/goods/archived_goods.html
@@ -3,7 +3,17 @@
 {% load svg %}
 
 {% block back_link %}
-	{% include 'includes/breadcrumbs.html' with title='goods.GoodsList.TITLE' %}
+<div class="govuk-breadcrumbs">
+	<ol class="govuk-breadcrumbs__list">
+		{% for item in breadcrumbs %}
+			<li class="govuk-breadcrumbs__list-item">
+				<a class="govuk-breadcrumbs__link" href="{{ item.url }}">
+					{{ item.title }}
+				</a>
+			</li>
+		{% endfor %}
+	</ol>
+</div>
 {% endblock %}
 
 {% block body %}

--- a/exporter/templates/goods/product-details.html
+++ b/exporter/templates/goods/product-details.html
@@ -6,19 +6,13 @@
 {% block back_link %}
 	<div class="govuk-breadcrumbs">
 		<ol class="govuk-breadcrumbs__list">
-			<li class="govuk-breadcrumbs__list-item">
-				<a class="govuk-breadcrumbs__link" href="{% url 'core:home' %}">
-					{% lcs 'hub.ACCOUNT_HOME' %}
-				</a>
-			</li>
-			<li class="govuk-breadcrumbs__list-item">
-				<a class="govuk-breadcrumbs__link" href="{% url 'goods:goods' %}">
-					{% lcs 'goods.GoodsList.TITLE' %}
-				</a>
-			</li>
-			<li class="govuk-breadcrumbs__list-item">
-				{% lcs 'goods.GoodPage.TITLE' %}
-			</li>
+            {% for item in breadcrumbs %}
+                <li class="govuk-breadcrumbs__list-item">
+                    <a class="govuk-breadcrumbs__link" href="{{ item.url }}">
+                        {{ item.title }}
+                    </a>
+                </li>
+            {% endfor %}
 		</ol>
 	</div>
 {% endblock %}

--- a/unit_tests/exporter/goods/views/test_archive_restore.py
+++ b/unit_tests/exporter/goods/views/test_archive_restore.py
@@ -215,7 +215,10 @@ def test_archived_product_details_context(
     mock_archived_good_with_history_get,
 ):
 
-    response = authorized_client.get(firearm_product_details_url)
+    response = authorized_client.get(
+        firearm_product_details_url,
+        HTTP_REFERER=reverse("goods:archived_goods"),
+    )
     assert response.status_code == 200
     soup = BeautifulSoup(response.content, "html.parser")
 
@@ -228,6 +231,21 @@ def test_archived_product_details_context(
         "Archived by Exporter User1 at 20:47 on 18 June 2024",
         "Restored by Exporter User2 at 13:02 on 24 May 2024",
         "Archived by Exporter User1 at 12:46 on 10 April 2024",
+    ]
+
+    assert response.context["breadcrumbs"] == [
+        {
+            "title": "Account home",
+            "url": reverse("core:home"),
+        },
+        {
+            "title": "Product list",
+            "url": reverse("goods:goods"),
+        },
+        {
+            "title": "Archived products",
+            "url": reverse("goods:archived_goods"),
+        },
     ]
 
 

--- a/unit_tests/exporter/goods/views/test_archive_restore.py
+++ b/unit_tests/exporter/goods/views/test_archive_restore.py
@@ -209,15 +209,54 @@ def test_restore_product_asks_for_confirmation(
     assert soup.find("a", {"id": "back-link"})["href"] == firearm_product_details_url
 
 
+@pytest.mark.parametrize(
+    "additional_headers,expected",
+    (
+        (
+            {
+                "HTTP_REFERER": reverse("goods:archived_goods"),
+            },
+            [
+                {
+                    "title": "Account home",
+                    "url": reverse("core:home"),
+                },
+                {
+                    "title": "Product list",
+                    "url": reverse("goods:goods"),
+                },
+                {
+                    "title": "Archived products",
+                    "url": reverse("goods:archived_goods"),
+                },
+            ],
+        ),
+        (
+            {},
+            [
+                {
+                    "title": "Account home",
+                    "url": reverse("core:home"),
+                },
+                {
+                    "title": "Product list",
+                    "url": reverse("goods:goods"),
+                },
+            ],
+        ),
+    ),
+)
 def test_archived_product_details_context(
     authorized_client,
     firearm_product_details_url,
     mock_archived_good_with_history_get,
+    additional_headers,
+    expected,
 ):
 
     response = authorized_client.get(
         firearm_product_details_url,
-        HTTP_REFERER=reverse("goods:archived_goods"),
+        **additional_headers,
     )
     assert response.status_code == 200
     soup = BeautifulSoup(response.content, "html.parser")
@@ -233,20 +272,7 @@ def test_archived_product_details_context(
         "Archived by Exporter User1 at 12:46 on 10 April 2024",
     ]
 
-    assert response.context["breadcrumbs"] == [
-        {
-            "title": "Account home",
-            "url": reverse("core:home"),
-        },
-        {
-            "title": "Product list",
-            "url": reverse("goods:goods"),
-        },
-        {
-            "title": "Archived products",
-            "url": reverse("goods:archived_goods"),
-        },
-    ]
+    assert response.context["breadcrumbs"] == expected
 
 
 def test_post_archive_product(


### PR DESCRIPTION
## Change description

Once a product is archived the path to view its details is,

Home -> Products list -> Archived products -> Product detail.

Update breadcrumbs links to reflect the same.


[LTD-5161](https://uktrade.atlassian.net/browse/LTD-5161)


[LTD-5161]: https://uktrade.atlassian.net/browse/LTD-5161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ