### PR TITLE
[LTD-5804] add in f680 approval advice type

### DIFF
--- a/caseworker/advice/constants.py
+++ b/caseworker/advice/constants.py
@@ -9,6 +9,7 @@ DECISION_TYPE_VERB_MAPPING = {
 
 
 TEAM_DECISION_APPROVED = "has approved"
+TEAM_DECISION_APPROVED_F680 = "has approved this F680 application"
 TEAM_DECISION_APPROVED_REFUSED = "has approved and refused"
 TEAM_DECISION_PROVISO = "has approved with licence conditions"
 TEAM_DECISION_REFUSED = "has refused"

--- a/caseworker/advice/templatetags/advice_tags.py
+++ b/caseworker/advice/templatetags/advice_tags.py
@@ -220,5 +220,7 @@ def _add_team_decisions(grouped_advice):
                 team_advice["decision"] = constants.TEAM_DECISION_PROVISO
             elif decisions == {"Refuse"}:
                 team_advice["decision"] = constants.TEAM_DECISION_REFUSED
+            elif decisions == {"F680"}:
+                team_advice["decision"] = constants.TEAM_DECISION_APPROVED_F680
             else:
                 team_advice["decision"] = constants.TEAM_DECISION_APPROVED_REFUSED


### PR DESCRIPTION
### Aim

Aim
Ensure front end can handle F680 approval when showing advice

[LTD-5804](https://uktrade.atlassian.net/browse/LTD-5804)

[LTD-](https://uktrade.atlassian.net/browse/LTD-)


[LTD-5804]: https://uktrade.atlassian.net/browse/LTD-5804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ