### PR TITLE
[LTD-5836] Make allocate and approve use new approval flow

### DIFF
--- a/caseworker/cases/helpers/case.py
+++ b/caseworker/cases/helpers/case.py
@@ -108,9 +108,7 @@ class CaseworkerMixin:
                     "queue_id": self.queue_id,
                     "user_id": self.caseworker["id"],
                     "case_id": self.case_id,
-                    "return_to": reverse(
-                        "cases:approve_all_legacy", kwargs={"queue_pk": self.queue_id, "pk": self.case_id}
-                    ),
+                    "return_to": reverse("cases:approve_all", kwargs={"queue_pk": self.queue_id, "pk": self.case_id}),
                 },
             )
         )


### PR DESCRIPTION
### Aim

Fixes a bug where allocate and approve would use the legacy approval flow (which has now been paired back to FCDO-only).

[LTD-5836](https://uktrade.atlassian.net/browse/LTD-5836)


[LTD-5836]: https://uktrade.atlassian.net/browse/LTD-5836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ