### PR TITLE
Update exporter app to use new CLEs list view

### DIFF
--- a/exporter/core/services.py
+++ b/exporter/core/services.py
@@ -198,19 +198,23 @@ def put_organisation_user(request, user_pk, json):
     return data.json(), data.status_code
 
 
-def get_control_list_entries(request, convert_to_options=False):
-    response = client.get(request, "/exporter/static/control-list-entries/")
-
+def get_control_list_entries(request, convert_to_options=False, converted_control_list_entries_cache=[]):  # noqa
     if convert_to_options:
-        return [
-            Option(
-                key=control_list_entry["rating"],
-                value=control_list_entry["rating"],
-                description=control_list_entry["text"],
-            )
-            for control_list_entry in response.json()
-        ]
+        if converted_control_list_entries_cache:
+            return converted_control_list_entries_cache
+        else:
+            response = client.get(request, "/exporter/static/control-list-entries/")
+            for control_list_entry in response.json():
+                converted_control_list_entries_cache.append(
+                    Option(
+                        key=control_list_entry["rating"],
+                        value=control_list_entry["rating"],
+                        description=control_list_entry["text"],
+                    )
+                )
+            return converted_control_list_entries_cache
 
+    response = client.get(request, "/exporter/static/control-list-entries/")
     return response.json()
 
 

--- a/exporter/core/services.py
+++ b/exporter/core/services.py
@@ -198,26 +198,20 @@ def put_organisation_user(request, user_pk, json):
     return data.json(), data.status_code
 
 
-def get_control_list_entries(request, convert_to_options=False, converted_control_list_entries_cache=[]):  # noqa
+def get_control_list_entries(request, convert_to_options=False):
+    response = client.get(request, "/static/control-list-entries/exporter-list/")
+
     if convert_to_options:
-        if converted_control_list_entries_cache:
-            return converted_control_list_entries_cache
-        else:
-            data = client.get(request, "/static/control-list-entries/?flatten=True")
-
-        for control_list_entry in data.json().get("control_list_entries", []):
-            converted_control_list_entries_cache.append(
-                Option(
-                    key=control_list_entry["rating"],
-                    value=control_list_entry["rating"],
-                    description=control_list_entry["text"],
-                )
+        return [
+            Option(
+                key=control_list_entry["rating"],
+                value=control_list_entry["rating"],
+                description=control_list_entry["text"],
             )
+            for control_list_entry in response.json()
+        ]
 
-        return converted_control_list_entries_cache
-
-    data = client.get(request, "/static/control-list-entries/")
-    return data.json().get("control_list_entries")
+    return response.json()
 
 
 # F680 clearance types

--- a/exporter/core/services.py
+++ b/exporter/core/services.py
@@ -199,7 +199,7 @@ def put_organisation_user(request, user_pk, json):
 
 
 def get_control_list_entries(request, convert_to_options=False):
-    response = client.get(request, "/static/control-list-entries/exporter-list/")
+    response = client.get(request, "/exporter/static/control-list-entries/")
 
     if convert_to_options:
         return [

--- a/unit_tests/exporter/applications/views/conftest.py
+++ b/unit_tests/exporter/applications/views/conftest.py
@@ -505,7 +505,7 @@ def application_with_rfd_and_section_5_document(data_standard_case, requests_moc
 
 @pytest.fixture
 def control_list_entries(requests_mock):
-    clc_url = client._build_absolute_uri("/static/control-list-entries/exporter-list/")
+    clc_url = client._build_absolute_uri("/exporter/static/control-list-entries/")
     matcher = requests_mock.get(url=clc_url, json=[{"rating": "ML1"}, {"rating": "ML1a"}])
     return matcher
 

--- a/unit_tests/exporter/applications/views/conftest.py
+++ b/unit_tests/exporter/applications/views/conftest.py
@@ -505,8 +505,8 @@ def application_with_rfd_and_section_5_document(data_standard_case, requests_moc
 
 @pytest.fixture
 def control_list_entries(requests_mock):
-    clc_url = client._build_absolute_uri("/static/control-list-entries/")
-    matcher = requests_mock.get(url=clc_url, json={"control_list_entries": [{"rating": "ML1"}, {"rating": "ML1a"}]})
+    clc_url = client._build_absolute_uri("/static/control-list-entries/exporter-list/")
+    matcher = requests_mock.get(url=clc_url, json=[{"rating": "ML1"}, {"rating": "ML1a"}])
     return matcher
 
 

--- a/unit_tests/exporter/applications/views/goods/component/test_edit_component.py
+++ b/unit_tests/exporter/applications/views/goods/component/test_edit_component.py
@@ -13,7 +13,7 @@ def setup(
     mock_application_get,
     mock_good_get,
     mock_good_put,
-    mock_control_list_entries_get,
+    mock_exporter_control_list_entries_get,
     mock_good_document_post,
     mock_good_document_delete,
     no_op_storage,

--- a/unit_tests/exporter/applications/views/goods/firearm/test_edit_firearm.py
+++ b/unit_tests/exporter/applications/views/goods/firearm/test_edit_firearm.py
@@ -15,7 +15,7 @@ def setup(
     mock_good_document_post,
     mock_good_document_put,
     mock_good_document_delete,
-    mock_control_list_entries_get,
+    mock_exporter_control_list_entries_get,
     no_op_storage,
 ):
     yield

--- a/unit_tests/exporter/applications/views/goods/material/test_edit_material.py
+++ b/unit_tests/exporter/applications/views/goods/material/test_edit_material.py
@@ -12,7 +12,7 @@ def setup(
     mock_application_get,
     mock_good_get,
     mock_good_put,
-    mock_control_list_entries_get,
+    mock_exporter_control_list_entries_get,
     mock_good_document_post,
     mock_good_document_delete,
     no_op_storage,

--- a/unit_tests/exporter/applications/views/goods/platform/test_edit_platform.py
+++ b/unit_tests/exporter/applications/views/goods/platform/test_edit_platform.py
@@ -12,7 +12,7 @@ def setup(
     mock_application_get,
     mock_good_get,
     mock_good_put,
-    mock_control_list_entries_get,
+    mock_exporter_control_list_entries_get,
     mock_good_document_post,
     mock_good_document_delete,
     no_op_storage,

--- a/unit_tests/exporter/applications/views/goods/software/test_edit_software.py
+++ b/unit_tests/exporter/applications/views/goods/software/test_edit_software.py
@@ -10,7 +10,7 @@ def setup(
     mock_application_get,
     mock_good_get,
     mock_good_put,
-    mock_control_list_entries_get,
+    mock_exporter_control_list_entries_get,
 ):
     yield
 

--- a/unit_tests/exporter/applications/views/test_add_good.py
+++ b/unit_tests/exporter/applications/views/test_add_good.py
@@ -43,7 +43,7 @@ def application_url(requests_mock, data_standard_case):
 
 @pytest.fixture(autouse=True)
 def clc_url(requests_mock):
-    clc_url = client._build_absolute_uri("/static/control-list-entries/exporter-list/")
+    clc_url = client._build_absolute_uri("/exporter/static/control-list-entries/")
     requests_mock.get(url=clc_url, json=[{"rating": "ML1"}, {"rating": "ML1a"}])
 
 

--- a/unit_tests/exporter/applications/views/test_add_good.py
+++ b/unit_tests/exporter/applications/views/test_add_good.py
@@ -43,8 +43,8 @@ def application_url(requests_mock, data_standard_case):
 
 @pytest.fixture(autouse=True)
 def clc_url(requests_mock):
-    clc_url = client._build_absolute_uri("/static/control-list-entries/")
-    requests_mock.get(url=clc_url, json={"control_list_entries": [{"rating": "ML1"}, {"rating": "ML1a"}]})
+    clc_url = client._build_absolute_uri("/static/control-list-entries/exporter-list/")
+    requests_mock.get(url=clc_url, json=[{"rating": "ML1"}, {"rating": "ML1a"}])
 
 
 @pytest.fixture(autouse=True)

--- a/unit_tests/exporter/conftest.py
+++ b/unit_tests/exporter/conftest.py
@@ -707,13 +707,13 @@ def data_control_list_entries():
 
 @pytest.fixture
 def mock_exporter_control_list_entries(requests_mock, data_control_list_entries):
-    url = client._build_absolute_uri("/static/control-list-entries/exporter-list/")
+    url = client._build_absolute_uri("/exporter/static/control-list-entries/")
     yield requests_mock.get(url=url, json=data_control_list_entries)
 
 
 @pytest.fixture
 def mock_exporter_control_list_entries_get(requests_mock):
-    url = client._build_absolute_uri(f"/static/control-list-entries/exporter-list/")
+    url = client._build_absolute_uri(f"/exporter/static/control-list-entries/")
     return requests_mock.get(
         url=url, json=[{"rating": "ML1a", "text": "some text"}, {"rating": "ML22b", "text": "some text"}]
     )

--- a/unit_tests/exporter/conftest.py
+++ b/unit_tests/exporter/conftest.py
@@ -1,5 +1,4 @@
 import os
-import re
 import pytest
 import requests
 
@@ -696,3 +695,25 @@ def mock_get_application(requests_mock, application_pk, application_reference_nu
 def mock_validate_registration_number(requests_mock):
     url = client._build_absolute_uri("/organisations/registration_number")
     return requests_mock.post(url=url, json={}, status_code=200)
+
+
+@pytest.fixture
+def data_control_list_entries():
+    return [
+        {"rating": "ML1", "text": "Smooth-bore weapons with a calibre of less than 20mm, other firearms..."},
+        {"rating": "ML1a", "text": "Rifles and combination guns, handguns, machine, sub-machine and volley guns"},
+    ]
+
+
+@pytest.fixture
+def mock_exporter_control_list_entries(requests_mock, data_control_list_entries):
+    url = client._build_absolute_uri("/static/control-list-entries/exporter-list/")
+    yield requests_mock.get(url=url, json=data_control_list_entries)
+
+
+@pytest.fixture
+def mock_exporter_control_list_entries_get(requests_mock):
+    url = client._build_absolute_uri(f"/static/control-list-entries/exporter-list/")
+    return requests_mock.get(
+        url=url, json=[{"rating": "ML1a", "text": "some text"}, {"rating": "ML22b", "text": "some text"}]
+    )

--- a/unit_tests/exporter/goods/forms/test_common.py
+++ b/unit_tests/exporter/goods/forms/test_common.py
@@ -37,9 +37,7 @@ def test_product_form_validation(data, is_valid, errors):
 
 @pytest.fixture
 def control_list_entries(requests_mock):
-    requests_mock.get(
-        "/static/control-list-entries/", json={"control_list_entries": [{"rating": "ML1"}, {"rating": "ML1a"}]}
-    )
+    requests_mock.get("/static/control-list-entries/exporter-list/", json=[{"rating": "ML1"}, {"rating": "ML1a"}])
 
 
 def test_product_control_list_entry_form_init_control_list_entries(request_with_session, control_list_entries):

--- a/unit_tests/exporter/goods/forms/test_common.py
+++ b/unit_tests/exporter/goods/forms/test_common.py
@@ -37,7 +37,7 @@ def test_product_form_validation(data, is_valid, errors):
 
 @pytest.fixture
 def control_list_entries(requests_mock):
-    requests_mock.get("/static/control-list-entries/exporter-list/", json=[{"rating": "ML1"}, {"rating": "ML1a"}])
+    requests_mock.get("/exporter/static/control-list-entries/", json=[{"rating": "ML1"}, {"rating": "ML1a"}])
 
 
 def test_product_control_list_entry_form_init_control_list_entries(request_with_session, control_list_entries):

--- a/unit_tests/exporter/goods/forms/test_forms.py
+++ b/unit_tests/exporter/goods/forms/test_forms.py
@@ -12,7 +12,7 @@ from lite_content.lite_exporter_frontend.goods import CreateGoodForm
 
 @pytest.fixture(autouse=True)
 def setup(
-    mock_control_list_entries,
+    mock_exporter_control_list_entries,
     mock_pv_gradings,
 ):
     yield

--- a/unit_tests/exporter/licences/test_views.py
+++ b/unit_tests/exporter/licences/test_views.py
@@ -140,7 +140,7 @@ def mock_list_open_general_licences(data_list_open_general_licences, requests_mo
 
 
 @pytest.fixture
-def client(authorized_client, mock_control_list_entries, mock_countries, mock_pv_gradings):
+def client(authorized_client, mock_exporter_control_list_entries, mock_countries, mock_pv_gradings):
     return authorized_client
 
 


### PR DESCRIPTION
This is dependent on this API change here: https://github.com/uktrade/lite-api/pull/2160/

This changes the exporter frontend to use the new exporter-specific CLEs endpoint.

[LTD-5381](https://uktrade.atlassian.net/browse/LTD-5381)

[LTD-5381]: https://uktrade.atlassian.net/browse/LTD-5381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ