### PR TITLE
[LTD-5712] Add ability to exclude cases with certain flags from queue view

### DIFF
--- a/caseworker/queues/views/cases.py
+++ b/caseworker/queues/views/cases.py
@@ -114,6 +114,7 @@ class CaseDataMixin:
                 params[param] = date_obj
 
         params["flags"] = self.request.GET.getlist("flags", [])
+        params["exclude_flags"] = self.request.GET.getlist("exclude_flags", [])
         params["countries"] = self.request.GET.getlist("countries", [])
         params["assigned_queues"] = self.request.GET.getlist("assigned_queues", [])
         params["control_list_entry"] = self.request.GET.getlist("control_list_entry", [])

--- a/caseworker/queues/views/forms.py
+++ b/caseworker/queues/views/forms.py
@@ -179,6 +179,14 @@ class CasesFiltersForm(forms.Form):
             # setting id for javascript to use
             widget=forms.SelectMultiple(attrs={"id": "flags"}),
         )
+        self.fields["exclude_flags"] = forms.MultipleChoiceField(
+            label="Exclude flags",
+            choices=flags_choices,
+            required=False,
+            help_text=f'<a href="{flag_url}" class="govuk-link govuk-link--no-visited-state" target="_blank">Flag information (open in a new window)</a>',
+            # setting id for javascript to use
+            widget=forms.SelectMultiple(attrs={"id": "exclude_flags"}),
+        )
         self.fields["control_list_entry"] = forms.MultipleChoiceField(
             label="Control list entry",
             choices=cle_choices,
@@ -220,6 +228,7 @@ class CasesFiltersForm(forms.Form):
             "submitted_from",
             "submitted_to",
             Field("flags", css_class="multi-select-filter"),
+            Field("exclude_flags", css_class="multi-select-filter"),
             "finalised_from",
             "finalised_to",
         ]

--- a/unit_tests/caseworker/queues/views/test_cases.py
+++ b/unit_tests/caseworker/queues/views/test_cases.py
@@ -167,6 +167,7 @@ def test_cases_home_page_view_context(authorized_client):
         "assigned_user",
         "licence_status",
         "flags",
+        "exclude_flags",
         "countries",
         "assigned_queues",
         "is_nca_applicable",
@@ -368,6 +369,19 @@ def test_cases_home_page_exclude_control_list_entries_search(authorized_client, 
         **default_params,
         "control_list_entry": ["ml1"],
         "exclude_control_list_entry": ["true"],
+    }
+
+
+def test_cases_home_page_exclude_flags_search(authorized_client, mock_cases_search):
+    url = reverse("queues:cases")
+    response = authorized_client.get(url)
+
+    url = reverse("queues:cases") + "?exclude_flags=flag_id_1&exclude_flags=flag_id_2"
+    response = authorized_client.get(url)
+    assert response.status_code == 200
+    assert mock_cases_search.last_request.qs == {
+        **default_params,
+        "exclude_flags": ["flag_id_1", "flag_id_2"],
     }
 
 


### PR DESCRIPTION
### Aim

Adds capability for excluding cases with certain flags from queue view search results.

**Note:** This depends on a companion lite-api PR: https://github.com/uktrade/lite-api/pull/2340

[LTD-5712](https://uktrade.atlassian.net/browse/LTD-5712)


[LTD-5712]: https://uktrade.atlassian.net/browse/LTD-5712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ