### PR TITLE
[LTD-5739] Ensure MOD-DI advice is shown at consolidation regardless of MOD-ECJU advice

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,9 @@ commands:
         default: auto
         type: string
     steps:
-      - browser-tools/install-chrome
+      - browser-tools/install-chrome:
+            chrome-version: "125.0.6422.112"
+            replace-existing: true
       - browser-tools/install-chromedriver
       - run:
             name: "Install dependencies"

--- a/caseworker/advice/services.py
+++ b/caseworker/advice/services.py
@@ -54,13 +54,20 @@ MOD_TEAMS = [MOD_ECJU_TEAM, *MOD_CONSOLIDATE_TEAMS]
 NCSC_TEAM = "NCSC"
 OGD_TEAMS_EXCLUDING_MOD = [
     *DESNZ_TEAMS,
+    # MOD-DI team present here to ensure that advice given in MOD-DI Direct is consolidated by LU
+    MOD_DI_TEAM,
     FCDO_TEAM,
     NCSC_TEAM,
 ]
-OGD_TEAMS = [
-    *OGD_TEAMS_EXCLUDING_MOD,
-    *MOD_TEAMS,
-]
+# Make OGD_TEAMS a set to avoid having duplicate entries for MOD-DI - advice from them should appear unconditionally
+OGD_TEAMS = list(
+    set(
+        [
+            *OGD_TEAMS_EXCLUDING_MOD,
+            *MOD_TEAMS,
+        ]
+    )
+)
 
 # Flags
 LU_COUNTERSIGN_REQUIRED_ID = "bbf29b42-0aae-4ebc-b77a-e502ddea30a8"  # /PS-IGNORE

--- a/caseworker/advice/tests/test_services.py
+++ b/caseworker/advice/tests/test_services.py
@@ -244,6 +244,28 @@ def test_get_advice_to_consolidate_unrecognized_team_raises_exception():
                         "team": {"alias": MOD_ECJU_TEAM, "id": "id-mod-ecju"},
                     },
                 ],
+                "id-mod-di-approve": [
+                    {
+                        "id": "advice-3",
+                        "level": "team",
+                        "type": {"key": "approve"},
+                        "team": {"alias": MOD_DI_TEAM, "id": "id-mod-di"},
+                    },
+                    {
+                        "id": "advice-4",
+                        "level": "user",
+                        "type": {"key": "approve"},
+                        "team": {"alias": MOD_DI_TEAM, "id": "id-mod-di"},
+                    },
+                ],
+                "id-mod-di-refuse": [
+                    {
+                        "id": "advice-4",
+                        "level": "user",
+                        "type": {"key": "refuse"},
+                        "team": {"alias": MOD_DI_TEAM, "id": "id-mod-di"},
+                    },
+                ],
             },
         ),
     ),


### PR DESCRIPTION
### Aim

Colin summarises the issue brilliantly here; https://teams.microsoft.com/l/message/19:c91f81450ae041028ed350e84de52e99@thread.tacv2/1734095933610?tenantId=8fa217ec-33aa-46fb-ad96-dfe68006bb86&groupId=eced0ad8-d420-418b-9e1a-1b3e26b68c46&parentMessageId=1734095933610&teamName=LITE%20DDaT%20Team&channelName=Licence%20conditions%20and%20DESNZ%20countersigning&createdTime=1734095933610

TLDR; We were "rolling up" advice from all MOD teams in to MOD-ECJU's advice at the point of LU consolidation **if there was advice present from MOD-ECJU on the case**.

The issue with this is that advice from MOD-DI is only consolidated by LU if it visited MOD-DI's "Indirect" queue.  MOD-DI direct advice would effectively be masked away incorrectly.  This could mean the potential for LU missing important licence conditions added by MOD-DI direct.

This change adjusts the advice that is surfaced at consolidation, such that MOD-DI's advice is **always** surfaced to LU.  This may mean - in the case where a licence condition was added by MOD-DI indirect - that we show an additional licence condition that has already been combined by MOD-ECJU.  However, it has been agreed that this is probably better than the alternative of potentially missing licence conditions raised by MOD-DI Direct.

[LTD-5739](https://uktrade.atlassian.net/browse/LTD-5739)


[LTD-5739]: https://uktrade.atlassian.net/browse/LTD-5739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ