### PR TITLE
[LTD-5949] F680 move case forward button

### DIFF
--- a/caseworker/core/rules.py
+++ b/caseworker/core/rules.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 import rules
 
 from caseworker.advice.constants import AdviceLevel
@@ -197,6 +198,11 @@ def check_user_is_not_logged_in_caseworker(request, user):
     return is_actioned_user_not_current_user
 
 
+@rules.predicate
+def is_f680_feature_flag_enabled(request):
+    return settings.FEATURE_FLAG_ALLOW_F680
+
+
 rules.add_rule("can_user_allocate_case", is_case_caseworker_operable)
 rules.add_rule("can_user_change_case", is_user_allocated)
 rules.add_rule("can_user_move_case_forward", is_user_allocated)
@@ -225,3 +231,4 @@ rules.add_rule("can_user_manage_organisation", is_user_manage_organisations_role
 rules.add_rule("can_caseworker_deactivate", (is_super_user) & check_user_is_not_logged_in_caseworker)  # noqa
 rules.add_rule("can_caseworker_edit_user", (is_super_user))  # noqa
 rules.add_rule("can_caseworker_add_user", (is_super_user))  # noqa
+rules.add_rule("can_user_modify_f680", is_f680_feature_flag_enabled)

--- a/caseworker/f680/templates/f680/case/detail.html
+++ b/caseworker/f680/templates/f680/case/detail.html
@@ -1,9 +1,30 @@
 {% extends 'layouts/case.html' %}
-{% block details %}
+{% load rules %}
+{% block full_width %}
+
+
 <section class="govuk-!-margin-top-8">
     <h1 class="govuk-visually-hidden">Case Summary</h1>
     {% include "f680/case/summary.html" %}
 </section>
+
+{% test_rule 'can_user_move_case_forward' request case as can_user_move_case_forward %}
+{% if can_user_move_case_forward and not is_all_cases_queue  %}
+<div class="govuk-width-container govuk-!-margin-top-5">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds"><br/></div>
+      <div class="govuk-grid-column-one-third">
+        <div class="govuk-grid-column-full" style="text-align: right">
+            <form action="{% url 'cases:f680:move_case_forward' queue.id case.id %}" method="POST">
+                {% csrf_token %}
+                <input class="govuk-button" type="submit" value="Move case forward">
+            </form>
+        </div>
+      </div>
+    </div>
+</div>
+{% endif %}
+
 
 {% for section_key, section in case.data.application.sections.items %}
     <div class="application-section">

--- a/caseworker/f680/urls.py
+++ b/caseworker/f680/urls.py
@@ -11,4 +11,9 @@ urlpatterns = [
         views.CaseDetailView.as_view(),
         name="details",
     ),
+    path(
+        "move-case-forward",
+        views.MoveCaseForward.as_view(),
+        name="move_case_forward",
+    ),
 ]

--- a/caseworker/f680/views.py
+++ b/caseworker/f680/views.py
@@ -41,7 +41,10 @@ class MoveCaseForward(LoginRequiredMixin, View):
         queue_pk = str(queue_pk)
         case_pk = str(pk)
         case = get_case(request, case_pk)
-        if not rules.test_rule("can_user_move_case_forward", self.request, case):
+        user_can_move_case = rules.test_rule("can_user_move_case_forward", self.request, case)
+        user_can_modify_f680 = rules.test_rule("can_user_modify_f680", self.request)
+        permission_granted = user_can_move_case and user_can_modify_f680
+        if not permission_granted:
             raise PermissionDenied("Cannot move case forward")
 
         move_case_forward(request, case_pk, queue_pk)

--- a/caseworker/f680/views.py
+++ b/caseworker/f680/views.py
@@ -47,11 +47,11 @@ class MoveCaseForward(LoginRequiredMixin, View):
         move_case_forward(request, case_pk, queue_pk)
 
         all_cases_queue_url = reverse("cases:f680:details", kwargs={"queue_pk": ALL_CASES_QUEUE_ID, "pk": case_pk})
-        success_message = (
-            mark_safe(
-                f"<a href='{all_cases_queue_url}' class='govuk-link govuk-link--inverse'>{case.reference_code}</a>&nbsp;"
-                "was successfully moved forward"
-            )
+        # WARNING: When changing this message be aware that the content is marked
+        #   as safe. No user-supplied string should be injected in to it
+        success_message = mark_safe(  # noqa: S308
+            f"<a href='{all_cases_queue_url}' class='govuk-link govuk-link--inverse'>{case.reference_code}</a>&nbsp;"
+            "was successfully moved forward"
         )
         messages.success(self.request, success_message, extra_tags="safe")
         queue_url = reverse("queues:cases", kwargs={"queue_pk": queue_pk})

--- a/caseworker/f680/views.py
+++ b/caseworker/f680/views.py
@@ -49,7 +49,8 @@ class MoveCaseForward(LoginRequiredMixin, View):
         all_cases_queue_url = reverse("cases:f680:details", kwargs={"queue_pk": ALL_CASES_QUEUE_ID, "pk": case_pk})
         success_message = (
             mark_safe(
-                f"<a href='{all_cases_queue_url}' class='govuk-link govuk-link--inverse'>{case.reference_code}</a>&nbsp;was successfully moved forward"
+                f"<a href='{all_cases_queue_url}' class='govuk-link govuk-link--inverse'>{case.reference_code}</a>&nbsp;"
+                "was successfully moved forward"
             )
         )
         messages.success(self.request, success_message, extra_tags="safe")

--- a/caseworker/f680/views.py
+++ b/caseworker/f680/views.py
@@ -1,8 +1,10 @@
 from django.contrib import messages
+from django.core.exceptions import PermissionDenied
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.safestring import mark_safe
 from django.views.generic import TemplateView, View
+import rules
 
 from core.auth.views import LoginRequiredMixin
 
@@ -39,7 +41,11 @@ class MoveCaseForward(LoginRequiredMixin, View):
         queue_pk = str(queue_pk)
         case_pk = str(pk)
         case = get_case(request, case_pk)
+        if not rules.test_rule("can_user_move_case_forward", self.request, case):
+            raise PermissionDenied("Cannot move case forward")
+
         move_case_forward(request, case_pk, queue_pk)
+
         all_cases_queue_url = reverse("cases:f680:details", kwargs={"queue_pk": ALL_CASES_QUEUE_ID, "pk": case_pk})
         success_message = (
             mark_safe(

--- a/caseworker/f680/views.py
+++ b/caseworker/f680/views.py
@@ -1,10 +1,12 @@
 from django.contrib import messages
 from django.shortcuts import redirect
 from django.urls import reverse
+from django.utils.safestring import mark_safe
 from django.views.generic import TemplateView, View
 
 from core.auth.views import LoginRequiredMixin
 
+from caseworker.core.constants import ALL_CASES_QUEUE_ID
 from caseworker.cases.services import get_case
 from caseworker.advice.services import move_case_forward
 from caseworker.cases.helpers.case import CaseworkerMixin
@@ -38,6 +40,12 @@ class MoveCaseForward(LoginRequiredMixin, View):
         case_pk = str(pk)
         case = get_case(request, case_pk)
         move_case_forward(request, case_pk, queue_pk)
-        messages.success(self.request, f"{case.reference_code} was successfully moved forward")
+        all_cases_queue_url = reverse("cases:f680:details", kwargs={"queue_pk": ALL_CASES_QUEUE_ID, "pk": case_pk})
+        success_message = (
+            mark_safe(
+                f"<a href='{all_cases_queue_url}' class='govuk-link govuk-link--inverse'>{case.reference_code}</a>&nbsp;was successfully moved forward"
+            )
+        )
+        messages.success(self.request, success_message, extra_tags="safe")
         queue_url = reverse("queues:cases", kwargs={"queue_pk": queue_pk})
         return redirect(queue_url)


### PR DESCRIPTION
### Aim

This PR adds a rudimentary "Move case forward" button when a case is on a team queue.

This also introduces a success message with a link; in order to allow the user to see where the case went after they have moved it forward.

[LTD-5949](https://uktrade.atlassian.net/browse/LTD-5949)


[LTD-5949]: https://uktrade.atlassian.net/browse/LTD-5949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ