### PR TITLE
Fix headings hierarchy for accessibility tools

### DIFF
--- a/exporter/templates/core/registration/confirmation-registration-base.html
+++ b/exporter/templates/core/registration/confirmation-registration-base.html
@@ -26,7 +26,7 @@
 	{% endblock %}
 
 	<div class="govuk-summary-list__row" id="org-name">
-		<h1 class="govuk-heading-m">Now send your application</h1>
+		<h2 class="govuk-heading-m">Now send your application</h2>
 		<p class="govuk-body">By submitting this notification you are confirming that, to the best of your knowledge, the details you are providing are correct. </p>
 	</div>
 

--- a/exporter/templates/core/registration/confirmation-registration-corporation-abroad.html
+++ b/exporter/templates/core/registration/confirmation-registration-corporation-abroad.html
@@ -4,9 +4,9 @@
 
         {% include "core/registration/includes/registration-details-corporation.html" %}
 
-        <h1 class="govuk-heading-m">
+        <h2 class="govuk-heading-m">
                 Where is your organisation based?
-        </h1>
+        </h2>
 
         {% include "core/registration/includes/address-details-abroad.html" %}
 

--- a/exporter/templates/core/registration/confirmation-registration-corporation-uk.html
+++ b/exporter/templates/core/registration/confirmation-registration-corporation-uk.html
@@ -4,9 +4,9 @@
 
         {% include "core/registration/includes/registration-details-corporation.html" %}
 
-        <h1 class="govuk-heading-m">
+        <h2 class="govuk-heading-m">
                 Where is your organisation based?
-        </h1>
+        </h2>
 
         {% include "core/registration/includes/address-details-uk.html" %}
 

--- a/exporter/templates/core/registration/confirmation-registration-individual-abroad.html
+++ b/exporter/templates/core/registration/confirmation-registration-individual-abroad.html
@@ -4,9 +4,9 @@
 
         {% include "core/registration/includes/registration-details-individual.html" %}
 
-        <h1 class="govuk-heading-m">
+        <h2 class="govuk-heading-m">
                 Where are you based?
-        </h1>
+        </h2>
 
         {% include "core/registration/includes/address-details-abroad.html" %}
 {% endblock %}

--- a/exporter/templates/core/registration/confirmation-registration-individual-uk.html
+++ b/exporter/templates/core/registration/confirmation-registration-individual-uk.html
@@ -4,9 +4,9 @@
 
     {% include "core/registration/includes/registration-details-individual.html" %}
 
-    <h1 class="govuk-heading-m">
+    <h2 class="govuk-heading-m">
          Where in the United Kingdom are you based?
-    </h1>
+    </h2>
 
     {% include "core/registration/includes/address-details-uk.html" %}
 {% endblock %}

--- a/exporter/templates/core/registration/includes/registration-details-corporation.html
+++ b/exporter/templates/core/registration/includes/registration-details-corporation.html
@@ -1,7 +1,7 @@
 
-<h1 class="govuk-heading-m">
+<h2 class="govuk-heading-m">
     Register a commercial organisation
-</h1>
+</h2>
 <dl class="govuk-summary-list govuk-!-margin-bottom-9" id="registration-summary">
     <div class="govuk-summary-list__row" id="org-name">
         <dt class="govuk-summary-list__key">

--- a/exporter/templates/core/registration/includes/registration-details-individual.html
+++ b/exporter/templates/core/registration/includes/registration-details-individual.html
@@ -1,8 +1,8 @@
 
 
-<h1 class="govuk-heading-m">
+<h2 class="govuk-heading-m">
     Organisation details
-</h1>
+</h2>
 <dl class="govuk-summary-list govuk-!-margin-bottom-9" id="registration-summary">
     <div class="govuk-summary-list__row" id="name">
         <dt class="govuk-summary-list__key">


### PR DESCRIPTION
### Aim

For accessibility it is expected that there is one H1 heading element on the page and other H2 or smaller headings to make it clear to screen readers what the relative importance of information on the page is. The example here (https://design-system.service.gov.uk/styles/headings/) shows H2 headings should be used when the `govuk-heading-m` class is used. The style does not change as a result of changing H1 elements to H2 because that is set by the CSS class `govuk-heading-m`, so the change only impacts accessibility tools.

[LTD-5173](https://uktrade.atlassian.net/browse/LTD-5173)


[LTD-5173]: https://uktrade.atlassian.net/browse/LTD-5173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ