### PR TITLE
Fix back links for end user questions

### DIFF
--- a/exporter/applications/views/parties/end_users.py
+++ b/exporter/applications/views/parties/end_users.py
@@ -142,6 +142,13 @@ class SetPartyView(LoginRequiredMixin, BaseSessionWizardView):
     def application(self):
         return get_application(self.request, self.kwargs["pk"])
 
+    # back_link_url only needs to be set for the first question in the form wizard,
+    # for subsequent questions the back link is generated through another mechanism
+    def get_context_data(self, form, **kwargs):
+        context = super().get_context_data(form, **kwargs)
+        context.update({"back_link_url": reverse("applications:add_end_user", kwargs=self.kwargs)})
+        return context
+
     def get_form_kwargs(self, step=None):
         kwargs = super().get_form_kwargs(step)
 

--- a/exporter/applications/views/parties/end_users.py
+++ b/exporter/applications/views/parties/end_users.py
@@ -78,7 +78,13 @@ class AddEndUserView(LoginRequiredMixin, FormView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["form_title"] = self.form_class.Layout.TITLE
+        context.update(
+            {
+                "form_title": self.form_class.Layout.TITLE,
+                "back_link_text": "Back to application overview",
+                "back_link_url": reverse("applications:task_list", kwargs=self.kwargs),
+            }
+        )
         return context
 
     def form_valid(self, form):


### PR DESCRIPTION
### Aim

The back links were not working for the `add_end_user` and `set_end_user` views so this fixes that functionality.

[LTD-5811](https://uktrade.atlassian.net/browse/LTD-5811)


[LTD-5811]: https://uktrade.atlassian.net/browse/LTD-5811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ