### PR TITLE
 LTD-5539-cw-show-user-status 

### DIFF
--- a/caseworker/templates/organisations/organisation/members.html
+++ b/caseworker/templates/organisations/organisation/members.html
@@ -12,12 +12,13 @@
 		<table class="govuk-table">
 			<thead class="govuk-table__head">
 				<tr class="govuk-table__row">
-					<th class="govuk-table__header" scope="col">{% lcs 'organisations.OrganisationPage.Members.Table.NAME' %}</th>
-					<th class="govuk-table__header" scope="col">{% lcs 'organisations.OrganisationPage.Members.Table.EMAIL' %}</th>
+					<th class="govuk-table__header" scope="col">Name</th>
+					<th class="govuk-table__header" scope="col">Email</th>
 					{% if "phone_number" in members.0 %}
 						<th class="govuk-table__header" scope="col">Contact number</th>
 					{% endif %}
-					<th class="govuk-table__header" scope="col">{% lcs 'organisations.OrganisationPage.Members.Table.ROLE' %}</th>
+					<th class="govuk-table__header" scope="col">Role</th>
+					<th class="govuk-table__header" scope="col">Status</th>
 				</tr>
 			</thead>
 			<tbody class="govuk-table__body">
@@ -37,6 +38,7 @@
 							<td class="govuk-table__cell">{{ member.phone_number }}</td>
 						{% endif %}
 						<td class="govuk-table__cell">{{ member.role_name }}</td>
+						<td class="govuk-table__cell">{{ member.status }}</td>
 					</tr>
 				{% endfor %}
 			</tbody>


### PR DESCRIPTION
Internal users are unable to see the status of a member within an Organisation. 

Hence this PR allows status to be displayed to help assist LITE support to help with loggin issues. 