### PR TITLE
Fix wrong exporter URL for document digital signatures

### DIFF
--- a/exporter/templates/core/hub.html
+++ b/exporter/templates/core/hub.html
@@ -162,7 +162,7 @@
 					or call +44(0)20 7215 4595 (select option 2).
 				</div>
 				<div class="app-tile__body">
-					View <a class="govuk-link" href="https://exporter.lite.service.uat.uktrade.digital/signature-help/" target="_blank">guidance on LITE document digital signatures</a>.
+					View <a class="govuk-link" href="{% url 'core:signature_help' %}" target="_blank">guidance on LITE document digital signatures</a>.
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
### Aim

The URL was hardcoded and pointed to the UAT environment, so it has been changed to use a template tag instead.

[LTD-5328](https://uktrade.atlassian.net/browse/LTD-5328)


[LTD-5328]: https://uktrade.atlassian.net/browse/LTD-5328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ