### PR TITLE
[LTD-5727] Updated page headers and removed label

### DIFF
--- a/caseworker/advice/forms/approval.py
+++ b/caseworker/advice/forms/approval.py
@@ -89,7 +89,7 @@ class RecommendAnApprovalForm(PicklistAdviceForm, BaseForm):
 
 class LicenceConditionsForm(PicklistAdviceForm, BaseForm):
     class Layout:
-        TITLE = "Add licence conditions, instructions to exporter or footnotes (optional)"
+        TITLE = "Add licence conditions (optional)"
 
     proviso = forms.CharField(
         widget=forms.Textarea(attrs={"rows": 7, "class": "govuk-!-margin-top-4"}),
@@ -104,7 +104,7 @@ class LicenceConditionsForm(PicklistAdviceForm, BaseForm):
         choices=(),
     )
     proviso_checkboxes = forms.MultipleChoiceField(
-        label="Add a licence condition (optional)",
+        label="",
         required=False,
         widget=forms.CheckboxSelectMultiple,
         choices=(),
@@ -143,7 +143,7 @@ class LicenceConditionsForm(PicklistAdviceForm, BaseForm):
 
 class FootnotesApprovalAdviceForm(PicklistAdviceForm, BaseForm):
     class Layout:
-        TITLE = "Instructions for the exporter (optional)"
+        TITLE = "Add instructions to the exporter, or a reporting footnote (optional)"
 
     instructions_to_exporter = forms.CharField(
         widget=forms.Textarea(attrs={"rows": "3"}),

--- a/caseworker/advice/forms/edit.py
+++ b/caseworker/advice/forms/edit.py
@@ -5,7 +5,7 @@ from core.common.forms import BaseForm
 
 class PicklistApprovalAdviceEditForm(BaseForm):
     class Layout:
-        TITLE = "Add licence conditions, instructions to exporter or footnotes (optional)"
+        TITLE = "Add licence conditions (optional)"
 
     proviso = forms.CharField(
         widget=forms.Textarea(attrs={"rows": 30, "class": "govuk-!-margin-top-4"}),

--- a/unit_tests/caseworker/advice/views/test_edit_advice.py
+++ b/unit_tests/caseworker/advice/views/test_edit_advice.py
@@ -374,7 +374,7 @@ def test_DESNZ_give_approval_advice_post_valid_add_conditional(
     soup = beautiful_soup(response.content)
     # redirected to next form
     header = soup.find("h1")
-    assert header.text == "Add licence conditions, instructions to exporter or footnotes (optional)"
+    assert header.text == "Add licence conditions (optional)"
 
     add_licence_condition_response = post_to_step(
         AdviceSteps.LICENCE_CONDITIONS,
@@ -384,7 +384,7 @@ def test_DESNZ_give_approval_advice_post_valid_add_conditional(
     soup = beautiful_soup(add_licence_condition_response.content)
     # redirected to next form
     header = soup.find("h1")
-    assert header.text == "Instructions for the exporter (optional)"
+    assert header.text == "Add instructions to the exporter, or a reporting footnote (optional)"
 
     add_instructions_response = post_to_step(
         AdviceSteps.LICENCE_FOOTNOTES,

--- a/unit_tests/caseworker/advice/views/test_give_approval_advice_view.py
+++ b/unit_tests/caseworker/advice/views/test_give_approval_advice_view.py
@@ -193,7 +193,7 @@ def test_DESNZ_give_approval_advice_post_valid_add_conditional(
     soup = beautiful_soup(response.content)
     # redirected to next form
     header = soup.find("h1")
-    assert header.text == "Add licence conditions, instructions to exporter or footnotes (optional)"
+    assert header.text == "Add licence conditions (optional)"
 
     add_LC_response = post_to_step(
         AdviceSteps.LICENCE_CONDITIONS,
@@ -203,7 +203,7 @@ def test_DESNZ_give_approval_advice_post_valid_add_conditional(
     soup = beautiful_soup(add_LC_response.content)
     # redirected to next form
     header = soup.find("h1")
-    assert header.text == "Instructions for the exporter (optional)"
+    assert header.text == "Add instructions to the exporter, or a reporting footnote (optional)"
 
     add_instructions_response = post_to_step(
         AdviceSteps.LICENCE_FOOTNOTES,
@@ -246,7 +246,7 @@ def test_DESNZ_give_approval_advice_post_valid_add_conditional_optional(
     soup = beautiful_soup(response.content)
     # redirected to next form
     header = soup.find("h1")
-    assert header.text == "Add licence conditions, instructions to exporter or footnotes (optional)"
+    assert header.text == "Add licence conditions (optional)"
 
     add_LC_response = post_to_step(
         AdviceSteps.LICENCE_CONDITIONS,
@@ -256,7 +256,7 @@ def test_DESNZ_give_approval_advice_post_valid_add_conditional_optional(
     soup = beautiful_soup(add_LC_response.content)
     # redirected to next form
     header = soup.find("h1")
-    assert header.text == "Instructions for the exporter (optional)"
+    assert header.text == "Add instructions to the exporter, or a reporting footnote (optional)"
 
     add_instructions_response = post_to_step(
         AdviceSteps.LICENCE_FOOTNOTES,


### PR DESCRIPTION
DESNZ multi page flow change only:
* 'Add licence conditions, instructions to exporter or footnotes (optional)' -> ‘Add licence conditions (optional)’
* Remove hint text "Add a licence condition (optional)" on proviso checkboxes
* Change page header from "Instructions for the exporter (optional)" -> ‘Add instructions to the exporter, or a reporting footnote (optional)'

[LTD-5725](https://uktrade.atlassian.net/browse/LTD-5725)


[LTD-5725]: https://uktrade.atlassian.net/browse/LTD-5725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ