### PR TITLE
Fix type error manifesting from appending lists

### DIFF
--- a/caseworker/cases/helpers/case.py
+++ b/caseworker/cases/helpers/case.py
@@ -168,10 +168,10 @@ class CaseView(CaseworkerMixin, TemplateView):
 
     def get_destination_countries(self):
         destination_countries = set()
-        all_parties = self.case.data.get("ultimate_end_users", {}) + self.case.data.get("third_parties", {})
-        if self.case.data.get("end_user", {}):
+        all_parties = self.case.data.get("ultimate_end_users", []) + self.case.data.get("third_parties", [])
+        if self.case.data.get("end_user"):
             all_parties.append(self.case.data["end_user"])
-        if self.case.data.get("consignee", {}):
+        if self.case.data.get("consignee"):
             all_parties.append(self.case.data["consignee"])
         for party in all_parties:
             destination_countries.add(party["country"]["name"])


### PR DESCRIPTION
### Aim

Noticed when working locally that various case views will error based on these new defaults with `TypeError unsupported operand type(s) for +: 'dict' and 'dict'`

This change remedies that issue.