### PR TITLE
Add tests for govuk link button template tag

### DIFF
--- a/lite_content/lite_internal_frontend/strings.py
+++ b/lite_content/lite_internal_frontend/strings.py
@@ -13,6 +13,7 @@ from lite_content.lite_internal_frontend import (  # noqa
     queues,  # noqa
     picklists,  # noqa
     routing_rules,  # noqa
+    tests,  # noqa
 )  # noqa
 
 # Buttons

--- a/lite_content/lite_internal_frontend/tests.py
+++ b/lite_content/lite_internal_frontend/tests.py
@@ -1,0 +1,2 @@
+class TestPage:
+    BUTTON = "Test Button"

--- a/lite_forms/templates/govuk-link-button.html
+++ b/lite_forms/templates/govuk-link-button.html
@@ -1,0 +1,8 @@
+<a {% if id %}id="button-{{ id }}" {% endif %}href="{{ url }}{{ query_params }}" role="button" draggable="false" class="govuk-button {{ classes }}" data-module="govuk-button"{% if hidden %} style="display: none;"{% endif %}>
+    {% lcs text %}
+    {% if show_chevron %}
+        <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="13" height="15" viewBox="0 0 33 43" aria-hidden="true" focusable="false">
+            <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+        </svg>
+    {% endif %}
+</a>

--- a/lite_forms/templatetags/custom_tags.py
+++ b/lite_forms/templatetags/custom_tags.py
@@ -6,7 +6,6 @@ from django.template.defaulttags import register
 from django.urls import reverse
 from django.utils.safestring import mark_safe
 
-from core.builtins.custom_tags import get_const_string
 from lite_forms.helpers import flatten_data
 
 
@@ -199,27 +198,25 @@ def item_with_rating_exists(items, rating):
                 return True
 
 
-@register.simple_tag
-@mark_safe  # noqa: S308
+@register.inclusion_tag("govuk-link-button.html")
 def govuk_link_button(text, url, url_param=None, id="", classes="", query_params="", show_chevron=False, hidden=False):
-    text = get_const_string(text)
+    if not url_param:
+        url_param = []
+
     if isinstance(url_param, str):
         url_param = [url_param]
-    url = reverse(url, args=url_param if url_param else [])
-    id = f'id="button-{id}"' if id else ""
-    chevron = ""
-    if show_chevron:
-        chevron = (
-            '<svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="13" height="15" '
-            'viewBox="0 0 33 43" aria-hidden="true" focusable="false">'
-            '<path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" /></svg>'
-        )
-    hidden = 'style="display: none;"' if hidden else ""
 
-    return (
-        f'<a {id} href="{url}{query_params}" role="button" draggable="false" class="govuk-button {classes}" {hidden} '
-        f'data-module="govuk-button">{text}{chevron}</a>'
-    )
+    url = reverse(url, args=url_param)
+
+    return {
+        "text": text,
+        "url": url,
+        "id": id,
+        "classes": classes,
+        "show_chevron": show_chevron,
+        "hidden": hidden,
+        "query_params": query_params,
+    }
 
 
 @register.filter()

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -2602,12 +2602,29 @@ def mock_s3_files(settings):
     return _create_files
 
 
-@pytest.fixture
+@pytest.fixture()
+def authorized_client(client):
+    return client
+
+
+@pytest.fixture()
 def mock_request(rf, authorized_client):
     request = rf.get("/")
     request.session = authorized_client.session
     request.requests_session = requests.Session()
-    yield request
+    return request
+
+
+@pytest.fixture()
+def render_template_string(mock_request):
+    def _render_template_string(template_string, context=None):
+        if not context:
+            context = {}
+        template = Template(template_string)
+        context = RequestContext(mock_request, context)
+        return template.render(context)
+
+    return _render_template_string
 
 
 @pytest.fixture()

--- a/unit_tests/lite_forms/templatetags/test_custom_tags.py
+++ b/unit_tests/lite_forms/templatetags/test_custom_tags.py
@@ -1,5 +1,7 @@
 import pytest
 
+from pytest_django.asserts import assertHTMLEqual
+
 from lite_forms.templatetags import custom_tags
 
 
@@ -12,3 +14,42 @@ from lite_forms.templatetags import custom_tags
 )
 def test_file_type(filename, expected):
     assert expected == custom_tags.file_type(filename)
+
+
+@pytest.mark.parametrize(
+    "input, context, expected",
+    [
+        (
+            "{% govuk_link_button text='tests.TestPage.BUTTON' url='core:index' %}",
+            {},
+            '<a href="/" role="button" draggable="false" class="govuk-button" data-module="govuk-button">Test Button</a>',
+        ),
+        (
+            "{% govuk_link_button text='tests.TestPage.BUTTON' url='core:index' id='test-id' classes='govuk-button--secondary' %}",
+            {},
+            '<a id="button-test-id" href="/" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button">Test Button</a>',
+        ),
+        (
+            "{% govuk_link_button text='tests.TestPage.BUTTON' url='core:index' show_chevron=True %}",
+            {},
+            '<a href="/" role="button" draggable="false" class="govuk-button" data-module="govuk-button">Test Button<svg aria-hidden="true" class="govuk-button__start-icon" focusable="false" height="15" viewbox="0 0 33 43" width="13" xmlns="http://www.w3.org/2000/svg"><path d="M0 0h13l20 20-20 20H0l20-20z" fill="currentColor"></svg></a>',
+        ),
+        (
+            "{% govuk_link_button text='tests.TestPage.BUTTON' url='core:index' query_params='?foo=bar' %}",
+            {},
+            '<a href="/?foo=bar" role="button" draggable="false" class="govuk-button" data-module="govuk-button">Test Button</a>',
+        ),
+        (
+            "{% govuk_link_button text='tests.TestPage.BUTTON' url='core:index' hidden=True %}",
+            {},
+            '<a href="/" role="button" draggable="false" class="govuk-button" data-module="govuk-button" style="display: none;">Test Button</a>',
+        ),
+        (
+            "{% govuk_link_button text='tests.TestPage.BUTTON' url='core:index' query_params=html_content %}",
+            {"html_content": '">foo</a><script>alert("xss")</script><a href="blah'},
+            '<a href="/&quot;&gt;foo&lt;/a&gt;&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;&lt;a href=&quot;blah" role="button" draggable="false" class="govuk-button " data-module="govuk-button">Test Button</a>',
+        ),
+    ],
+)
+def test_govuk_link_button(render_template_string, input, context, expected):
+    assertHTMLEqual(render_template_string(input, context), expected)


### PR DESCRIPTION
### Aim

Ensure the govuk link button template tag doesn't need to use `mark_safe` and therefore will always correctly sanitised any information that is sent to it.

[LTD-5745](https://uktrade.atlassian.net/browse/LTD-5745)


[LTD-5745]: https://uktrade.atlassian.net/browse/LTD-5745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ