### PR TITLE
Hide disabled cards in exporter hub

### DIFF
--- a/exporter/assets/scss/components/_hub.scss
+++ b/exporter/assets/scss/components/_hub.scss
@@ -3,3 +3,7 @@
         max-width: 100%;
     }
 }
+
+#compliance-open-licence-app-tiles {
+    display: none;
+}

--- a/exporter/templates/core/hub.html
+++ b/exporter/templates/core/hub.html
@@ -192,7 +192,7 @@
 			</ul>
 		</div>
 
-		<div class="app-tiles" aria-label="Content currently unavailable">
+		<div id="compliance-open-licence-app-tiles" class="app-tiles" aria-label="Content currently unavailable">
 			{# Compliance licence tile #}
 			<div class="app-tile app-tile__disabled">
 				<h2 class="govuk-!-margin-top-0">


### PR DESCRIPTION
### Aim

Previously the app tiles for compliance and open licence returns were shown on screen, but disabled. As discussed in the ticket it is better to hide the tiles for now until we implement these features, as it is difficult to accessibly show disabled visual content.

[LTD-5177](https://uktrade.atlassian.net/browse/LTD-5177)


[LTD-5177]: https://uktrade.atlassian.net/browse/LTD-5177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ