### PR TITLE
[LTD-5921] Clean up presentation of question/answer sections for F680 details

### DIFF
--- a/caseworker/assets/styles/components/_all.scss
+++ b/caseworker/assets/styles/components/_all.scss
@@ -39,3 +39,4 @@
 @import "customiser";
 @import "table-expander";
 @import "query-search";
+@import "application-section";

--- a/caseworker/assets/styles/components/_application-section.scss
+++ b/caseworker/assets/styles/components/_application-section.scss
@@ -1,0 +1,10 @@
+.application-section {
+
+  table {
+      col.application-questions {
+        width: 30rem;
+      }
+
+    }
+
+}

--- a/caseworker/f680/templates/f680/case/detail.html
+++ b/caseworker/f680/templates/f680/case/detail.html
@@ -6,11 +6,13 @@
 </section>
 
 {% for section_key, section in case.data.application.sections.items %}
+    <div class="application-section">
     {% if section.type == "single" %}
         {% include "f680/includes/application_section_single.html" with section=section section_key=section_key %}
     {% else %}
         {% include "f680/includes/application_section_multiple.html" with section=section section_key=section_key %}
     {% endif %}
+    </div>
 {% endfor %}
 
 {% endblock %}

--- a/caseworker/f680/templates/f680/includes/answer.html
+++ b/caseworker/f680/templates/f680/includes/answer.html
@@ -1,0 +1,9 @@
+{% if field.datatype == "list" %}
+    <ul class="govuk-list--bullet">
+    {% for answer_item in field.answer %}
+        <li>{{answer_item}}</li>
+    {% endfor %}
+    </ul>
+{% else %}
+{{field.answer}}
+{% endif %}

--- a/caseworker/f680/templates/f680/includes/application_section_fields.html
+++ b/caseworker/f680/templates/f680/includes/application_section_fields.html
@@ -1,10 +1,15 @@
 <table class="govuk-table application-section-{{section_key}}">
     <tbody class="govuk-table__body">
+        <colgroup>
+            <col span="1" class="application-questions"/>
+        </colgroup>
         {% for field in item.fields %}
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header">{{field.question}}</th>
-            <td class="govuk-table__cell">{{field.answer}}</td>
-        </tr>
+            {% if field.answer %}
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header">{{field.question}}</th>
+                <td class="govuk-table__cell">{% include "f680/includes/answer.html" with field=field %}</td>
+            </tr>
+            {% endif %}
         {% endfor %}
     </tbody>
 </table>


### PR DESCRIPTION
### Aim

This change cleans up the display of the application question/answers on the F680 case details page;
- A uniform column width is used for the questions.
- Questions where no answer is present are hidden.
- Answers for fields with `datatype="list"` are displayed in a `<ul>`

[LTD-5921](https://uktrade.atlassian.net/browse/LTD-5921)


[LTD-5921]: https://uktrade.atlassian.net/browse/LTD-5921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ