### PR TITLE
Make F1686 reference number field optional

### DIFF
--- a/exporter/applications/views/security_approvals/forms.py
+++ b/exporter/applications/views/security_approvals/forms.py
@@ -76,7 +76,7 @@ class SubjectToITARControlsForm(BaseForm):
         TITLE = "Are any products on this application subject to ITAR controls?"
 
     label = """
-    We need to know if this export involves any defence articles including technical data that are 
+    We need to know if this export involves any defence articles including technical data that are
     subject to controls under the United States (US) International Traffic in Arms regulations (ITAR).
     """
 
@@ -126,11 +126,9 @@ class F1686DetailsForm(BaseForm):
     )
 
     f1686_reference_number = forms.CharField(
+        required=False,
         widget=forms.TextInput,
         label="Reference number",
-        error_messages={
-            "required": "Enter a reference number",
-        },
     )
 
     f1686_approval_date = CustomErrorDateInputField(

--- a/exporter/applications/views/security_approvals/forms.py
+++ b/exporter/applications/views/security_approvals/forms.py
@@ -128,7 +128,7 @@ class F1686DetailsForm(BaseForm):
     f1686_reference_number = forms.CharField(
         required=False,
         widget=forms.TextInput,
-        label="Reference number",
+        label="Reference number (optional)",
     )
 
     f1686_approval_date = CustomErrorDateInputField(

--- a/unit_tests/exporter/applications/views/security_approvals/test_security_approvals_edit_views.py
+++ b/unit_tests/exporter/applications/views/security_approvals/test_security_approvals_edit_views.py
@@ -83,6 +83,20 @@ def post_to_edit_security_approvals(post_to_step_factory, edit_security_approval
                 "f1686_approval_date": "2020-02-02",
             },
         ),
+        (
+            "edit_security_approvals_f1686_details",
+            {
+                "f1686_contracting_authority": "some text",
+                "f1686_approval_date_0": "01",
+                "f1686_approval_date_1": "01",
+                "f1686_approval_date_2": "2022",
+            },
+            {
+                "f1686_contracting_authority": "some text",
+                "f1686_reference_number": "",
+                "f1686_approval_date": "2022-01-01",
+            },
+        ),
     ),
 )
 def test_edit_export_details_post(

--- a/unit_tests/exporter/applications/views/security_approvals/test_security_approvals_forms.py
+++ b/unit_tests/exporter/applications/views/security_approvals/test_security_approvals_forms.py
@@ -118,7 +118,6 @@ def test_security_other_details(data, is_valid, errors):
             {
                 "f1686_contracting_authority": ["Enter the contracting authority (or signatory and job role)"],
                 "f1686_approval_date": ["Enter the approval date"],
-                "f1686_reference_number": ["Enter a reference number"],
             },
         ),
         (


### PR DESCRIPTION
### Aim

In the security approvals section of exporter app, the F1686 reference number needs to be optional. This updates the field so that `required=False` and updates the label to show it is an optional field.

[LTD-5592](https://uktrade.atlassian.net/browse/LTD-5592)


[LTD-5592]: https://uktrade.atlassian.net/browse/LTD-5592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ