### PR TITLE
[LTD-5301] Ensure E2E tests use new application change status endpoint

### DIFF
--- a/tests_common/api_client/sub_helpers/applications.py
+++ b/tests_common/api_client/sub_helpers/applications.py
@@ -312,8 +312,8 @@ class Applications:
 
     def set_status(self, application_id, status):
         self.api_client.make_request(
-            method="PUT",
-            url="/applications/" + application_id + "/status/",
+            method="POST",
+            url="/caseworker/applications/" + application_id + "/status/",
             headers=self.api_client.gov_headers,
             body={"status": status},
         )


### PR DESCRIPTION
### Aim

Ensure E2E tests use new application change status endpoint now that we want to remove the legacy shared authentication endpoint.

[LTD-5301](https://uktrade.atlassian.net/browse/LTD-5301)


[LTD-5301]: https://uktrade.atlassian.net/browse/LTD-5301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ