### PR TITLE
Ensure API logs are always output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,7 +192,10 @@ commands:
       - cache_env_circleci_dir
       - store_artifacts:
           path: ui_tests/screenshots
-      - run: docker logs api > ui_tests/api_logs.txt
+      - run:
+          name: Generate API logs
+          when: always
+          command: docker logs api > ui_tests/api_logs.txt
       - store_artifacts:
           path: ui_tests/api_logs.txt
       - store_test_results:


### PR DESCRIPTION
### Aim

Make sure that API logs are always output even if previous steps have failed.

There are currently some end-to-end tests failing on a feature branch and it looks like the API isn't coming up, however there are no API logs being output and I think it may be because the failure stops that command from being run. This ensures that the command is always run.
