### PR TITLE
LTD-5603-privilege-escalation-restrict-view-profile 

### DIFF
--- a/caseworker/core/rules.py
+++ b/caseworker/core/rules.py
@@ -12,6 +12,7 @@ from caseworker.advice.services import (
 )
 from caseworker.core.constants import (
     ADMIN_TEAM_ID,
+    SUPER_USER_ROLE_ID,
     TAU_TEAM_ID,
     LICENSING_UNIT_TEAM_ID,
     LICENSING_UNIT_SENIOR_MANAGER_ROLE_ID,
@@ -180,6 +181,21 @@ def is_organisation_active(request, organisation):
     return organisation["status"]["key"] == "active"
 
 
+@rules.predicate
+def is_super_user(request):
+    user = get_logged_in_caseworker(request)
+    return user.get("role", {}).get("id") == SUPER_USER_ROLE_ID
+
+
+@rules.predicate
+def check_user_is_not_logged_in_caseworker(request, user):
+    caseworker = get_logged_in_caseworker(request)
+    caseworker_user_id = caseworker["id"]
+    if not user:
+        return True
+    return user.get("user", {}).get("id") != caseworker_user_id
+
+
 rules.add_rule("can_user_allocate_case", is_case_caseworker_operable)
 rules.add_rule("can_user_change_case", is_user_allocated)
 rules.add_rule("can_user_move_case_forward", is_user_allocated)
@@ -205,3 +221,9 @@ rules.add_rule(
     "can_licence_status_be_changed", is_user_licencing_unit_senior_manager & is_case_finalised_and_licence_editable
 )
 rules.add_rule("can_user_manage_organisation", is_user_manage_organisations_role & is_organisation_active)
+rules.add_rule("can_caseworker_edit_role", is_super_user | is_user_in_admin_team)  # noqa
+rules.add_rule("can_caseworker_edit_team", is_super_user | is_user_in_admin_team)  # noqa
+rules.add_rule(
+    "can_caseworker_deactivate",
+    (is_super_user | is_user_in_admin_team) & check_user_is_not_logged_in_caseworker,  # noqa
+)

--- a/caseworker/templates/users/profile.html
+++ b/caseworker/templates/users/profile.html
@@ -1,4 +1,5 @@
 {% extends 'layouts/two-pane.html' %}
+{% load rules %}
 
 {% block back_link %}
 	<a href="{% url 'users:users' %}" id="back-link" class="govuk-back-link">
@@ -20,8 +21,8 @@
 			</h1>
 		</div>
 		<div class="lite-app-bar__controls">
-			{% if can_deactivate %}
-				{% if request.session.lite_api_user_id|stringformat:"s" != data.user.id|stringformat:"s" %}
+			{% test_rule 'can_caseworker_deactivate' request data as show_deactivate %}
+			{% if show_deactivate %}
 					{% if data.user.status == 'Active' %}
 						<a id="button-deactivate-user" href="{% url 'users:change_status' data.user.id 'deactivate' %}" role="button" draggable="false" class="govuk-button govuk-button--secondary">
 							{% lcs 'users.UserProfile.DEACTIVATE_BUTTON' %}
@@ -31,7 +32,6 @@
 							{% lcs 'users.UserProfile.REACTIVATE_BUTTON' %}
 						</a>
 					{% endif %}
-				{% endif %}
 			{% endif %}
 		</div>
 	</div>
@@ -81,7 +81,8 @@
 				<a href="{% url 'teams:team' data.user.team.id %}" id="user-team-name" class="govuk-link govuk-link--no-visited-state">{{ data.user.team.name }}</a>
 			</dd>
 			<dd class="govuk-summary-list__actions">
-				{% if can_edit_team %}
+				{% test_rule 'can_caseworker_edit_team' request as show_edit_team %}
+				{% if show_edit_team %}
 					<a id="link-edit-team" href="{% url 'users:edit' data.user.id %}#team" class="govuk-link govuk-link--no-visited-state">
 						{% lcs 'users.UserProfile.SummaryList.CHANGE' %}
 						<span class="govuk-visually-hidden">{% lcs 'users.UserProfile.SummaryList.TEAM' %}</span>
@@ -97,7 +98,8 @@
 				{{ data.user.role.name }}
 			</dd>
 			<dd class="govuk-summary-list__actions">
-				{% if can_edit_role %}
+				{% test_rule 'can_caseworker_edit_role' request as show_edit_role %}
+				{% if show_edit_role %}
 					<a id="link-edit-role" href="{% url 'users:edit' data.user.id %}#role" class="govuk-link govuk-link--no-visited-state">
 						{% lcs 'users.UserProfile.SummaryList.CHANGE' %}
 						<span class="govuk-visually-hidden">{% lcs 'users.UserProfile.SummaryList.ROLE' %}</span>

--- a/caseworker/users/views/users.py
+++ b/caseworker/users/views/users.py
@@ -9,7 +9,6 @@ from caseworker.cases.services import update_mentions
 from core.auth.views import LoginRequiredMixin
 from caseworker.core.constants import (
     ADMIN_TEAM_ID,
-    SUPER_USER_ROLE_ID,
     UserStatuses,
 )
 from lite_content.lite_internal_frontend import strings
@@ -78,19 +77,8 @@ class AddUser(SingleFormView):
 class ViewUser(TemplateView):
     def get(self, request, **kwargs):
         data, _ = get_gov_user(request, str(kwargs["pk"]))
-        request_user, _ = get_gov_user(request, str(request.session["lite_api_user_id"]))
-        super_user = is_super_user(request_user)
-        can_deactivate = not is_super_user(data)
-        can_edit_role = data["user"]["id"] != request.session["lite_api_user_id"]
-        can_edit_team = super_user or is_user_in_team(request_user, ADMIN_TEAM_ID)
-
         context = {
             "data": data,
-            "super_user": super_user,
-            "super_user_role_id": SUPER_USER_ROLE_ID,
-            "can_deactivate": can_deactivate,
-            "can_edit_role": can_edit_role,
-            "can_edit_team": can_edit_team,
         }
         return render(request, "users/profile.html", context)
 

--- a/unit_tests/caseworker/core/test_rules.py
+++ b/unit_tests/caseworker/core/test_rules.py
@@ -19,6 +19,7 @@ from caseworker.core.constants import (
     ADMIN_TEAM_ID,
     FCDO_TEAM_ID,
     LICENSING_UNIT_TEAM_ID,
+    SUPER_USER_ROLE_ID,
     TAU_TEAM_ID,
     LICENSING_UNIT_SENIOR_MANAGER_ROLE_ID,
     Permission,
@@ -698,3 +699,74 @@ def test_can_user_manage_organisation(
     request = get_mock_request(user)
     data_organisation["status"]["key"] = organisation_status
     assert rules.test_rule("can_user_manage_organisation", request, data_organisation) is expected
+
+
+@pytest.mark.parametrize(
+    ("user_role", "user_team", "expected"),
+    (
+        (SUPER_USER_ROLE_ID, ADMIN_TEAM_ID, True),
+        (SUPER_USER_ROLE_ID, TAU_TEAM_ID, True),
+        (LICENSING_UNIT_SENIOR_MANAGER_ROLE_ID, ADMIN_TEAM_ID, True),
+        (LICENSING_UNIT_SENIOR_MANAGER_ROLE_ID, TAU_TEAM_ID, False),
+        (None, None, False),
+    ),
+)
+def test_can_caseworker_edit_role(mock_gov_user, get_mock_request, user_team, user_role, expected):
+    user = mock_gov_user["user"]
+    user["role"]["id"] = user_role
+    user["team"]["id"] = user_team
+    request = get_mock_request(user)
+    assert rules.test_rule("can_caseworker_edit_role", request) is expected
+
+
+@pytest.mark.parametrize(
+    ("user_role", "user_team", "expected"),
+    (
+        (SUPER_USER_ROLE_ID, ADMIN_TEAM_ID, True),
+        (SUPER_USER_ROLE_ID, TAU_TEAM_ID, True),
+        (LICENSING_UNIT_SENIOR_MANAGER_ROLE_ID, ADMIN_TEAM_ID, True),
+        (LICENSING_UNIT_SENIOR_MANAGER_ROLE_ID, TAU_TEAM_ID, False),
+        (None, None, False),
+    ),
+)
+def test_can_caseworker_edit_team(mock_gov_user, get_mock_request, user_team, user_role, expected):
+
+    user = mock_gov_user["user"]
+    user["role"]["id"] = user_role
+    user["team"]["id"] = user_team
+
+    request = get_mock_request(user)
+    assert rules.test_rule("can_caseworker_edit_team", request) is expected
+
+
+@pytest.mark.parametrize(
+    ("user_role", "user_team", "user_data", "expected"),
+    (
+        (SUPER_USER_ROLE_ID, ADMIN_TEAM_ID, {"user": {"id": "123"}}, True),
+        (SUPER_USER_ROLE_ID, TAU_TEAM_ID, {"user": {"id": "123"}}, True),
+        (LICENSING_UNIT_SENIOR_MANAGER_ROLE_ID, ADMIN_TEAM_ID, {"user": {"id": "123"}}, True),
+        (SUPER_USER_ROLE_ID, ADMIN_TEAM_ID, {"user": {"id": "2a43805b-c082-47e7-9188-c8b3e1a83cb0"}}, False),
+        (SUPER_USER_ROLE_ID, TAU_TEAM_ID, {"user": {"id": "2a43805b-c082-47e7-9188-c8b3e1a83cb0"}}, False),
+        (
+            LICENSING_UNIT_SENIOR_MANAGER_ROLE_ID,
+            ADMIN_TEAM_ID,
+            {"user": {"id": "2a43805b-c082-47e7-9188-c8b3e1a83cb0"}},
+            False,
+        ),
+        (
+            LICENSING_UNIT_SENIOR_MANAGER_ROLE_ID,
+            TAU_TEAM_ID,
+            {"user": {"id": "2a43805b-c082-47e7-9188-c8b3e1a83cb0"}},
+            False,
+        ),
+        (SUPER_USER_ROLE_ID, ADMIN_TEAM_ID, None, True),
+        (None, None, None, False),
+    ),
+)
+def test_can_caseworker_deactivate(mock_gov_user, get_mock_request, user_team, user_role, user_data, expected):
+
+    user = mock_gov_user["user"]
+    user["role"]["id"] = user_role
+    user["team"]["id"] = user_team
+    request = get_mock_request(user)
+    assert rules.test_rule("can_caseworker_deactivate", request, user_data) is expected


### PR DESCRIPTION
https://uktrade.atlassian.net/browse/LTD-5603

This restricts the view profile and removes the change links so only a super-user or someone from Admin team can change roles and teams. 

This PR is more about injecting in the permissions for following PR which will restrict  the change profile screen. 

At the moment i've decided to keep this as a lite form but the change user profile screen may be easier to convert to a crispy_form at that point I will consider moving both  views. 