### PR TITLE
LTD-5434 Improve out of date content on the service start page

### DIFF
--- a/lite_content/lite_exporter_frontend/core.py
+++ b/lite_content/lite_exporter_frontend/core.py
@@ -37,11 +37,11 @@ class StartPage:
 
 
 class StartPageGovUK:
-    TITLE = "Apply for an export licence using LITE"
+    TITLE = "Apply for a standard individual export licence (SIEL)"
     BULLET_POINTS = [
-        "apply for a SIEL firearms licence",
+        "apply for a SIEL to export goods or products",
         "edit or check an application",
-        "view existing licences issued in LITE ",
+        "view your existing SIELs",
     ]
     DESCRIPTION = "Use this service to:"
     SIGN_IN_BUTTON = "Start now >"


### PR DESCRIPTION
### Aim

The content on the start page of the service is currently out of date: https://apply-for-a-standard-individual-export-licence.service.gov.uk/. 

The current content suggests that you can only use the service to apply for a SIEL firearms licence. It also uses the term ‘LITE’ which is no longer being used on any public facing content.

The title on this page should be changed to: Apply for a standard individual export licence (SIEL). This mirrors the URL and the title on the [GOV.UK](http://gov.uk/) start page

The content under ‘Use this service to:' needs amended to match the [GOV.UK](http://gov.uk/) start page. It should read… 

Use this service to:

- apply for a SIEL to export goods or products

- edit or check an application

- view your existing SIELs

[LTD-5434](https://uktrade.atlassian.net/browse/LTD-5434)
