### PR TITLE
Stop displaying markdown on summary component

### DIFF
--- a/lite_forms/templates/components/summary.html
+++ b/lite_forms/templates/components/summary.html
@@ -5,7 +5,7 @@
                 {{ key }}
             </dt>
             <dd class="govuk-summary-list__value">
-                <span data-max-length="300">{{ value|markdown }}</span>
+                {{ value }}
             </dd>
         </div>
     {% endfor %}

--- a/unit_tests/caseworker/organisations/test_views.py
+++ b/unit_tests/caseworker/organisations/test_views.py
@@ -160,4 +160,4 @@ def test_review_organisation(authorized_client, requests_mock, retrieved_organis
     soup = BeautifulSoup(response.content, "html.parser")
     soup.find_all("govuk-summary-list__row")
     org_details = soup.find_all(class_="govuk-summary-list__row")
-    assert org_details[1].span.text == expected_value
+    assert org_details[1].select_one(".govuk-summary-list__value").text.strip() == expected_value


### PR DESCRIPTION
### Aim

Remove markdown rendering in lite_forms summary component.

[LTD-5572](https://uktrade.atlassian.net/browse/LTD-5572)


[LTD-5572]: https://uktrade.atlassian.net/browse/LTD-5572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ