### PR TITLE
[LTD-5859] - Reinstate case details panel in advice approval views

### DIFF
--- a/caseworker/advice/templates/advice/form_wizard.html
+++ b/caseworker/advice/templates/advice/form_wizard.html
@@ -1,0 +1,7 @@
+{% extends 'core/form-wizard.html' %}
+
+{% block right_side_panel %}
+  <div class="govuk-grid-column-one-third">
+    {% include "advice/case_detail.html" %}
+  </div>
+{% endblock %}

--- a/caseworker/advice/views/approval.py
+++ b/caseworker/advice/views/approval.py
@@ -43,6 +43,7 @@ class SelectAdviceView(LoginRequiredMixin, CaseContextMixin, FormView):
 
 
 class BaseApprovalAdviceView(LoginRequiredMixin, CaseContextMixin, BaseSessionWizardView):
+    template_name = "advice/form_wizard.html"
 
     condition_dict = {
         AdviceSteps.RECOMMEND_APPROVAL: ~C(is_fcdo_team),

--- a/caseworker/templates/core/form-wizard.html
+++ b/caseworker/templates/core/form-wizard.html
@@ -37,6 +37,7 @@
                         {% crispy wizard.form %}
                     {% endif %}
                 </div>
+                {% block right_side_panel %}{% endblock %}
             </div>
         </div>
     </form>


### PR DESCRIPTION
### Aim

To reinstate (or add) the case details panel into the new recommendation flow

[LTD-5859](https://uktrade.atlassian.net/browse/LTD-5859)


[LTD-5859]: https://uktrade.atlassian.net/browse/LTD-5859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ