### PR TITLE
Remove unused licence value from the response

### DIFF
--- a/tests_common/api_client/sub_helpers/cases.py
+++ b/tests_common/api_client/sub_helpers/cases.py
@@ -79,14 +79,12 @@ class Cases:
         ).json()["generated_document"]
         self.api_client.add_to_context("generated_document", generated_document)
 
-    def finalise_licence(self, case_id, save_licence=True):
+    def finalise_licence(self, case_id):
         response = self.api_client.make_request(
             method="PUT",
             url="/cases/" + case_id + "/finalise/",
             headers=self.api_client.gov_headers,
         ).json()
-        if save_licence:
-            self.api_client.add_to_context("licence", response["licence"])
 
     def manage_case_status(self, draft_id, status="withdrawn"):
         draft_id_to_change = draft_id or self.api_client.context["draft_id"]

--- a/ui_tests/exporter/conftest.py
+++ b/ui_tests/exporter/conftest.py
@@ -754,7 +754,6 @@ def create_licence(context, decision, api_test_client):  # noqa
 
     if decision != "no_licence_required":
         api_test_client.cases.finalise_licence(context.case_id)
-        context.licence = api_test_client.context["licence"]
 
 
 @given(parsers.parse('I create a licence for my open application with "{decision}" decision document'))  # noqa
@@ -771,7 +770,6 @@ def create_open_licence(context, decision, api_test_client):  # noqa
 
     if decision != "no_licence_required":
         api_test_client.cases.finalise_licence(context.case_id)
-        context.licence = api_test_client.context["licence"]
 
 
 @given("I finalise my NLR decision")  # noqa
@@ -782,7 +780,7 @@ def finalise_case_with_nlr_decision(context, api_test_client):  # noqa
     api_test_client.cases.finalise_case(context.case_id, "no_licence_required")
     api_test_client.cases.add_generated_document(context.case_id, document_template["id"], "no_licence_required")
     context.generated_document = api_test_client.context["generated_document"]
-    api_test_client.cases.finalise_licence(context.case_id, save_licence=False)
+    api_test_client.cases.finalise_licence(context.case_id)
 
 
 @given(
@@ -799,7 +797,6 @@ def create_licence_with_licenced_goods(context, decision, api_test_client):  # n
     api_test_client.cases.finalise_case(context.case_id, "approve", additional_data)
     api_test_client.cases.add_generated_document(context.case_id, document_template["id"], decision)
     api_test_client.cases.finalise_licence(context.case_id)
-    context.licence = api_test_client.context["licence"]
 
 
 @then(parsers.parse('I can see the sections "{sections}" are on the task list'))  # noqa

--- a/ui_tests/exporter/step_defs/test_licences.py
+++ b/ui_tests/exporter/step_defs/test_licences.py
@@ -51,7 +51,7 @@ def licences_page(driver, exporter_url):
 @then("I see my standard licence")
 def standard_licence_row(context, driver, assessed_control_list_entries):
     Shared(driver).filter_by_reference_number(context.reference_code)
-    row = LicencesPage(driver).licence_row_properties(context.licence)
+    row = LicencesPage(driver).licence_row_properties(context.reference_code)
     assert context.reference_code in row
     assert ", ".join(assessed_control_list_entries) in row
     assert context.goods[0]["good"]["name"] in row


### PR DESCRIPTION
## Change description

As part of refactoring in https://github.com/uktrade/lite-api/pull/2271/files#diff-3188e96699ad37ebbf91918c4ddd9ba0f05db1a8651b0885e0842530e69d268bR897 removing this from the return value.
It is also not used in the FE. This is also not consistent as the value can be null if it is a refusal or all NLR products leading to additional checks on the client side

References in the UI tests are also removed.
