### PR TITLE
Remove unused flagging rule fixtures

### DIFF
--- a/unit_tests/caseworker/conftest.py
+++ b/unit_tests/caseworker/conftest.py
@@ -2335,21 +2335,9 @@ def mock_put_flags(requests_mock, stub_response):
 
 
 @pytest.fixture
-def mock_flagging_rules(requests_mock):
-    url = client._build_absolute_uri(f"/flags/rules/?page=1")
-    yield requests_mock.get(url=url, json={"results": []})
-
-
-@pytest.fixture
 def mock_flag_get(requests_mock, request):
     url = client._build_absolute_uri("/flags/e9f8711e-b383-47e5-b160-153f27771234/")
     yield requests_mock.get(url=url, json={})
-
-
-@pytest.fixture
-def mock_flagging_rule_get(requests_mock):
-    url = client._build_absolute_uri("/flags/rules/e9f8711e-b383-47e5-b160-153f27771234/")
-    yield requests_mock.get(url=url, json={"flag": {"level": "Destination", "matching_values": []}})
 
 
 @pytest.fixture

--- a/unit_tests/caseworker/flags/test_views.py
+++ b/unit_tests/caseworker/flags/test_views.py
@@ -12,10 +12,8 @@ def setup(
     mock_put_flags,
     mock_case,
     mock_get_organisation,
-    mock_flagging_rules,
     mock_countries,
     mock_flag_get,
-    mock_flagging_rule_get,
 ):
     yield
 


### PR DESCRIPTION
### Aim

Remove fixtures that aren't used that relate to flagging rules.

[LTD-5518](https://uktrade.atlassian.net/browse/LTD-5518)


[LTD-5518]: https://uktrade.atlassian.net/browse/LTD-5518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ