### PR TITLE
Rewrite CLEs caching to use Django cache

### DIFF
--- a/caseworker/core/services.py
+++ b/caseworker/core/services.py
@@ -136,41 +136,43 @@ def get_user_role_name(request):
 # Control List Entries
 def get_control_list_entries(request, convert_to_options=False, include_parent=False):
     if convert_to_options:
-        if cache.get("caseworker_converted_control_list_entries_cache"):
-            return cache.get("caseworker_converted_control_list_entries_cache")
-        response = client.get(request, "/static/control-list-entries/")
-        response.raise_for_status()
-        caseworker_converted_control_list_entries_cache = [
+        if cache.get("caseworker_control_list_entries_cache"):
+            caseworker_control_list_entries = cache.get("caseworker_control_list_entries_cache")
+        else:
+            response = client.get(request, "/static/control-list-entries/")
+            response.raise_for_status()
+            caseworker_control_list_entries = response.json().get("control_list_entries")
+            cache.set("caseworker_control_list_entries_cache", caseworker_control_list_entries)
+
+        converted_control_list_entries = [
             Option(
                 key=control_list_entry["rating"],
                 value=control_list_entry["rating"],
                 description=control_list_entry["text"],
             )
-            for control_list_entry in response.json().get("control_list_entries")
+            for control_list_entry in caseworker_control_list_entries
         ]
-        cache.set("caseworker_converted_control_list_entries_cache", caseworker_converted_control_list_entries_cache)
-        return caseworker_converted_control_list_entries_cache
+        return converted_control_list_entries
 
     if include_parent:
-        if cache.get("caseworker_control_list_entries_cache__include_parent"):
-            return cache.get("caseworker_control_list_entries_cache__include_parent")
+        if cache.get("caseworker_control_list_entries_including_parent_cache"):
+            return cache.get("caseworker_control_list_entries_including_parent_cache")
         response = client.get(request, "/static/control-list-entries/?include_parent=True")
         response.raise_for_status()
-        caseworker_control_list_entries_cache__include_parent = response.json().get("control_list_entries")
+        control_list_entries_including_parent = response.json().get("control_list_entries")
         cache.set(
-            "caseworker_control_list_entries_cache__include_parent",
-            caseworker_control_list_entries_cache__include_parent,
+            "caseworker_control_list_entries_including_parent_cache",
+            control_list_entries_including_parent,
         )
-        return caseworker_control_list_entries_cache__include_parent
+        return control_list_entries_including_parent
 
-    if cache.get("caseworker_control_list_entries_cache__group"):
-        return cache.get("caseworker_control_list_entries_cache__group")
-
+    if cache.get("caseworker_control_list_entries_grouped_cache"):
+        return cache.get("caseworker_control_list_entries_grouped_cache")
     response = client.get(request, "/static/control-list-entries/?group=True")
     response.raise_for_status()
-    caseworker_control_list_entries_cache__group = response.json().get("control_list_entries")
-    cache.set("caseworker_control_list_entries_cache__group", caseworker_control_list_entries_cache__group)
-    return caseworker_control_list_entries_cache__group
+    control_list_entries_grouped = response.json().get("control_list_entries")
+    cache.set("caseworker_control_list_entries_grouped_cache", control_list_entries_grouped)
+    return control_list_entries_grouped
 
 
 # Regime Entries

--- a/exporter/core/services.py
+++ b/exporter/core/services.py
@@ -2,6 +2,7 @@ import logging
 from http import HTTPStatus
 from urllib.parse import urlencode
 
+from django.core.cache import cache
 from django.http import HttpResponse
 
 from core import client
@@ -198,24 +199,31 @@ def put_organisation_user(request, user_pk, json):
     return data.json(), data.status_code
 
 
-def get_control_list_entries(request, convert_to_options=False, converted_control_list_entries_cache=[]):  # noqa
+def get_control_list_entries(request, convert_to_options=False):
     if convert_to_options:
-        if converted_control_list_entries_cache:
-            return converted_control_list_entries_cache
+        if cache.get("exporter_converted_control_list_entries_cache"):
+            return cache.get("exporter_converted_control_list_entries_cache")
         else:
             response = client.get(request, "/exporter/static/control-list-entries/")
-            for control_list_entry in response.json():
-                converted_control_list_entries_cache.append(
-                    Option(
-                        key=control_list_entry["rating"],
-                        value=control_list_entry["rating"],
-                        description=control_list_entry["text"],
-                    )
+            response.raise_for_status()
+            converted_control_list_entries_cache = [
+                Option(
+                    key=control_list_entry["rating"],
+                    value=control_list_entry["rating"],
+                    description=control_list_entry["text"],
                 )
+                for control_list_entry in response.json()
+            ]
+            cache.set("exporter_converted_control_list_entries_cache", converted_control_list_entries_cache)
             return converted_control_list_entries_cache
-
-    response = client.get(request, "/exporter/static/control-list-entries/")
-    return response.json()
+    if cache.get("exporter_control_list_entries_cache"):
+        return cache.get("exporter_control_list_entries_cache")
+    else:
+        response = client.get(request, "/exporter/static/control-list-entries/")
+        response.raise_for_status()
+        exporter_control_list_entries_cache = response.json()
+        cache.set("exporter_control_list_entries_cache", exporter_control_list_entries_cache)
+        return exporter_control_list_entries_cache
 
 
 # F680 clearance types

--- a/exporter/core/services.py
+++ b/exporter/core/services.py
@@ -203,27 +203,28 @@ def get_control_list_entries(request, convert_to_options=False):
     if convert_to_options:
         if cache.get("exporter_converted_control_list_entries_cache"):
             return cache.get("exporter_converted_control_list_entries_cache")
-        else:
-            response = client.get(request, "/exporter/static/control-list-entries/")
-            response.raise_for_status()
-            converted_control_list_entries_cache = [
-                Option(
-                    key=control_list_entry["rating"],
-                    value=control_list_entry["rating"],
-                    description=control_list_entry["text"],
-                )
-                for control_list_entry in response.json()
-            ]
-            cache.set("exporter_converted_control_list_entries_cache", converted_control_list_entries_cache)
-            return converted_control_list_entries_cache
-    if cache.get("exporter_control_list_entries_cache"):
-        return cache.get("exporter_control_list_entries_cache")
-    else:
+
         response = client.get(request, "/exporter/static/control-list-entries/")
         response.raise_for_status()
-        exporter_control_list_entries_cache = response.json()
-        cache.set("exporter_control_list_entries_cache", exporter_control_list_entries_cache)
-        return exporter_control_list_entries_cache
+        converted_control_list_entries_cache = [
+            Option(
+                key=control_list_entry["rating"],
+                value=control_list_entry["rating"],
+                description=control_list_entry["text"],
+            )
+            for control_list_entry in response.json()
+        ]
+        cache.set("exporter_converted_control_list_entries_cache", converted_control_list_entries_cache)
+        return converted_control_list_entries_cache
+
+    if cache.get("exporter_control_list_entries_cache"):
+        return cache.get("exporter_control_list_entries_cache")
+
+    response = client.get(request, "/exporter/static/control-list-entries/")
+    response.raise_for_status()
+    exporter_control_list_entries_cache = response.json()
+    cache.set("exporter_control_list_entries_cache", exporter_control_list_entries_cache)
+    return exporter_control_list_entries_cache
 
 
 # F680 clearance types

--- a/exporter/core/services.py
+++ b/exporter/core/services.py
@@ -200,31 +200,26 @@ def put_organisation_user(request, user_pk, json):
 
 
 def get_control_list_entries(request, convert_to_options=False):
-    if convert_to_options:
-        if cache.get("exporter_converted_control_list_entries_cache"):
-            return cache.get("exporter_converted_control_list_entries_cache")
-
+    if cache.get("exporter_control_list_entries_cache"):
+        exporter_control_list_entries = cache.get("exporter_control_list_entries_cache")
+    else:
         response = client.get(request, "/exporter/static/control-list-entries/")
         response.raise_for_status()
-        converted_control_list_entries_cache = [
+        exporter_control_list_entries = response.json()
+        cache.set("exporter_control_list_entries_cache", exporter_control_list_entries)
+
+    if convert_to_options:
+        converted_control_list_entries = [
             Option(
                 key=control_list_entry["rating"],
                 value=control_list_entry["rating"],
                 description=control_list_entry["text"],
             )
-            for control_list_entry in response.json()
+            for control_list_entry in exporter_control_list_entries
         ]
-        cache.set("exporter_converted_control_list_entries_cache", converted_control_list_entries_cache)
-        return converted_control_list_entries_cache
+        return converted_control_list_entries
 
-    if cache.get("exporter_control_list_entries_cache"):
-        return cache.get("exporter_control_list_entries_cache")
-
-    response = client.get(request, "/exporter/static/control-list-entries/")
-    response.raise_for_status()
-    exporter_control_list_entries_cache = response.json()
-    cache.set("exporter_control_list_entries_cache", exporter_control_list_entries_cache)
-    return exporter_control_list_entries_cache
+    return exporter_control_list_entries
 
 
 # F680 clearance types

--- a/unit_tests/caseworker/conftest.py
+++ b/unit_tests/caseworker/conftest.py
@@ -42,7 +42,6 @@ def pytest_configure(config):
 @pytest.fixture(autouse=True)
 def delete_caseworker_control_list_entries_cache():
     caseworker_control_list_entries_cache_keys = [
-        "caseworker_converted_control_list_entries_cache",
         "caseworker_control_list_entries_cache__include_parent",
         "caseworker_control_list_entries_cache__group",
     ]

--- a/unit_tests/caseworker/conftest.py
+++ b/unit_tests/caseworker/conftest.py
@@ -7,6 +7,7 @@ from urllib import parse
 
 import pytest
 from dotenv import load_dotenv
+from django.core.cache import cache
 from django.conf import settings
 from django.test import Client
 from django.utils import timezone
@@ -36,6 +37,18 @@ def pytest_configure(config):
     # Force mock_sso django application to be activated for test environments;
     # must be activated up front for mock_sso django app urls to be added
     settings.MOCK_SSO_ACTIVATE_ENDPOINTS = True
+
+
+@pytest.fixture(autouse=True)
+def delete_caseworker_control_list_entries_cache():
+    caseworker_control_list_entries_cache_keys = [
+        "caseworker_converted_control_list_entries_cache",
+        "caseworker_control_list_entries_cache__include_parent",
+        "caseworker_control_list_entries_cache__group",
+    ]
+    for key in caseworker_control_list_entries_cache_keys:
+        if cache.get(key):
+            cache.delete(key)
 
 
 @pytest.fixture

--- a/unit_tests/caseworker/conftest.py
+++ b/unit_tests/caseworker/conftest.py
@@ -42,8 +42,9 @@ def pytest_configure(config):
 @pytest.fixture(autouse=True)
 def delete_caseworker_control_list_entries_cache():
     caseworker_control_list_entries_cache_keys = [
-        "caseworker_control_list_entries_cache__include_parent",
-        "caseworker_control_list_entries_cache__group",
+        "caseworker_control_list_entries_cache",
+        "caseworker_control_list_entries_including_parent_cache",
+        "caseworker_control_list_entries_grouped_cache",
     ]
     for key in caseworker_control_list_entries_cache_keys:
         if cache.get(key):

--- a/unit_tests/caseworker/core/test_services.py
+++ b/unit_tests/caseworker/core/test_services.py
@@ -1,4 +1,7 @@
-from caseworker.core.services import group_denial_reasons
+from django.core.cache import cache
+
+from caseworker.core.services import get_control_list_entries, group_denial_reasons
+from lite_forms.components import Option
 
 
 def test_group_denial_reasons():
@@ -28,3 +31,187 @@ def test_group_denial_reasons():
     expected_result = [("1", [("1a", "1a"), ("1b", "1b")])]
 
     assert list(result) == expected_result
+
+
+def test_get_control_list_entries_grouped_cache_empty_success(mock_control_list_entries_grouped_get, mock_request):
+    assert cache.get("caseworker_control_list_entries_grouped_cache") is None
+
+    control_list_entries_grouped = get_control_list_entries(mock_request)
+    assert control_list_entries_grouped == [
+        {
+            "id": "3fc955d3-1b0e-406f-96ee-b2a3c237f9bd",
+            "rating": "ML1",
+            "text": "Smooth-bore weapons with a calibre of less than 20mm, other firearms and automatic weapons with a calibre of 12.7mm or less, and accessories and specially designed components",
+            "parent_id": None,
+            "category": "UK Military List",
+            "controlled": True,
+            "selectable_for_assessment": True,
+            "children": [
+                {
+                    "id": "0b9116c2-3aa0-49fb-a590-944b4738b208",
+                    "rating": "ML1a",
+                    "text": "Rifles and combination guns, handguns, machine, sub-machine and volley guns",
+                    "parent_id": "3fc955d3-1b0e-406f-96ee-b2a3c237f9bd",
+                    "category": "UK Military List",
+                    "controlled": True,
+                    "selectable_for_assessment": True,
+                }
+            ],
+        }
+    ]
+
+    # assert that the API is called to get the grouped list of CLEs
+    assert mock_control_list_entries_grouped_get.called_once
+
+    # assert that the grouped CLEs are in the cache
+    assert cache.get("caseworker_control_list_entries_grouped_cache") == control_list_entries_grouped
+
+
+def test_get_control_list_entries_grouped_cached_data_success(mock_control_list_entries_grouped_get, mock_request):
+    # arrange test following empty cache test above
+    assert cache.get("caseworker_control_list_entries_grouped_cache") is None
+    control_list_entries_grouped = get_control_list_entries(mock_request)
+    assert control_list_entries_grouped == [
+        {
+            "id": "3fc955d3-1b0e-406f-96ee-b2a3c237f9bd",
+            "rating": "ML1",
+            "text": "Smooth-bore weapons with a calibre of less than 20mm, other firearms and automatic weapons with a calibre of 12.7mm or less, and accessories and specially designed components",
+            "parent_id": None,
+            "category": "UK Military List",
+            "controlled": True,
+            "selectable_for_assessment": True,
+            "children": [
+                {
+                    "id": "0b9116c2-3aa0-49fb-a590-944b4738b208",
+                    "rating": "ML1a",
+                    "text": "Rifles and combination guns, handguns, machine, sub-machine and volley guns",
+                    "parent_id": "3fc955d3-1b0e-406f-96ee-b2a3c237f9bd",
+                    "category": "UK Military List",
+                    "controlled": True,
+                    "selectable_for_assessment": True,
+                }
+            ],
+        }
+    ]
+    assert mock_control_list_entries_grouped_get.called_once
+
+    # get grouped CLEs again
+    control_list_entries_grouped = get_control_list_entries(mock_request)
+
+    # assert that call_count == 1 because the cached data was used
+    assert mock_control_list_entries_grouped_get.call_count == 1
+
+    # assert that the CLEs are still in the cache
+    assert cache.get("caseworker_control_list_entries_grouped_cache") == control_list_entries_grouped
+
+
+def test_get_control_list_entries_convert_to_options_cache_empty_success(mock_control_list_entries_get, mock_request):
+    assert cache.get("caseworker_control_list_entries_cache") is None
+
+    converted_control_list_entries = get_control_list_entries(mock_request, convert_to_options=True)
+
+    for option in converted_control_list_entries:
+        assert type(option) == Option
+    converted_control_list_entries_dicts = [
+        {"key": option.key, "value": option.value, "description": option.description}
+        for option in converted_control_list_entries
+    ]
+    assert converted_control_list_entries_dicts == [
+        {"description": "some text", "key": "ML1a", "value": "ML1a"},
+        {"description": "some text", "key": "ML22b", "value": "ML22b"},
+    ]
+
+    # assert that the API is called to get the grouped list of CLEs
+    assert mock_control_list_entries_get.called_once
+
+    # assert that the CLEs are in the cache
+    assert cache.get("caseworker_control_list_entries_cache") == [
+        {"rating": "ML1a", "text": "some text"},
+        {"rating": "ML22b", "text": "some text"},
+    ]
+
+
+def test_get_control_list_entries_convert_to_options_cached_data_success(mock_control_list_entries_get, mock_request):
+    # arrange test following empty cache test above
+    assert cache.get("caseworker_control_list_entries_cache") is None
+    converted_control_list_entries = get_control_list_entries(mock_request, convert_to_options=True)
+    for option in converted_control_list_entries:
+        assert type(option) == Option
+    converted_control_list_entries_dicts = [
+        {"key": option.key, "value": option.value, "description": option.description}
+        for option in converted_control_list_entries
+    ]
+    assert converted_control_list_entries_dicts == [
+        {"description": "some text", "key": "ML1a", "value": "ML1a"},
+        {"description": "some text", "key": "ML22b", "value": "ML22b"},
+    ]
+    assert mock_control_list_entries_get.called_once
+
+    # get CLE options again
+    converted_control_list_entries = get_control_list_entries(mock_request, convert_to_options=True)
+
+    # assert that call_count == 1 because the cached data was used
+    assert mock_control_list_entries_get.call_count == 1
+
+    # assert that the CLEs are still in the cache
+    assert cache.get("caseworker_control_list_entries_cache") == [
+        {"rating": "ML1a", "text": "some text"},
+        {"rating": "ML22b", "text": "some text"},
+    ]
+
+
+def test_get_control_list_entries_including_parent_empty_cache_success(
+    mock_control_list_entries_including_parent_get, mock_request
+):
+    assert cache.get("caseworker_control_list_entries_including_parent_cache") is None
+
+    control_list_entries_including_parent = get_control_list_entries(mock_request, include_parent=True)
+
+    assert control_list_entries_including_parent == [
+        {
+            "rating": "ML1",
+            "text": "Smooth-bore weapons with a calibre of less than 20mm, other firearms and automatic weapons with a calibre of 12.7mm or less, and accessories and specially designed components",
+            "parent": None,
+        },
+        {
+            "rating": "ML1a",
+            "text": "Rifles and combination guns, handguns, machine, sub-machine and volley guns",
+            "parent": "3fc955d3-1b0e-406f-96ee-b2a3c237f9bd",
+        },
+    ]
+
+    # assert that the API is called to get the list of CLEs including parent
+    assert mock_control_list_entries_including_parent_get.called_once
+
+    # assert that the CLEs including parent are in the cache
+    assert cache.get("caseworker_control_list_entries_including_parent_cache") == control_list_entries_including_parent
+
+
+def test_get_control_list_entries_including_parent_cached_data_success(
+    mock_control_list_entries_including_parent_get, mock_request
+):
+    # arrange test following empty cache test above
+    assert cache.get("caseworker_control_list_entries_including_parent_cache") is None
+    control_list_entries_including_parent = get_control_list_entries(mock_request, include_parent=True)
+    assert control_list_entries_including_parent == [
+        {
+            "rating": "ML1",
+            "text": "Smooth-bore weapons with a calibre of less than 20mm, other firearms and automatic weapons with a calibre of 12.7mm or less, and accessories and specially designed components",
+            "parent": None,
+        },
+        {
+            "rating": "ML1a",
+            "text": "Rifles and combination guns, handguns, machine, sub-machine and volley guns",
+            "parent": "3fc955d3-1b0e-406f-96ee-b2a3c237f9bd",
+        },
+    ]
+    assert mock_control_list_entries_including_parent_get.called_once
+
+    # get CLEs including parent again
+    control_list_entries_including_parent = get_control_list_entries(mock_request, include_parent=True)
+
+    # assert that call_count == 1 because the cached data was used
+    assert mock_control_list_entries_including_parent_get.call_count == 1
+
+    # assert that the CLEs including parent are still in the cache
+    assert cache.get("caseworker_control_list_entries_including_parent_cache") == control_list_entries_including_parent

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -21,7 +21,6 @@ from django.utils import timezone
 
 from formtools.wizard.views import normalize_name
 
-from caseworker.core.services import CLC_ENTRIES_CACHE
 from core import client
 from core.constants import OrganisationDocumentType
 
@@ -96,10 +95,6 @@ def data_control_list_entries():
 
 @pytest.fixture
 def mock_control_list_entries(requests_mock, data_control_list_entries):
-    # We must clear app-level CLE cache used by core.services.get_control_list_entrie
-    # so that tests remain isolated from eachother
-    # TODO: Remove this when we have a better way of caching CLEs
-    CLC_ENTRIES_CACHE.clear()
     url = client._build_absolute_uri("/static/control-list-entries/")
     yield requests_mock.get(url=url, json=data_control_list_entries)
 

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -2536,6 +2536,60 @@ def mock_control_list_entries_get(requests_mock):
     )
 
 
+@pytest.fixture
+def mock_control_list_entries_grouped_get(requests_mock):
+    url = client._build_absolute_uri(f"/static/control-list-entries/?group=True")
+    return requests_mock.get(
+        url=url,
+        json={
+            "control_list_entries": [
+                {
+                    "id": "3fc955d3-1b0e-406f-96ee-b2a3c237f9bd",
+                    "rating": "ML1",
+                    "text": "Smooth-bore weapons with a calibre of less than 20mm, other firearms and automatic weapons with a calibre of 12.7mm or less, and accessories and specially designed components",
+                    "parent_id": None,
+                    "category": "UK Military List",
+                    "controlled": True,
+                    "selectable_for_assessment": True,
+                    "children": [
+                        {
+                            "id": "0b9116c2-3aa0-49fb-a590-944b4738b208",
+                            "rating": "ML1a",
+                            "text": "Rifles and combination guns, handguns, machine, sub-machine and volley guns",
+                            "parent_id": "3fc955d3-1b0e-406f-96ee-b2a3c237f9bd",
+                            "category": "UK Military List",
+                            "controlled": True,
+                            "selectable_for_assessment": True,
+                        }
+                    ],
+                }
+            ],
+        },
+    )
+
+
+@pytest.fixture
+def mock_control_list_entries_including_parent_get(requests_mock):
+    url = client._build_absolute_uri(f"/static/control-list-entries/?include_parent=True")
+    return requests_mock.get(
+        url=url,
+        json={
+            "control_list_entries": [
+                {
+                    "rating": "ML1",
+                    "text": "Smooth-bore weapons with a calibre of less than 20mm, other firearms and automatic weapons with a calibre of 12.7mm or less, and accessories and specially designed components",
+                    "parent": None,
+                },
+                {
+                    "rating": "ML1a",
+                    "text": "Rifles and combination guns, handguns, machine, sub-machine and volley guns",
+                    "parent": "3fc955d3-1b0e-406f-96ee-b2a3c237f9bd",
+                },
+            ]
+        },
+    )
+
+
 class WizardStepPoster:
     def __init__(self, authorized_client, url):
         self.authorized_client = authorized_client

--- a/unit_tests/exporter/conftest.py
+++ b/unit_tests/exporter/conftest.py
@@ -5,6 +5,7 @@ import requests
 from dotenv import load_dotenv
 
 from django.conf import settings
+from django.core.cache import cache
 from django.core.files.storage import Storage
 from django.test import Client
 
@@ -34,6 +35,15 @@ def pytest_configure(config):
 @pytest.fixture(autouse=True)
 def upload_handler():
     settings.FILE_UPLOAD_HANDLERS = ["django.core.files.uploadhandler.MemoryFileUploadHandler"]
+
+
+@pytest.fixture(autouse=True)
+def delete_exporter_control_list_entries_cache():
+    # This keeps tests isolated
+    if cache.get("exporter_converted_control_list_entries_cache"):
+        cache.delete("exporter_converted_control_list_entries_cache")
+    if cache.get("exporter_control_list_entries_cache"):
+        cache.delete("exporter_control_list_entries_cache")
 
 
 @pytest.fixture

--- a/unit_tests/exporter/conftest.py
+++ b/unit_tests/exporter/conftest.py
@@ -39,11 +39,13 @@ def upload_handler():
 
 @pytest.fixture(autouse=True)
 def delete_exporter_control_list_entries_cache():
-    # This keeps tests isolated
-    if cache.get("exporter_converted_control_list_entries_cache"):
-        cache.delete("exporter_converted_control_list_entries_cache")
-    if cache.get("exporter_control_list_entries_cache"):
-        cache.delete("exporter_control_list_entries_cache")
+    exporter_control_list_entries_cache_keys = [
+        "exporter_converted_control_list_entries_cache",
+        "exporter_control_list_entries_cache",
+    ]
+    for key in exporter_control_list_entries_cache_keys:
+        if cache.get(key):
+            cache.delete(key)
 
 
 @pytest.fixture

--- a/unit_tests/exporter/conftest.py
+++ b/unit_tests/exporter/conftest.py
@@ -39,13 +39,8 @@ def upload_handler():
 
 @pytest.fixture(autouse=True)
 def delete_exporter_control_list_entries_cache():
-    exporter_control_list_entries_cache_keys = [
-        "exporter_converted_control_list_entries_cache",
-        "exporter_control_list_entries_cache",
-    ]
-    for key in exporter_control_list_entries_cache_keys:
-        if cache.get(key):
-            cache.delete(key)
+    if cache.get("exporter_control_list_entries_cache"):
+        cache.delete("exporter_control_list_entries_cache")
 
 
 @pytest.fixture

--- a/unit_tests/exporter/core/test_services.py
+++ b/unit_tests/exporter/core/test_services.py
@@ -1,0 +1,33 @@
+from django.core.cache import cache
+
+from exporter.core.services import get_control_list_entries
+
+
+def test_get_control_list_entries_cache_empty_success(mock_exporter_control_list_entries_get, mock_request):
+    assert cache.get("exporter_control_list_entries_cache") is None
+
+    control_list_entries = get_control_list_entries(mock_request)
+    assert control_list_entries == [{"rating": "ML1a", "text": "some text"}, {"rating": "ML22b", "text": "some text"}]
+
+    # assert that the API is called to get the list of CLEs
+    assert mock_exporter_control_list_entries_get.called_once
+
+    # assert that the CLEs are in the cache
+    assert cache.get("exporter_control_list_entries_cache") == control_list_entries
+
+
+def test_get_control_list_entries_cached_data_success(mock_exporter_control_list_entries_get, mock_request):
+    # arrange test following empty cache test above
+    assert cache.get("exporter_control_list_entries_cache") is None
+    control_list_entries = get_control_list_entries(mock_request)
+    assert control_list_entries == [{"rating": "ML1a", "text": "some text"}, {"rating": "ML22b", "text": "some text"}]
+    assert mock_exporter_control_list_entries_get.called_once
+
+    # get CLEs again
+    control_list_entries = get_control_list_entries(mock_request)
+
+    # assert that call_count == 1 because the cached data was used
+    assert mock_exporter_control_list_entries_get.call_count == 1
+
+    # assert that the CLEs are still in the cache
+    assert cache.get("exporter_control_list_entries_cache") == control_list_entries

--- a/unit_tests/exporter/core/test_services.py
+++ b/unit_tests/exporter/core/test_services.py
@@ -1,6 +1,7 @@
 from django.core.cache import cache
 
 from exporter.core.services import get_control_list_entries
+from lite_forms.components import Option
 
 
 def test_get_control_list_entries_cache_empty_success(mock_exporter_control_list_entries_get, mock_request):
@@ -31,3 +32,17 @@ def test_get_control_list_entries_cached_data_success(mock_exporter_control_list
 
     # assert that the CLEs are still in the cache
     assert cache.get("exporter_control_list_entries_cache") == control_list_entries
+
+
+def test_get_control_list_entries_convert_to_options_success(mock_exporter_control_list_entries_get, mock_request):
+    converted_control_list_entries = get_control_list_entries(mock_request, convert_to_options=True)
+    for option in converted_control_list_entries:
+        assert type(option) == Option
+    converted_control_list_entries_dicts = [
+        {"key": option.key, "value": option.value, "description": option.description}
+        for option in converted_control_list_entries
+    ]
+    assert converted_control_list_entries_dicts == [
+        {"description": "some text", "key": "ML1a", "value": "ML1a"},
+        {"description": "some text", "key": "ML22b", "value": "ML22b"},
+    ]


### PR DESCRIPTION
### Aim

This rewrites the `get_control_list_entries` service functions in both caseworker and exporter to not use a mutable default variable cache and to use the Django cache instead.

[LTD-5397](https://uktrade.atlassian.net/browse/LTD-5397)


[LTD-5397]: https://uktrade.atlassian.net/browse/LTD-5397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ