### PR TITLE
Delegate out processing of licence type questions to separate apps

### DIFF
--- a/exporter/applications/licence_type_processors.py
+++ b/exporter/applications/licence_type_processors.py
@@ -1,0 +1,9 @@
+from django.shortcuts import redirect
+
+
+class ExportLicenceLicenceTypeProcessor:
+    def __init__(self, request):
+        self.request = request
+
+    def process(self):
+        return redirect("apply_for_a_licence:export_licence_questions")

--- a/exporter/apply_for_a_licence/enums.py
+++ b/exporter/apply_for_a_licence/enums.py
@@ -37,3 +37,10 @@ class OpenGeneralExportLicenceTypes:
     @classmethod
     def get_by_acronym(cls, acronym):
         return next(ogl for ogl in cls.all() if ogl.acronym.lower() == acronym.lower())
+
+
+class LicenceType:
+    EXPORT_LICENCE = "export_licence"
+    F680 = "f680"
+    TRANSHIPMENT = "transhipment"
+    TRADE_CONTROL_LICENCE = "trade_control_licence"

--- a/exporter/apply_for_a_licence/forms/triage_questions.py
+++ b/exporter/apply_for_a_licence/forms/triage_questions.py
@@ -13,6 +13,7 @@ from core.common.forms import (
 from core.constants import GoodsTypeCategory
 from core.forms.layouts import RenderTemplate
 from exporter.applications.forms.edit import firearms_form, reference_name_form, told_by_an_official_form
+from exporter.apply_for_a_licence.enums import LicenceType
 from exporter.core.constants import CaseTypes
 from lite_content.lite_exporter_frontend import generic
 from lite_content.lite_exporter_frontend.applications import (
@@ -38,27 +39,27 @@ class LicenceTypeForm(FieldsetForm):
     licence_type = forms.ChoiceField(
         choices=(
             Choice(
-                "export_licence",
+                LicenceType.EXPORT_LICENCE,
                 "Export licence",
                 hint="Select if you’re sending products from the UK to another country. You need an export licence "
                 "before you provide access to controlled technology, software or data.",
             ),
             Choice(
-                "f680",
+                LicenceType.F680,
                 "Security Approval",
                 hint="Select if you need approval to give classified products or information to non-UK organisations, "
                 "governments and individuals. This includes F680 approval. You should apply for security approval "
                 "before you apply for a licence.",
             ),
             Choice(
-                "transhipment",
+                LicenceType.TRANSHIPMENT,
                 "Transhipment licence",
                 disabled=True,
                 hint="Select if you're shipping something from overseas through the UK on to another country. If the "
                 "products will be in the UK for 30 days or more, apply for an export licence.",
             ),
             Choice(
-                "trade_control_licence",
+                LicenceType.TRADE_CONTROL_LICENCE,
                 "Trade control licence",
                 disabled=True,
                 hint="Select if you’re arranging or brokering the sale or movement of controlled military products "

--- a/exporter/apply_for_a_licence/urls.py
+++ b/exporter/apply_for_a_licence/urls.py
@@ -7,9 +7,8 @@ from exporter.apply_for_a_licence import views
 app_name = "apply_for_a_licence"
 
 urlpatterns = [
-    path("", views.LicenceType.as_view(), name="start"),
+    path("", views.LicenceTypeView.as_view(), name="start"),
     path("export/", views.ExportLicenceQuestions.as_view(), name="export_licence_questions"),
-    path("f680/", views.F680Questions.as_view(), name="f680_questions"),
 ]
 
 if not settings.FEATURE_FLAG_ONLY_ALLOW_SIEL:

--- a/exporter/f680/licence_type_processors.py
+++ b/exporter/f680/licence_type_processors.py
@@ -1,0 +1,25 @@
+from django.shortcuts import redirect
+
+from http import HTTPStatus
+
+from core.decorators import expect_status
+
+from exporter.f680.services import post_f680_application
+
+
+class F680LicenceLicenceTypeProcessor:
+    def __init__(self, request):
+        self.request = request
+
+    @expect_status(
+        HTTPStatus.CREATED,
+        "Error creating F680 application",
+        "Unexpected error creating F680 application",
+    )
+    def post_f680_application(self, data):
+        return post_f680_application(self.request, data)
+
+    def process(self):
+        data = {"application": {}}
+        response_data, _ = self.post_f680_application(data)
+        return redirect("f680:summary", pk=response_data["id"])

--- a/exporter/f680/tests/test_views.py
+++ b/exporter/f680/tests/test_views.py
@@ -20,8 +20,8 @@ def authorized_client(authorized_client_factory, mock_exporter_user):
 
 
 @pytest.fixture
-def f680_apply_url():
-    return reverse("f680:apply")
+def apply_for_a_licence_url():
+    return reverse("apply_for_a_licence:start")
 
 
 @pytest.fixture
@@ -129,68 +129,19 @@ def set_f680_allowed_organisation(settings, organisation_pk):
     settings.FEATURE_FLAG_ALLOW_F680 = False
 
 
-class TestApplyForLicenceQuestionsClass:
-    def test_triage_f680_apply_redirect_success(self, authorized_client, f680_apply_url):
-        response = authorized_client.post(reverse("apply_for_a_licence:f680_questions"))
-        assert response.status_code == 302
-        assert response.url == f680_apply_url
-
-
-class TestF680ApplicationCreateView:
-    def test_get_create_f680_view_success(
+class TestF680ApplyForALicence:
+    def test_POST_apply_for_a_licence_success(
         self,
         authorized_client,
-        f680_apply_url,
+        apply_for_a_licence_url,
         f680_summary_url_with_application,
         mock_application_post,
     ):
-        response = authorized_client.get(f680_apply_url)
+        response = authorized_client.post(apply_for_a_licence_url, data={"licence_type": "f680"})
         assert response.status_code == 302
         assert response.url == f680_summary_url_with_application
         assert mock_application_post.called_once
         assert mock_application_post.last_request.json() == {"application": {}}
-
-    def test_get_create_f680_view_success_allowed_organisation(
-        self,
-        authorized_client,
-        f680_apply_url,
-        f680_summary_url_with_application,
-        mock_application_post,
-        set_f680_allowed_organisation,
-    ):
-        response = authorized_client.get(f680_apply_url)
-        assert response.status_code == 302
-        assert response.url == f680_summary_url_with_application
-        assert mock_application_post.called_once
-        assert mock_application_post.last_request.json() == {"application": {}}
-
-    def test_get_create_f680_view_fail_with_feature_flag_off(
-        self,
-        authorized_client,
-        f680_apply_url,
-        mock_f680_application_get,
-        unset_f680_feature_flag,
-    ):
-        response = authorized_client.get(f680_apply_url)
-        assert response.context[0].get("title") == "Forbidden"
-        assert (
-            "You are not authorised to use the F680 Security Clearance application feature"
-            in response.context[0].get("description").args
-        )
-
-    def test_get_create_f680_view_fail_with_feature_organidation_not_allowed(
-        self,
-        authorized_client,
-        f680_apply_url,
-        mock_f680_application_get,
-        unset_f680_allowed_organisation,
-    ):
-        response = authorized_client.get(f680_apply_url)
-        assert response.context[0].get("title") == "Forbidden"
-        assert (
-            "You are not authorised to use the F680 Security Clearance application feature"
-            in response.context[0].get("description").args
-        )
 
 
 class TestF680ApplicationSummaryView:

--- a/exporter/f680/urls.py
+++ b/exporter/f680/urls.py
@@ -6,7 +6,6 @@ from . import views
 app_name = "f680"
 
 urlpatterns = [
-    path("apply/", views.F680ApplicationCreateView.as_view(), name="apply"),
     path("<uuid:pk>/apply/", views.F680ApplicationSummaryView.as_view(), name="summary"),
     path(
         "<uuid:pk>/general-application-details/",

--- a/exporter/f680/views.py
+++ b/exporter/f680/views.py
@@ -2,9 +2,8 @@ from http import HTTPStatus
 import rules
 
 from django.contrib.auth.mixins import AccessMixin
-from django.shortcuts import redirect
 from django.urls import reverse
-from django.views.generic import FormView, RedirectView
+from django.views.generic import FormView
 
 from core.auth.views import LoginRequiredMixin
 from core.decorators import expect_status
@@ -12,7 +11,6 @@ from core.decorators import expect_status
 from .forms import ApplicationSubmissionForm
 
 from .services import (
-    post_f680_application,
     get_f680_application,
     submit_f680_application,
 )
@@ -27,32 +25,6 @@ class F680FeatureRequiredMixin(AccessMixin):
             )
             return self.handle_no_permission()
         return super().dispatch(request, *args, **kwargs)
-
-
-class F680ApplicationCreateView(LoginRequiredMixin, F680FeatureRequiredMixin, RedirectView):
-
-    @expect_status(
-        HTTPStatus.CREATED,
-        "Error creating F680 application",
-        "Unexpected error creating F680 application",
-    )
-    def post_f680_application(self, data):
-        return post_f680_application(self.request, data)
-
-    def get_success_url(self, application_id):
-        return reverse(
-            "f680:summary",
-            kwargs={
-                "pk": application_id,
-            },
-        )
-
-    def get(self, request, *args, **kwargs):
-        super().get(request, *args, **kwargs)
-        # Data required to create a base application
-        data = {"application": {}}
-        response_data, _ = self.post_f680_application(data)
-        return redirect(self.get_success_url(response_data["id"]))
 
 
 class F680ApplicationSummaryView(LoginRequiredMixin, F680FeatureRequiredMixin, FormView):

--- a/unit_tests/exporter/applications/views/test_apply_for_a_licence.py
+++ b/unit_tests/exporter/applications/views/test_apply_for_a_licence.py
@@ -1,0 +1,17 @@
+import pytest
+
+from django.urls import reverse
+
+
+@pytest.fixture()
+def apply_for_a_licence_url():
+    return reverse("apply_for_a_licence:start")
+
+
+def test_POST_apply_for_a_licence_redirects(
+    authorized_client,
+    apply_for_a_licence_url,
+):
+    response = authorized_client.post(apply_for_a_licence_url, data={"licence_type": "export_licence"})
+    assert response.status_code == 302
+    assert response.url == reverse("apply_for_a_licence:export_licence_questions")

--- a/unit_tests/exporter/apply_for_a_licence/test_urls.py
+++ b/unit_tests/exporter/apply_for_a_licence/test_urls.py
@@ -18,7 +18,6 @@ def test_url_respects_siel_only_feature_flag_off(settings):
     # then SIEL and start url are found
     reverse("apply_for_a_licence:start")
     reverse("apply_for_a_licence:export_licence_questions")
-    reverse("apply_for_a_licence:f680_questions")
 
     # but non SIEL urls are not found
     with pytest.raises(NoReverseMatch):
@@ -37,7 +36,6 @@ def test_url_respects_siel_only_feature_flag_on(settings):
     # then SIEL and start url are found
     reverse("apply_for_a_licence:start")
     reverse("apply_for_a_licence:export_licence_questions")
-    reverse("apply_for_a_licence:f680_questions")
 
     # and non SIEL urls are found
     reverse("apply_for_a_licence:transhipment_questions")


### PR DESCRIPTION
### Aim

Delegate out the processing of the application type answer.

This is so that the logic about what to do with the application is in the django app of that application type.

[LTD-5994](https://uktrade.atlassian.net/browse/LTD-5994)


[LTD-5994]: https://uktrade.atlassian.net/browse/LTD-5994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ