### PR TITLE
Asset compilation dbt platform

### DIFF
--- a/.copilot/image_build_run.sh
+++ b/.copilot/image_build_run.sh
@@ -1,3 +1,26 @@
 #!/usr/bin/env bash
 
 set -e
+
+export DJANGO_SECRET_KEY="example"
+export TOKEN_SESSION_KEY="example"
+export AUTHBROKER_URL="example"
+export AUTHBROKER_CLIENT_ID="example"
+export AUTHBROKER_CLIENT_SECRET="example"
+export AWS_STORAGE_BUCKET_NAME="example"
+export LITE_API_URL="example"
+export PERMISSIONS_FINDER_URL="example"
+export NOTIFY_FEEDBACK_TEMPLATE_ID="example"
+export NOTIFY_FEEDBACK_EMAIL="example"
+export FEEDBACK_URL="example"
+export INTERNAL_FRONTEND_URL="example"
+export LITE_EXPORTER_HAWK_KEY="example"
+export COPILOT_ENVIRONMENT_NAME="example" # force env var to exist to build correctly
+export LITE_INTERNAL_HAWK_KEY="example"
+
+declare -a settings_modules=(conf.exporter conf.caseworker)
+
+for setting_module in "${settings_modules[@]}"; do
+  export DJANGO_SETTINGS_MODULE=$setting_module
+  python manage.py collectstatic --ignore=*.scss,*.md,*.txt,*.json,LICENSE,license,CHANGES,changes
+done

--- a/.copilot/image_build_run.sh
+++ b/.copilot/image_build_run.sh
@@ -15,7 +15,7 @@ export NOTIFY_FEEDBACK_EMAIL="example"
 export FEEDBACK_URL="example"
 export INTERNAL_FRONTEND_URL="example"
 export LITE_EXPORTER_HAWK_KEY="example"
-export COPILOT_ENVIRONMENT_NAME="example" # force env var to exist to build correctly
+export COPILOT_ENVIRONMENT_NAME="example"
 export LITE_INTERNAL_HAWK_KEY="example"
 
 declare -a settings_modules=(conf.exporter conf.caseworker)

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: ./manage.py collectstatic --ignore=*.scss,*.md,*.txt,*.json,LICENSE,license,CHANGES,changes && gunicorn --preload -c conf/gconfig.py -b 0.0.0.0:$PORT conf.wsgi
+web-dbt: gunicorn --preload -c conf/gconfig.py -b 0.0.0.0:$PORT conf.wsgi

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ The production assets are built on deployment as part of the cloudfoundry build.
 to run the tests run:
 `docker exec -it lite-frontend_frontend_assets_watcher_1 npm run test`
 
-### Without docker
+### Without Docker
 
 Node version required can be found in the `package.json` under `engines`.
 All javascripts and scss files are stored under caseworker/assets and exporter/assets

--- a/conf/base.py
+++ b/conf/base.py
@@ -6,7 +6,6 @@ from sentry_sdk.integrations.django import DjangoIntegration
 from django_log_formatter_ecs import ECSFormatter
 from django_log_formatter_asim import ASIMFormatter
 from dbt_copilot_python.utility import is_copilot
-from dbt_copilot_python.network import setup_allowed_hosts
 
 from django.urls import reverse_lazy
 
@@ -161,7 +160,10 @@ HAWK_RECEIVER_NONCE_EXPIRY_SECONDS = 60
 
 LOGIN_URL = reverse_lazy("auth:login")
 
-DATA_DIR = os.path.dirname(BASE_DIR)
+if IS_ENV_DBT_PLATFORM:
+    DATA_DIR = BASE_DIR
+else:
+    DATA_DIR = os.path.dirname(BASE_DIR)
 
 STATICFILES_FINDERS = (
     "django.contrib.staticfiles.finders.FileSystemFinder",
@@ -217,7 +219,6 @@ LOGGING = {
 }
 
 if IS_ENV_DBT_PLATFORM:
-    ALLOWED_HOSTS = setup_allowed_hosts(ALLOWED_HOSTS)
     REDIS_URL = env.str("REDIS_URL", "")
     LOGGING.update({"formatters": {"asim_formatter": {"()": ASIMFormatter}}})
     LOGGING.update({"handlers": {"asim": {"class": "logging.StreamHandler", "formatter": "asim_formatter"}}})


### PR DESCRIPTION
### Aim

Compile static assets at build time (build pipeline) not container boot time (Procfile entrypoint).
Introduce a new entrypoint to be used on DBT Platform so as to not affect the service running on GOVPaas.

Don't add container IP to allowed hosts, this is now managed at the infrastructure level.

Correct path to assets on DBT Platform, traversing up the directories like on GOVPaas will end up on the root directory.
