### PR TITLE
LTD-5278: Playback ITAR controls status on the internal side

### DIFF
--- a/caseworker/templates/components/security-approvals.html
+++ b/caseworker/templates/components/security-approvals.html
@@ -12,6 +12,10 @@
 
         {% if "F680" in case.data.security_approvals %}
             <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">Are any products on this application subject to ITAR controls?</dt>
+                <dd class="govuk-summary-list__value">{{ case.data.subject_to_itar_controls|yesno|capfirst }}</dd>
+            </div>
+            <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">What is the F680 reference number?</dt>
                 <dd class="govuk-summary-list__value">{{ case.data.f680_reference_number }}</dd>
             </div>

--- a/unit_tests/caseworker/cases/views/test_case_details.py
+++ b/unit_tests/caseworker/cases/views/test_case_details.py
@@ -16,6 +16,7 @@ from django.utils import timezone
 
 from core import client
 from caseworker.cases.helpers.case import LU_POST_CIRC_FINALISE_QUEUE_ALIAS
+from core.constants import SecurityClassifiedApprovalsType
 
 
 @pytest.fixture(autouse=True)
@@ -344,3 +345,36 @@ def test_case_amendment_warning(
         "This case was created when the exporter edited the original application at GBSIEL/2024/0000002/P."
         in amendment_message.text
     )
+
+
+@pytest.mark.parametrize(
+    "itar_controls_status,expected",
+    (
+        (False, "No"),
+        (True, "Yes"),
+    ),
+)
+def test_case_details_security_approvals(
+    data_standard_case, data_queue, authorized_client, itar_controls_status, expected
+):
+    data_standard_case["case"]["data"]["is_mod_security_approved"] = True
+    data_standard_case["case"]["data"]["security_approvals"] = [SecurityClassifiedApprovalsType.F680]
+    data_standard_case["case"]["data"]["subject_to_itar_controls"] = itar_controls_status
+
+    case_url = reverse("cases:case", kwargs={"queue_pk": data_queue["id"], "pk": data_standard_case["case"]["id"]})
+    response = authorized_client.get(case_url)
+
+    assertTemplateUsed(response, "components/security-approvals.html")
+
+    html = BeautifulSoup(response.content, "html.parser")
+    dt = html.find("dt", string=re.compile("Do you have an MOD security approval, such as F680 or F1686?"))
+    assert dt
+    assert dt.find_next().string == "Yes"
+
+    dt = html.find("dt", string=re.compile("What type of approval do you have?"))
+    assert dt
+    assert dt.find_next().string == "F680"
+
+    dt = html.find("dt", string=re.compile("Are any products on this application subject to ITAR controls?"))
+    assert dt
+    assert dt.find_next().string == expected


### PR DESCRIPTION
## Change description

Displays exporter provided answer for ITAR controls status on the internal side.
Add unit test to checks values displayed on the template.

[LTD-5278](https://uktrade.atlassian.net/browse/LTD-5278)


[LTD-5278]: https://uktrade.atlassian.net/browse/LTD-5278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ