### PR TITLE
LTD-5284-Fix-show-correct-cle

### DIFF
--- a/exporter/applications/helpers/check_your_answers.py
+++ b/exporter/applications/helpers/check_your_answers.py
@@ -248,7 +248,7 @@ def convert_goods_on_application(application, goods_on_application, is_exhibitio
     requires_actions_column = any(requires_actions(application, g) for g in goods_on_application)
     for good_on_application in goods_on_application:
         # When it is in Draft stage it will show all CLEs otherwise it will show the ones assessed by TAU
-        if application["status"].get("key") is ApplicationStatus.DRAFT:
+        if application["status"].get("key") == ApplicationStatus.DRAFT:
             control_list_entries = convert_control_list_entries(good_on_application["good"]["control_list_entries"])
         else:
             control_list_entries = convert_control_list_entries(good_on_application["control_list_entries"])

--- a/exporter/applications/helpers/check_your_answers.py
+++ b/exporter/applications/helpers/check_your_answers.py
@@ -38,13 +38,15 @@ from lite_content.lite_exporter_frontend.strings import Parties
 from lite_forms.helpers import conditional
 
 
-def convert_application_to_check_your_answers(application, editable=False, summary=False):
+def convert_application_to_check_your_answers(application, editable=False, summary=False, is_application_detail=False):
     """
     Returns a correctly formatted check your answers page for the supplied application
     """
     sub_type = application.sub_type
     if sub_type == STANDARD:
-        return _convert_standard_application(application, editable, is_summary=summary)
+        return _convert_standard_application(
+            application, editable, is_summary=summary, is_application_detail=is_application_detail
+        )
     elif sub_type == OPEN:
         return _convert_open_application(application, editable)
     elif sub_type == HMRC:
@@ -100,14 +102,14 @@ def _convert_gifting_clearance(application, editable=False):
     }
 
 
-def _convert_standard_application(application, editable=False, is_summary=False):
+def _convert_standard_application(application, editable=False, is_summary=False, is_application_detail=False):
     strings = applications.ApplicationSummaryPage
     pk = application["id"]
     url = reverse(f"applications:good_detail_summary", kwargs={"pk": pk})
     old_locations = bool(application["goods_locations"])
     converted = {
         convert_to_link(url, strings.GOODS): convert_goods_on_application(
-            application, application["goods"], is_summary=is_summary
+            application, application["goods"], is_summary=is_summary, is_application_detail=is_application_detail
         ),
         strings.END_USE_DETAILS: _get_end_use_details(application),
         strings.END_USER: convert_party(application["end_user"], application, editable),
@@ -238,7 +240,9 @@ def _convert_hmrc_query(application, editable=False):
     }
 
 
-def convert_goods_on_application(application, goods_on_application, is_exhibition=False, is_summary=False):
+def convert_goods_on_application(
+    application, goods_on_application, is_exhibition=False, is_summary=False, is_application_detail=False
+):
     converted = []
 
     def requires_actions(application, good_on_application):
@@ -246,7 +250,10 @@ def convert_goods_on_application(application, goods_on_application, is_exhibitio
 
     requires_actions_column = any(requires_actions(application, g) for g in goods_on_application)
     for good_on_application in goods_on_application:
-        control_list_entries = convert_control_list_entries(good_on_application["good"]["control_list_entries"])
+        if is_application_detail:
+            control_list_entries = convert_control_list_entries(good_on_application["control_list_entries"])
+        else:
+            control_list_entries = convert_control_list_entries(good_on_application["good"]["control_list_entries"])
 
         if good_on_application["good"].get("name"):
             name = good_on_application["good"]["name"]

--- a/exporter/applications/views/common.py
+++ b/exporter/applications/views/common.py
@@ -295,12 +295,11 @@ class ApplicationDetail(LoginRequiredMixin, TemplateView):
 
     def get(self, request, **kwargs):
         status_props, _ = get_status_properties(request, self.application["status"]["key"])
-
         context = {
             "case_id": self.application_id,
             "application": self.application,
             "type": self.view_type,
-            "answers": convert_application_to_check_your_answers(self.application),
+            "answers": convert_application_to_check_your_answers(self.application, is_application_detail=True),
             "status_is_terminal": status_props["is_terminal"],
             "errors": kwargs.get("errors"),
             "text": kwargs.get("text", ""),

--- a/exporter/applications/views/common.py
+++ b/exporter/applications/views/common.py
@@ -299,7 +299,7 @@ class ApplicationDetail(LoginRequiredMixin, TemplateView):
             "case_id": self.application_id,
             "application": self.application,
             "type": self.view_type,
-            "answers": convert_application_to_check_your_answers(self.application, is_application_detail=True),
+            "answers": convert_application_to_check_your_answers(self.application),
             "status_is_terminal": status_props["is_terminal"],
             "errors": kwargs.get("errors"),
             "text": kwargs.get("text", ""),

--- a/unit_tests/exporter/applications/helpers/test_check_your_answers.py
+++ b/unit_tests/exporter/applications/helpers/test_check_your_answers.py
@@ -222,3 +222,18 @@ def test_convert_standard_application_has_security_approvals(application, settin
     test_application = Application(application)
     actual = check_your_answers._convert_standard_application(test_application)
     assert "Do you have a security approval?" in actual.keys()
+
+
+def test_goods_on_application_when_application_detail(application, data_good_on_application):
+    data_good_on_application["is_good_controlled"] = True
+    # Given this is an application detail page
+    actual = check_your_answers.convert_goods_on_application(
+        application, [data_good_on_application], is_application_detail=True
+    )
+
+    assert len(actual) == 1
+    # Shows assessed CLE-s by TAU
+    assert (
+        actual[0]["Control list entries"]
+        == "<span data-definition-title='ML1' data-definition-text='Smooth-bore weapons...'>ML1</span>, <span data-definition-title='ML2' data-definition-text='Smooth-bore weapons...'>ML2</span>"
+    )

--- a/unit_tests/exporter/applications/views/test_application_summary.py
+++ b/unit_tests/exporter/applications/views/test_application_summary.py
@@ -3,10 +3,12 @@ from django.urls import reverse
 from bs4 import BeautifulSoup
 
 from core import client
+from exporter.applications.constants import ApplicationStatus
 
 
 @pytest.fixture(autouse=True)
 def mock_get_application(requests_mock, data_standard_case):
+    data_standard_case["case"]["data"]["status"] = {"key": ApplicationStatus.DRAFT, "value": "Draft"}
     applications_url = client._build_absolute_uri(f"/applications/{data_standard_case['case']['id']}/")
     requests_mock.get(url=applications_url, json=data_standard_case["case"]["data"])
 


### PR DESCRIPTION
https://uktrade.atlassian.net/browse/LTD-5284

Exporter fix for the licence template is on BE

This shows only where it matters in `ApplicationDetail` page where it should show only the one where Licence is required and have been assessed by TAU. 

In the `CheckYourAnswers` and `GoodsDetailSummaryCheckYourAnswers` it will stay how it was before so showing the ones added by Users.
