### PR TITLE
LTD-5287: Include submitted by column when displaying Archived applications

### DIFF
--- a/exporter/applications/views/common.py
+++ b/exporter/applications/views/common.py
@@ -131,9 +131,10 @@ class ApplicationsList(LoginRequiredMixin, FormView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
+        selected_filter = self.request.GET.get("selected_filter", "submitted_applications")
         params = {
             "page": int(self.request.GET.get("page", 1)),
-            "selected_filter": self.request.GET.get("selected_filter", "submitted_applications"),
+            "selected_filter": selected_filter,
             "sort_by": self.request.GET.get("sort_by", "-submitted_at"),
         }
 
@@ -146,10 +147,10 @@ class ApplicationsList(LoginRequiredMixin, FormView):
             "applications": applications,
             "organisation": organisation,
             "tabs": self.get_tabs(),
-            "selected_filter": params["selected_filter"],
+            "selected_filter": selected_filter,
             "page": params.pop("page"),
             "is_user_multiple_organisations": is_user_multiple_organisations,
-            "show_sort_options": params["selected_filter"] != "draft_applications",
+            "show_sort_options": selected_filter != "draft_applications",
         }
 
 

--- a/exporter/templates/applications/applications.html
+++ b/exporter/templates/applications/applications.html
@@ -52,6 +52,9 @@
 				<tr class="govuk-table__row">
 					<th class="govuk-table__header" scope="col">{% lcs "applications.ApplicationsSummaryPage.YOUR_REFERENCE" %}</th>
 					<th class="govuk-table__header" scope="col"></th>
+					{% if selected_filter == "archived_applications" %}
+						<th class="govuk-table__header" scope="col">Submitted by</th>
+					{% endif %}
 					<th class="govuk-table__header" scope="col">{% lcs "applications.ApplicationsSummaryPage.REFERENCE_CODE" %}</th>
 					<th class="govuk-table__header" scope="col">{% lcs "applications.ApplicationsSummaryPage.TYPE" %}</th>
 					<th class="govuk-table__header" scope="col">Date submitted</th>
@@ -77,6 +80,11 @@
 								<span class="lite-notification-bubble">{{ application.exporter_user_notification_count }} <span class="govuk-visually-hidden"> {% lcs "applications.ApplicationsList.NOTIFICATIONS_SUFFIX" %}</span></span>
 							{% endif %}
 						</td>
+						{% if selected_filter == "archived_applications" %}
+							<td class="govuk-table__cell">
+								{{ application.submitted_by }}
+							</td>
+						{% endif %}
 						<td class="govuk-table__cell">
 							{{ application.reference_code }}
 						</td>

--- a/exporter/templates/applications/applications.html
+++ b/exporter/templates/applications/applications.html
@@ -52,7 +52,7 @@
 				<tr class="govuk-table__row">
 					<th class="govuk-table__header" scope="col">{% lcs "applications.ApplicationsSummaryPage.YOUR_REFERENCE" %}</th>
 					<th class="govuk-table__header" scope="col"></th>
-					{% if selected_filter == "archived_applications" %}
+					{% if show_sort_options %}
 						<th class="govuk-table__header" scope="col">Submitted by</th>
 					{% endif %}
 					<th class="govuk-table__header" scope="col">{% lcs "applications.ApplicationsSummaryPage.REFERENCE_CODE" %}</th>
@@ -80,7 +80,7 @@
 								<span class="lite-notification-bubble">{{ application.exporter_user_notification_count }} <span class="govuk-visually-hidden"> {% lcs "applications.ApplicationsList.NOTIFICATIONS_SUFFIX" %}</span></span>
 							{% endif %}
 						</td>
-						{% if selected_filter == "archived_applications" %}
+						{% if show_sort_options %}
 							<td class="govuk-table__cell">
 								{{ application.submitted_by }}
 							</td>

--- a/unit_tests/exporter/applications/views/test_applications_list.py
+++ b/unit_tests/exporter/applications/views/test_applications_list.py
@@ -1,5 +1,7 @@
 import pytest
 
+from datetime import datetime
+
 from bs4 import BeautifulSoup
 from faker import Faker
 from urllib.parse import urlencode
@@ -8,13 +10,36 @@ from uuid import uuid4
 from django.urls import reverse
 from pytest_django.asserts import assertTemplateUsed
 
+from core.builtins.custom_tags import str_date
+
 faker = Faker()
 
 
-def base_application_data():
+headers = [
+    {"key": "name", "value": "Your reference"},
+    {"key": "exporter_user_notification_count", "value": ""},
+    {"key": "reference_code", "value": "ECJU reference"},
+    {"key": "case_type", "value": "Type"},
+    {"key": "submitted_at", "value": "Date submitted"},
+    {"key": "updated_at", "value": "Last updated"},
+    {"key": "status", "value": "Status"},
+]
+archived_headers = [
+    {"key": "name", "value": "Your reference"},
+    {"key": "exporter_user_notification_count", "value": ""},
+    {"key": "submitted_by", "value": "Submitted by"},
+    {"key": "reference_code", "value": "ECJU reference"},
+    {"key": "case_type", "value": "Type"},
+    {"key": "submitted_at", "value": "Date submitted"},
+    {"key": "updated_at", "value": "Last updated"},
+    {"key": "status", "value": "Status"},
+]
+
+
+def base_application_data(index):
     return {
         "id": str(uuid4()),
-        "name": faker.name(),
+        "name": f"Application{index}",
         "export_type": {"key": "permanent", "value": "Permanent"},
         "exporter_user_notification_count": 0,
         "case_type": {"sub_type": {"key": "standard", "value": "Standard Licence"}},
@@ -26,9 +51,12 @@ def draft_applications():
         {
             "status": {"id": "00000000-0000-0000-0000-000000000000", "key": "draft", "value": "Draft"},
             "reference_code": "",
-            **base_application_data(),
+            "submitted_by": "",
+            "submitted_at": None,
+            "updated_at": datetime.now().isoformat(),
+            **base_application_data(index),
         }
-        for _ in range(5)
+        for index in range(5)
     ]
 
 
@@ -37,7 +65,10 @@ def submitted_applications():
         {
             "status": {"id": "00000000-0000-0000-0000-000000000004", "key": "submitted", "value": "Submitted"},
             "reference_code": "GBSIEL/2024/0000004/P",
-            **base_application_data(),
+            "submitted_by": "Exporter user",
+            "submitted_at": datetime.now().isoformat(),
+            "updated_at": datetime.now().isoformat(),
+            **base_application_data(0),
         },
         {
             "status": {
@@ -46,17 +77,26 @@ def submitted_applications():
                 "value": "Initial checks",
             },
             "reference_code": "GBSIEL/2024/0000003/P",
-            **base_application_data(),
+            "submitted_by": "Exporter user",
+            "submitted_at": datetime.now().isoformat(),
+            "updated_at": datetime.now().isoformat(),
+            **base_application_data(1),
         },
         {
             "status": {"id": "00000000-0000-0000-0000-000000000002", "key": "under_review", "value": "Under review"},
             "reference_code": "GBSIEL/2024/0000002/P",
-            **base_application_data(),
+            "submitted_by": "Exporter user",
+            "submitted_at": datetime.now().isoformat(),
+            "updated_at": datetime.now().isoformat(),
+            **base_application_data(2),
         },
         {
             "status": {"id": "00000000-0000-0000-0000-000000000001", "key": "ogd_advice", "value": "OGD Advice"},
             "reference_code": "GBSIEL/2024/0000001/P",
-            **base_application_data(),
+            "submitted_by": "Exporter user",
+            "submitted_at": datetime.now().isoformat(),
+            "updated_at": datetime.now().isoformat(),
+            **base_application_data(3),
         },
     ]
 
@@ -66,7 +106,10 @@ def finalised_applications():
         {
             "status": {"id": "00000000-0000-0000-0000-000000000009", "key": "finalised", "value": "Finalised"},
             "reference_code": f"GBSIEL/2024/000000{index}/P",
-            **base_application_data(),
+            "submitted_by": "Exporter user",
+            "submitted_at": datetime.now().isoformat(),
+            "updated_at": datetime.now().isoformat(),
+            **base_application_data(index),
         }
         for index in range(8)
     ]
@@ -81,7 +124,10 @@ def archived_applications():
                 "value": "Superseded by Exporter edit",
             },
             "reference_code": f"GBSIEL/2024/000000{index}/P",
-            **base_application_data(),
+            "submitted_by": "Exporter user",
+            "submitted_at": datetime.now().isoformat(),
+            "updated_at": datetime.now().isoformat(),
+            **base_application_data(index),
         }
         for index in range(4)
     ]
@@ -148,6 +194,41 @@ def get_applications(response):
     return soup.find("tbody", {"class": "govuk-table__body"}).find_all("tr", recursive=False)
 
 
+def get_formatted_data(application):
+    """Returns formatted data of required fields for each application"""
+    return {
+        "name": application["name"],
+        "exporter_user_notification_count": "",
+        "reference_code": application["reference_code"],
+        "submitted_by": application["submitted_by"],
+        "submitted_at": (
+            str_date(application["submitted_at"]) if application["submitted_at"] else str(application["submitted_at"])
+        ),
+        "updated_at": str_date(application["updated_at"]),
+        "case_type": application["case_type"]["sub_type"]["value"],
+        "status": application["status"]["value"],
+    }
+
+
+def verify_application_data(response, headers, expected):
+    soup = BeautifulSoup(response.content, "html.parser")
+    rows = soup.find("tbody", {"class": "govuk-table__body"}).find_all("tr", recursive=False)
+
+    # check we have expected number of applications for this status
+    assert len(rows) == len(expected)
+
+    # Check for each application the data is as expected
+    for row_index, item in enumerate(expected):
+        soup = BeautifulSoup(rows[row_index].encode("utf-8"), "html.parser")
+        columns = soup.find("tr", {"class": "govuk-table__row"}).find_all("td", recursive=False)
+        assert len(columns) == len(headers)
+
+        application = get_formatted_data(item)
+        for col_index, col in enumerate(columns):
+            key = headers[col_index]["key"]
+            assert application[key] in col.text
+
+
 def test_get_applications(authorized_client, mock_get_submitted_applications):
     url = reverse("applications:applications")
     response = authorized_client.get(url)
@@ -165,7 +246,7 @@ def test_get_draft_applications(authorized_client, mock_get_draft_applications):
     assert response.status_code == 200
 
     assertTemplateUsed(response, "applications/applications.html")
-    assert len(get_applications(response)) == len(draft_applications())
+    verify_application_data(response, headers, draft_applications())
 
 
 def test_get_submitted_applications(authorized_client, mock_get_submitted_applications):
@@ -176,7 +257,7 @@ def test_get_submitted_applications(authorized_client, mock_get_submitted_applic
     assert response.status_code == 200
 
     assertTemplateUsed(response, "applications/applications.html")
-    assert len(get_applications(response)) == len(submitted_applications())
+    verify_application_data(response, headers, submitted_applications())
 
 
 def test_get_finalised_applications(authorized_client, mock_get_finalised_applications):
@@ -187,7 +268,7 @@ def test_get_finalised_applications(authorized_client, mock_get_finalised_applic
     assert response.status_code == 200
 
     assertTemplateUsed(response, "applications/applications.html")
-    assert len(get_applications(response)) == len(finalised_applications())
+    verify_application_data(response, headers, finalised_applications())
 
 
 def test_get_archived_applications(authorized_client, mock_get_archived_applications):
@@ -198,4 +279,4 @@ def test_get_archived_applications(authorized_client, mock_get_archived_applicat
     assert response.status_code == 200
 
     assertTemplateUsed(response, "applications/applications.html")
-    assert len(get_applications(response)) == len(archived_applications())
+    verify_application_data(response, archived_headers, archived_applications())

--- a/unit_tests/exporter/applications/views/test_applications_list.py
+++ b/unit_tests/exporter/applications/views/test_applications_list.py
@@ -15,7 +15,7 @@ from core.builtins.custom_tags import str_date
 faker = Faker()
 
 
-headers = [
+draft_headers = [
     {"key": "name", "value": "Your reference"},
     {"key": "exporter_user_notification_count", "value": ""},
     {"key": "reference_code", "value": "ECJU reference"},
@@ -24,7 +24,7 @@ headers = [
     {"key": "updated_at", "value": "Last updated"},
     {"key": "status", "value": "Status"},
 ]
-archived_headers = [
+headers = [
     {"key": "name", "value": "Your reference"},
     {"key": "exporter_user_notification_count", "value": ""},
     {"key": "submitted_by", "value": "Submitted by"},
@@ -246,7 +246,7 @@ def test_get_draft_applications(authorized_client, mock_get_draft_applications):
     assert response.status_code == 200
 
     assertTemplateUsed(response, "applications/applications.html")
-    verify_application_data(response, headers, draft_applications())
+    verify_application_data(response, draft_headers, draft_applications())
 
 
 def test_get_submitted_applications(authorized_client, mock_get_submitted_applications):
@@ -279,4 +279,4 @@ def test_get_archived_applications(authorized_client, mock_get_archived_applicat
     assert response.status_code == 200
 
     assertTemplateUsed(response, "applications/applications.html")
-    verify_application_data(response, archived_headers, archived_applications())
+    verify_application_data(response, headers, archived_applications())


### PR DESCRIPTION
## Change description

Designs required displaying 'submitted by' column for archived applications.
This was missed in the initial change and fixed in this PR.

This field is missing in the serializer so API changes are also required.
https://github.com/uktrade/lite-api/pull/2129

Updated tests to also verify the data rather than just the count of applications.


[LTD-5287](https://uktrade.atlassian.net/browse/LTD-5287)


[LTD-5287]: https://uktrade.atlassian.net/browse/LTD-5287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ