### PR TITLE
LTD-5290 adds role_other to filter

### DIFF
--- a/exporter/applications/services.py
+++ b/exporter/applications/services.py
@@ -339,7 +339,7 @@ def get_party_document(request, application_pk, obj_pk):
 
 
 def get_ultimate_end_users(request, pk):
-    data = client.get(request, f"/applications/{pk}/parties/?type=ultimate_end_user")
+    data = client.get(request, f"/applications/{pk}/parties/?type=ultimate_end_user&role_other=Ultimate End-User")
     return data.json()["ultimate_end_users"]
 
 


### PR DESCRIPTION
**Exporter User** wanted to see a Ultimate end user that was added as a third party, the type of this UEU became third_party instead of ultimate end user and so the exporter wasn't able to remove the third party from the case.

[LTD-5290](https://uktrade.atlassian.net/browse/LTD-5290)


[LTD-5290]: https://uktrade.atlassian.net/browse/LTD-5290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ