### PR TITLE
[LTD-5743] Add line separator to multiple licence condition concatenation

### DIFF
--- a/caseworker/advice/forms/approval.py
+++ b/caseworker/advice/forms/approval.py
@@ -113,7 +113,11 @@ class LicenceConditionsForm(PicklistAdviceForm, BaseForm):
     def clean(self):
         cleaned_data = super().clean()
         # only return proviso (text) for selected radios, nothing else matters, join by 2 newlines
-        return {"proviso": "\r\n\r\n".join([cleaned_data[selected] for selected in cleaned_data["proviso_checkboxes"]])}
+        return {
+            "proviso": "\n\n--------\n".join(
+                [cleaned_data[selected] for selected in cleaned_data["proviso_checkboxes"]]
+            )
+        }
 
     def __init__(self, *args, **kwargs):
         proviso = kwargs.pop("proviso")

--- a/unit_tests/caseworker/advice/views/test_give_approval_advice_view.py
+++ b/unit_tests/caseworker/advice/views/test_give_approval_advice_view.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 
 from caseworker.advice import services
 from caseworker.advice.constants import AdviceSteps
+from core import client
 
 
 @pytest.fixture(autouse=True)
@@ -210,6 +211,78 @@ def test_DESNZ_give_approval_advice_post_valid_add_conditional(
         {"instructions_to_exporter": "instructions", "footnote_details": "footnotes"},
     )
     assert add_instructions_response.status_code == 302
+
+
+@pytest.fixture
+def mock_proviso_multiple(requests_mock):
+    url = client._build_absolute_uri("/picklist/?type=proviso&page=1&disable_pagination=True&show_deactivated=False")
+    data = {
+        "results": [
+            {"name": "condition 1", "text": "condition 1 text"},
+            {"name": "condition 2", "text": "condition 2 text"},
+            {"name": "condition 3", "text": "condition 3 text"},
+        ]
+    }
+    return requests_mock.get(url=url, json=data)
+
+
+@mock.patch("caseworker.advice.views.mixins.get_gov_user")
+def test_DESNZ_give_approval_advice_post_valid_multiple_conditions(
+    mock_get_gov_user,
+    authorized_client,
+    data_standard_case,
+    url,
+    mock_approval_reason,
+    mock_proviso_multiple,
+    mock_footnote_details,
+    mock_post_advice,
+    post_to_step,
+    beautiful_soup,
+):
+    mock_get_gov_user.return_value = (
+        {
+            "user": {
+                "team": {
+                    "id": "56273dd4-4634-4ad7-a782-e480f85a85a9",
+                    "name": "DESNZ Chemical",
+                    "alias": services.DESNZ_CHEMICAL,
+                }
+            }
+        },
+        None,
+    )
+
+    response = post_to_step(
+        AdviceSteps.RECOMMEND_APPROVAL,
+        {"approval_reasons": "reason", "add_licence_conditions": True},
+    )
+    assert response.status_code == 200
+    soup = beautiful_soup(response.content)
+    # redirected to next form
+    header = soup.find("h1")
+    assert header.text == "Add licence conditions (optional)"
+
+    add_LC_response = post_to_step(
+        AdviceSteps.LICENCE_CONDITIONS,
+        {
+            "proviso_checkboxes": ["condition_1", "condition_3"],
+            "condition_1": "condition 1 abc",
+            "condition_3": "condition 3 xyz",
+        },
+    )
+    assert add_LC_response.status_code == 200
+    soup = beautiful_soup(add_LC_response.content)
+    # redirected to next form
+    header = soup.find("h1")
+    assert header.text == "Add instructions to the exporter, or a reporting footnote (optional)"
+
+    add_instructions_response = post_to_step(
+        AdviceSteps.LICENCE_FOOTNOTES,
+        {},
+    )
+    assert add_instructions_response.status_code == 302
+    assert len(mock_post_advice.request_history) == 1
+    assert mock_post_advice.request_history[0].json()[0]["proviso"] == "condition 1 abc\n\n--------\ncondition 3 xyz"
 
 
 @mock.patch("caseworker.advice.views.mixins.get_gov_user")


### PR DESCRIPTION
### Aim

Ensure that the new multiple licence conditions flow concatenates licence conditions with a line separator.

[LTD-5743](https://uktrade.atlassian.net/browse/LTD-5743)


[LTD-5743]: https://uktrade.atlassian.net/browse/LTD-5743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ