### PR TITLE
LTD-5850: Add queue view sort options

### DIFF
--- a/caseworker/queues/views/forms.py
+++ b/caseworker/queues/views/forms.py
@@ -138,6 +138,17 @@ class CasesFiltersForm(forms.Form):
         country_choices = [(country["id"], country["name"]) for country in countries]
         assigned_queues_choices = [(queue["id"], f"{queue['team']['name']}: {queue['name']}") for queue in queues]
 
+        sort_options = [
+            ("-submitted_at", "Submitted (newest to oldest)"),
+            ("submitted_at", "Submitted (oldest to newest)"),
+        ]
+        self.fields["sort_by"] = forms.ChoiceField(
+            choices=sort_options,
+            label="Sort by",
+            required=False,
+        )
+        self.fields["sort_by"].initial = sort_options[0]
+
         self.fields["status"] = forms.ChoiceField(
             choices=case_status_choices,
             label="Case status",
@@ -249,6 +260,7 @@ class CasesFiltersForm(forms.Form):
         self.helper = FormHelper()
         self.helper.layout = Layout(
             "return_to",
+            "sort_by",
             Accordion(
                 AccordionSection(
                     "Case",

--- a/caseworker/templates/queues/cases.html
+++ b/caseworker/templates/queues/cases.html
@@ -62,8 +62,8 @@
             <details class="govuk-details" {% if is_filters_visible or search_form_has_errors %}open{% endif %}>
                 <summary class="govuk-details__summary" id="show-filters-link">
                   <span class="govuk-details__summary-text">
-                    <span class="govuk-details__summary-text-closed">Show filters</span>
-                    <span class="govuk-details__summary-text-open">Hide filters</span>
+                    <span class="govuk-details__summary-text-closed">Show filters and sort</span>
+                    <span class="govuk-details__summary-text-open">Hide filters and sort</span>
                   </span>
                 </summary>
                 <div class="govuk-details__text">

--- a/unit_tests/caseworker/cases/views/test_case_filters.py
+++ b/unit_tests/caseworker/cases/views/test_case_filters.py
@@ -43,9 +43,11 @@ def setup(
         ({"field": "finalised_to", "params": {"finalised_to_0": "1", "finalised_to_1": "1", "finalised_to_2": "2022"}}),
         ({"params": {"export_type": "permanent", "assigned_queues": "fake-queue-id-1"}}),
         ({"params": {"case_type": "siel", "sub_status": "inform_letter_sent"}}),
+        ({"params": {"sort_by": "submitted_at"}}),
+        ({"params": {"sort_by": "-submitted_at"}}),
     ],
 )
-def test_case_filters(
+def test_case_filters_and_sort(
     authorized_client,
     requests_mock,
     mock_queues_list,

--- a/unit_tests/caseworker/queues/views/test_cases.py
+++ b/unit_tests/caseworker/queues/views/test_cases.py
@@ -173,6 +173,7 @@ def test_cases_home_page_view_context(authorized_client):
         "is_nca_applicable",
         "is_trigger_list",
         "return_to",
+        "sort_by",
         "product_name",
         "includes_refusal_recommendation_from_ogd",
     ]


### PR DESCRIPTION
## Change description

We are adding option to sort the case list in queue view. Initially users can sort based on submission date (newest first or oldest first).
Relevant API PR https://github.com/uktrade/lite-api/pull/2390

[LTD-5850](https://uktrade.atlassian.net/browse/LTD-5850)


[LTD-5850]: https://uktrade.atlassian.net/browse/LTD-5850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ