### PR TITLE
Update fieldsets to group related elements

### DIFF
--- a/core/assets/styles/overrides/_all.scss
+++ b/core/assets/styles/overrides/_all.scss
@@ -1,5 +1,6 @@
 @import "button";
 @import "checkboxes";
+@import "fieldset";
 @import "file-upload";
 @import "form-group";
 @import "form-input";

--- a/core/assets/styles/overrides/_fieldset.scss
+++ b/core/assets/styles/overrides/_fieldset.scss
@@ -1,0 +1,11 @@
+fieldset {
+    .govuk-fieldset__legend--xl {
+        margin-bottom: 30px;
+    }
+
+    @media (min-width: 40.0625em) {
+        .govuk-fieldset__legend--xl {
+            margin-bottom: 50px;
+        }
+    }
+}

--- a/core/common/forms.py
+++ b/core/common/forms.py
@@ -2,8 +2,10 @@ from crispy_forms_gds.helper import FormHelper
 from crispy_forms_gds.choices import Choice
 from crispy_forms_gds.layout import (
     Div,
+    Fieldset,
     HTML,
     Layout,
+    Size,
     Submit,
 )
 from django import forms
@@ -60,6 +62,30 @@ class BaseForm(forms.Form):
         return [
             Submit("submit", getattr(self.Layout, "SUBMIT_BUTTON", submit_button_text)),
         ]
+
+
+class FieldsetForm(BaseForm):
+    """This is a suitable layout for a single question form. By using a
+    <fieldset> and <legend> it ensures that related inputs are grouped together
+    with a common label to enable users to easily identify the group, as
+    covered by WCAG Technique H71.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.helper.layout = Layout(
+            Fieldset(
+                *self.get_layout_fields(),
+                legend=self.get_title(),
+                legend_size=Size.EXTRA_LARGE,
+                legend_tag="h1",
+            ),
+            Div(
+                *self.get_layout_actions(),
+                css_class="govuk-button-group",
+            ),
+        )
 
 
 class MultipleFileInput(forms.ClearableFileInput):

--- a/exporter/applications/forms/hcsat.py
+++ b/exporter/applications/forms/hcsat.py
@@ -1,5 +1,5 @@
 from crispy_forms_gds.helper import FormHelper
-from crispy_forms_gds.layout import Field, Layout, Submit, HTML
+from crispy_forms_gds.layout import Field, Fieldset, Layout, Size, Submit, HTML
 from django.urls import reverse_lazy
 from django import forms
 
@@ -7,6 +7,9 @@ from core.forms.layouts import StarRadioSelect
 
 
 class HCSATminiform(forms.Form):
+    class Layout:
+        TITLE = "Overall, how would you rate your experience with the 'apply for a standard individual export licence (SIEL)' service today?"
+
     RECOMMENDATION_CHOICES = [
         ("VERY_DISSATISFIED", "Very dissatisfied"),
         ("DISSATISFIED", "Dissatisfied"),
@@ -23,11 +26,19 @@ class HCSATminiform(forms.Form):
         error_messages={"required": "Star rating is required"},
     )
 
+    def get_title(self):
+        return self.Layout.TITLE
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.helper = FormHelper()
         self.helper.layout = Layout(
-            StarRadioSelect("satisfaction_rating"),
+            Fieldset(
+                StarRadioSelect("satisfaction_rating"),
+                legend=self.get_title(),
+                legend_size=Size.MEDIUM,
+                legend_tag="h2",
+            ),
             Submit("submit", "Submit and continue"),
         )
 

--- a/exporter/applications/forms/parties.py
+++ b/exporter/applications/forms/parties.py
@@ -1,13 +1,13 @@
 from core.helpers import remove_non_printable_characters
 from crispy_forms_gds.choices import Choice
 from crispy_forms_gds.helper import FormHelper
-from crispy_forms_gds.layout import Layout, Submit, HTML
+from crispy_forms_gds.layout import Fieldset, Layout, Size, Submit, HTML
 from django import forms
 from django.core.exceptions import ValidationError
 from django.core.validators import MaxLengthValidator, URLValidator
 from django.urls import reverse_lazy
 
-from core.common.forms import BaseForm
+from core.common.forms import BaseForm, FieldsetForm
 from core.forms.layouts import ConditionalRadios, ConditionalRadiosQuestion
 from core.forms.widgets import Autocomplete
 from exporter.core.constants import CaseTypes, FileUploadFileTypes
@@ -133,10 +133,9 @@ def new_party_form_group(request, application, strings, back_url, clearance_opti
     return FormGroup(forms)
 
 
-class PartyReuseForm(BaseForm):
+class PartyReuseForm(FieldsetForm):
     class Layout:
         TITLE = "Do you want to reuse an existing party?"
-        TITLE_AS_LABEL_FOR = "reuse_party"
 
     reuse_party = forms.ChoiceField(
         choices=(
@@ -154,7 +153,7 @@ class PartyReuseForm(BaseForm):
         return ("reuse_party",)
 
 
-class PartySubTypeSelectForm(BaseForm):
+class PartySubTypeSelectForm(FieldsetForm):
     """
     This form needs to be instantiated with a Layout.TITLE for the type of party whose data is being set
     as per the BaseForm.
@@ -200,13 +199,11 @@ class PartySubTypeSelectForm(BaseForm):
 class EndUserSubTypeSelectForm(PartySubTypeSelectForm):
     class Layout:
         TITLE = "Select the type of end user"
-        TITLE_AS_LABEL_FOR = "sub_type"
 
 
 class ConsigneeSubTypeSelectForm(PartySubTypeSelectForm):
     class Layout:
         TITLE = "Select the type of consignee"
-        TITLE_AS_LABEL_FOR = "sub_type"
 
 
 class PartyNameForm(BaseForm):
@@ -395,15 +392,19 @@ class PartyDocumentsForm(forms.Form):
 
         self.helper = FormHelper()
         self.helper.layout = Layout(
-            HTML.h1(self.title),
-            HTML.p(self.text_p1),
-            HTML.p(self.text_p2),
-            HTML.p(self.text_p3),
-            HTML.p(self.text_p4),
-            ConditionalRadios(
-                "end_user_document_available",
-                "Yes",
-                ConditionalRadiosQuestion("No", "end_user_document_missing_reason"),
+            Fieldset(
+                HTML.p(self.text_p1),
+                HTML.p(self.text_p2),
+                HTML.p(self.text_p3),
+                HTML.p(self.text_p4),
+                ConditionalRadios(
+                    "end_user_document_available",
+                    "Yes",
+                    ConditionalRadiosQuestion("No", "end_user_document_missing_reason"),
+                ),
+                legend=self.title,
+                legend_size=Size.EXTRA_LARGE,
+                legend_tag="h1",
             ),
             Submit("submit", "Continue"),
         )

--- a/exporter/applications/views/goods/goods.py
+++ b/exporter/applications/views/goods/goods.py
@@ -354,7 +354,10 @@ class AddGood(LoginRequiredMixin, BaseSessionWizardView):
 
     def get_context_data(self, form, **kwargs):
         context = super().get_context_data(form, **kwargs)
-        context["title"] = form.title
+        try:
+            context["title"] = form.Layout.TITLE
+        except AttributeError:
+            context["title"] = form.title
         # The back_link_url is used for the first form in the sequence. For subsequent forms,
         # the wizard automatically generates the back link to the previous form.
         context["back_link_url"] = reverse("applications:goods", kwargs={"pk": self.kwargs["pk"]})

--- a/exporter/applications/views/goods/goods.py
+++ b/exporter/applications/views/goods/goods.py
@@ -354,9 +354,9 @@ class AddGood(LoginRequiredMixin, BaseSessionWizardView):
 
     def get_context_data(self, form, **kwargs):
         context = super().get_context_data(form, **kwargs)
-        try:
+        if hasattr(form, "Layout") and hasattr(form.Layout, "TITLE"):
             context["title"] = form.Layout.TITLE
-        except AttributeError:
+        else:
             context["title"] = form.title
         # The back_link_url is used for the first form in the sequence. For subsequent forms,
         # the wizard automatically generates the back link to the previous form.

--- a/exporter/core/organisation/forms.py
+++ b/exporter/core/organisation/forms.py
@@ -58,7 +58,7 @@ class RegistrationTypeForm(FieldsetForm):
         return ("type",)
 
 
-class RegistrationUKBasedForm(BaseForm):
+class RegistrationUKBasedForm(FieldsetForm):
     class Layout:
         TITLE = "Where is your organisation based?"
 

--- a/exporter/core/organisation/forms.py
+++ b/exporter/core/organisation/forms.py
@@ -5,7 +5,7 @@ from django.core.exceptions import ValidationError
 
 from crispy_forms_gds.layout import HTML
 
-from core.common.forms import BaseForm, TextChoice
+from core.common.forms import BaseForm, FieldsetForm, TextChoice
 from exporter.core.services import get_countries
 from .validators import validate_phone
 from exporter.core.organisation.services import validate_registration_number
@@ -27,7 +27,7 @@ class RegistrationConfirmation(BaseForm):
         return ()
 
 
-class RegistrationTypeForm(BaseForm):
+class RegistrationTypeForm(FieldsetForm):
     class Layout:
         TITLE = "Select the type of organisation"
 

--- a/exporter/goods/forms/common.py
+++ b/exporter/goods/forms/common.py
@@ -120,7 +120,7 @@ class ProductControlListEntryForm(FieldsetForm):
         return cleaned_data
 
 
-class ProductPVGradingForm(BaseForm):
+class ProductPVGradingForm(FieldsetForm):
     class Layout:
         TITLE = "Does the product have a government security grading or classification?"
 

--- a/exporter/goods/forms/common.py
+++ b/exporter/goods/forms/common.py
@@ -16,7 +16,7 @@ from core.forms.layouts import (
 )
 from core.forms.utils import coerce_str_to_bool
 
-from core.common.forms import BaseForm
+from core.common.forms import BaseForm, FieldsetForm
 from exporter.core.forms import CustomErrorDateInputField
 from exporter.core.services import (
     get_control_list_entries,
@@ -52,7 +52,7 @@ class ProductNameForm(BaseForm):
         )
 
 
-class ProductControlListEntryForm(BaseForm):
+class ProductControlListEntryForm(FieldsetForm):
     class Layout:
         TITLE = "Do you know the product's control list entry?"
 

--- a/exporter/goods/forms/common.py
+++ b/exporter/goods/forms/common.py
@@ -148,7 +148,7 @@ class ProductPVGradingForm(FieldsetForm):
         )
 
 
-class ProductPVGradingDetailsForm(BaseForm):
+class ProductPVGradingDetailsForm(FieldsetForm):
     class Layout:
         TITLE = "What is the security grading or classification?"
 

--- a/exporter/goods/forms/common.py
+++ b/exporter/goods/forms/common.py
@@ -275,7 +275,7 @@ class ProductPartNumberForm(BaseForm):
         return cleaned_data
 
 
-class ProductDocumentAvailabilityForm(BaseForm):
+class ProductDocumentAvailabilityForm(FieldsetForm):
     class Layout:
         TITLE = "Do you have a document that shows what your product is and what it's designed to do?"
 
@@ -324,7 +324,7 @@ class ProductDocumentAvailabilityForm(BaseForm):
         return cleaned_data
 
 
-class ProductDocumentSensitivityForm(BaseForm):
+class ProductDocumentSensitivityForm(FieldsetForm):
     class Layout:
         TITLE = "Is the document rated above Official-sensitive?"
 
@@ -354,7 +354,7 @@ class ProductDocumentSensitivityForm(BaseForm):
         )
 
 
-class ProductDocumentUploadForm(BaseForm):
+class ProductDocumentUploadForm(FieldsetForm):
     class Layout:
         TITLE = "Upload a document that shows what your product is designed to do"
 
@@ -404,7 +404,7 @@ class ProductDocumentUploadForm(BaseForm):
         return layout_fields
 
 
-class ProductOnwardExportedForm(BaseForm):
+class ProductOnwardExportedForm(FieldsetForm):
     class Layout:
         TITLE = "Is the product going to any ultimate end-users?"
 
@@ -431,7 +431,7 @@ class ProductOnwardExportedForm(BaseForm):
         )
 
 
-class ProductOnwardAlteredProcessedForm(BaseForm):
+class ProductOnwardAlteredProcessedForm(FieldsetForm):
     class Layout:
         TITLE = "Will the item be altered or processed before it is exported again?"
 
@@ -482,7 +482,7 @@ class ProductOnwardAlteredProcessedForm(BaseForm):
         return cleaned_data
 
 
-class ProductOnwardIncorporatedForm(BaseForm):
+class ProductOnwardIncorporatedForm(FieldsetForm):
     class Layout:
         TITLE = "Will the product be incorporated into another item before it is onward exported?"
 

--- a/exporter/goods/forms/firearms.py
+++ b/exporter/goods/forms/firearms.py
@@ -462,7 +462,7 @@ class FirearmSection5Form(BaseForm):
         return ("is_covered_by_section_5",)
 
 
-class FirearmMadeBefore1938Form(BaseForm):
+class FirearmMadeBefore1938Form(FieldsetForm):
     class Layout:
         TITLE = "Was the product made before 1938?"
 
@@ -503,7 +503,7 @@ class FirearmYearOfManufactureForm(BaseForm):
         return ("year_of_manufacture",)
 
 
-class FirearmIsDeactivatedForm(BaseForm):
+class FirearmIsDeactivatedForm(FieldsetForm):
     class Layout:
         TITLE = "Has the product been deactivated?"
 
@@ -599,7 +599,7 @@ class FirearmDeactivationDetailsForm(BaseForm):
         return cleaned_data
 
 
-class FirearmSerialIdentificationMarkingsForm(BaseForm):
+class FirearmSerialIdentificationMarkingsForm(FieldsetForm):
     class Layout:
         TITLE = "Will each product have a serial number or other identification marking?"
 

--- a/exporter/goods/forms/firearms.py
+++ b/exporter/goods/forms/firearms.py
@@ -267,7 +267,7 @@ class FirearmAttachRFDCertificate(BaseForm):
         )
 
 
-class FirearmFirearmAct1968Form(BaseForm):
+class FirearmFirearmAct1968Form(FieldsetForm):
     class Layout:
         TITLE = "Which section of the Firearms Act 1968 is the product covered by?"
 

--- a/exporter/goods/forms/firearms.py
+++ b/exporter/goods/forms/firearms.py
@@ -16,7 +16,7 @@ from core.forms.layouts import (
 )
 from core.forms.utils import coerce_str_to_bool
 
-from core.common.forms import BaseForm, TextChoice
+from core.common.forms import BaseForm, FieldsetForm, TextChoice
 from exporter.core.forms import (
     CustomErrorDateInputField,
     PotentiallyUnsafeClearableFileInput,
@@ -100,7 +100,7 @@ class FirearmCalibreForm(BaseForm):
         return ("calibre",)
 
 
-class FirearmReplicaForm(BaseForm):
+class FirearmReplicaForm(FieldsetForm):
     class Layout:
         TITLE = "Is the product a replica firearm?"
 

--- a/exporter/goods/forms/firearms.py
+++ b/exporter/goods/forms/firearms.py
@@ -192,7 +192,7 @@ class FirearmRFDValidityForm(BaseForm):
         )
 
 
-class FirearmRegisteredFirearmsDealerForm(BaseForm):
+class FirearmRegisteredFirearmsDealerForm(FieldsetForm):
     class Layout:
         TITLE = "Are you a registered firearms dealer?"
 

--- a/exporter/goods/forms/goods.py
+++ b/exporter/goods/forms/goods.py
@@ -13,7 +13,7 @@ from core.constants import ComponentAccessoryChoices, ProductCategories
 from core.forms.layouts import ConditionalRadiosQuestion, ConditionalRadios, summary_list
 from core.forms.utils import coerce_str_to_bool
 
-from core.common.forms import TextChoice
+from core.common.forms import FieldsetForm, TextChoice
 from exporter.core.constants import (
     ProductSecurityFeatures,
     ProductDeclaredAtCustoms,
@@ -332,8 +332,9 @@ def has_valid_section_five_certificate(application):
     return False
 
 
-class GroupTwoProductTypeForm(forms.Form):
-    title = CreateGoodForm.FirearmGood.ProductType.TITLE
+class GroupTwoProductTypeForm(FieldsetForm):
+    class Layout:
+        TITLE = CreateGoodForm.FirearmGood.ProductType.TITLE
 
     type = forms.TypedChoiceField(
         choices=(
@@ -352,20 +353,13 @@ class GroupTwoProductTypeForm(forms.Form):
         label="",
     )
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        self.helper = FormHelper()
-        self.helper.layout = Layout(
-            HTML.h1(self.title),
-            "type",
-            Submit("submit", CreateGoodForm.SUBMIT_BUTTON),
-        )
-
     def clean(self):
         cleaned_data = super().clean()
         cleaned_data["product_type_step"] = True
         return cleaned_data
+
+    def get_layout_fields(self):
+        return ("type",)
 
 
 class FirearmsNumberOfItemsForm(forms.Form):

--- a/exporter/goods/views.py
+++ b/exporter/goods/views.py
@@ -102,10 +102,11 @@ class GoodCommonMixin:
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        try:
-            context["title"] = self.get_form().Layout.TITLE
-        except AttributeError:
-            context["title"] = self.get_form().title
+        form = self.get_form()
+        if hasattr(form, "Layout") and hasattr(form.Layout, "TITLE"):
+            context["title"] = form.Layout.TITLE
+        else:
+            context["title"] = form.title
 
         return context
 

--- a/exporter/goods/views.py
+++ b/exporter/goods/views.py
@@ -102,7 +102,10 @@ class GoodCommonMixin:
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["title"] = self.get_form().title
+        try:
+            context["title"] = self.get_form().Layout.TITLE
+        except AttributeError:
+            context["title"] = self.get_form().title
 
         return context
 
@@ -543,7 +546,7 @@ class EditFirearmProductTypeView(LoginRequiredMixin, GoodCommonMixin, FormView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["form_title"] = self.form_class.title
+        context["form_title"] = self.form_class.Layout.TITLE
         return context
 
     def form_valid(self, form):

--- a/exporter/templates/applications/application-submit-success.html
+++ b/exporter/templates/applications/application-submit-success.html
@@ -51,7 +51,6 @@
 		{% endfor %}
 
         <hr>
-        <h2 class="govuk-heading-m">Overall, how would you rate your experience with the 'apply for a standard individual export licence (SIEL)' service today?</h2>
         {% crispy form %}
 	</div>
 {% endblock %}

--- a/unit_tests/exporter/applications/views/parties/test_end_users.py
+++ b/unit_tests/exporter/applications/views/parties/test_end_users.py
@@ -127,9 +127,9 @@ def set_end_user(url, authorized_client):
     assert not response.context["form"].errors
 
     content = BeautifulSoup(response.content, "html.parser")
-    heading_element = content.find("h1", class_="govuk-heading-xl")
+    heading_element = content.find("h1", class_="govuk-fieldset__heading")
 
-    assert heading_element.string == "Select the type of end user"
+    assert heading_element.string.strip() == "Select the type of end user"
 
     response = authorized_client.post(
         url,
@@ -457,6 +457,6 @@ def test_add_end_user_view(authorized_client, data_standard_case):
     url = reverse("applications:add_end_user", kwargs={"pk": application_id})
     response = authorized_client.get(url)
     soup = BeautifulSoup(response.content, "html.parser")
-    heading_element = soup.find("h1", class_="govuk-heading-xl")
+    heading_element = soup.find("h1", class_="govuk-fieldset__heading")
 
-    assert heading_element.string == "Do you want to reuse an existing party?"
+    assert heading_element.string.strip() == "Do you want to reuse an existing party?"


### PR DESCRIPTION
### Aim

The forms listed in the ticket have been updated to make use of the Fieldset component: https://design-system.service.gov.uk/components/fieldset/ via the Fieldset component in Crispy Forms GDS: https://crispy-forms-gds.readthedocs.io/en/latest/components/fieldset.html

A Fieldset component with a Legend serving as the title is considered an accessible way to structure single question forms; see the ticket and link above for more information.

Using DevTools you can see that there is now a `<fieldset>` element which wraps the form inputs and is given a name through the `<legend>` element, this means that the accessibility requirements for WCAG to label form inputs and to structure the page to make relations clear to the user can both be met.

Mostly this is done through the use of a new class `FieldsetForm` that subclasses `BaseForm`. By having a separate class it means that we can easily roll out this new style across LITE on an individual form basis rather than changing everything that uses `BaseForm` at once.

[LTD-5170](https://uktrade.atlassian.net/browse/LTD-5170)


[LTD-5170]: https://uktrade.atlassian.net/browse/LTD-5170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ