### PR TITLE
Update inputs to show accessible names

### DIFF
--- a/exporter/core/organisation/forms.py
+++ b/exporter/core/organisation/forms.py
@@ -261,33 +261,31 @@ class RegisterAddressDetailsUKCommercialForm(RegisterAddressDetailsBaseForm):
     )
 
     address_line_1 = AddressLineField(
-        label="Building and street",
+        label="Address line 1",
         error_messages={
-            "required": "Enter a real building and street name",
+            "required": "Enter address line 1, typically the building and street",
         },
     )
     address_line_2 = AddressLineField(
-        label="",
+        label="Address line 2 (optional)",
         required=False,
     )
 
     city = AddressLineField(
         label="Town or city",
         error_messages={
-            "required": "Enter a real city",
+            "required": "Enter town or city",
         },
     )
     region = AddressLineField(
-        label="County or state",
-        error_messages={
-            "required": "Enter a county or state",
-        },
+        label="County (optional)",
+        required=False,
     )
 
     postcode = forms.CharField(
         label="Postcode",
         error_messages={
-            "required": "Enter a real postcode",
+            "required": "Enter postcode",
         },
     )
 

--- a/lite_forms/templates/components.html
+++ b/lite_forms/templates/components.html
@@ -18,25 +18,25 @@
 		</label>
 	{% endif %}
 	{% if question.description %}
-		<span class="govuk-hint" for="{{ question.name }}">
+		<label class="govuk-hint" for="{{ question.name }}">
 			<span>{{ question.description|safe }}</span>
-		</span>
+		</label>
 	{% endif %}
 	{% if question.accessible_description %}
-		<span class="govuk-hint govuk-visually-hidden" for="{{ question.name }}">
+		<label class="govuk-hint govuk-visually-hidden" for="{{ question.name }}">
 			{{ question.accessible_description }}
-		</span>
+		</label>
 	{% endif %}
 
 	<!-- Error -->
 	{% if errors %}
 		{% if errors|key_value:question.name and question.input_type != "hidden" %}
-			<span id="error-{{ question.name }}" for="{{ question.name }}" class="govuk-error-message">
+			<label id="error-{{ question.name }}" for="{{ question.name }}" class="govuk-error-message">
 				<span class="govuk-visually-hidden">Error:</span>
 				{% for error in errors|key_value:question.name %}
 					{{ error }}
 				{% endfor %}
-			</span>
+			</label>
 		{% endif %}
 	{% endif %}
 

--- a/lite_forms/templates/components/file_upload.html
+++ b/lite_forms/templates/components/file_upload.html
@@ -27,4 +27,4 @@
 	</div>
 	<span class="govuk-hint">You can replace the uploaded file below:</span>
 {% endif %}
-<input aria-labelledby="span--hint" id="{{ name }}" type="file" name="{{ name }}" accept='{{ accept|join:"," }}' />
+<input aria-labelledby="span-{{ page.single_form_element.name }}-hint" id="{{ name }}" type="file" name="{{ name }}" accept='{{ accept|join:"," }}' />

--- a/lite_forms/templates/components/file_upload.html
+++ b/lite_forms/templates/components/file_upload.html
@@ -27,4 +27,4 @@
 	</div>
 	<span class="govuk-hint">You can replace the uploaded file below:</span>
 {% endif %}
-<input id="{{ name }}" type="file" name="{{ name }}" accept='{{ accept|join:"," }}' />
+<input aria-labelledby="span--hint" id="{{ name }}" type="file" name="{{ name }}" accept='{{ accept|join:"," }}' />


### PR DESCRIPTION
### Aim

This PR makes some changes to resolve issues with accessible labels found in the most recent DAC report - these are listed in the ticket. The problems are generally that an input may appear to a screen reader but it's not clear what the input relates to.

As well as updating some `for=""` and `aria-labelledby=""` attributes to make clear what inputs relate to what hint text, the address input for UK based org registration has been updated. This was discussed in the ticket comments and it brings the UK based org registration form for address in line with the GDS design pattern (https://design-system.service.gov.uk/patterns/addresses/) by using "Address line 1" and "Address line 2" instead of "Building and street" and no label. The other inputs for address were also updated (along with the error messages) to keep things consistent with the Address example on the Design System page.

[LTD-5172](https://uktrade.atlassian.net/browse/LTD-5172)


[LTD-5172]: https://uktrade.atlassian.net/browse/LTD-5172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ