### PR TITLE
Move SIEL application code into SIELs Django app

### DIFF
--- a/exporter/applications/constants.py
+++ b/exporter/applications/constants.py
@@ -65,3 +65,9 @@ class OielLicenceTypes(Enum):
             OielLicenceTypes.DEALER.value,
             OielLicenceTypes.UK_CONTINENTAL_SHELF.value,
         ]
+
+
+class ExportLicenceSteps:
+    LICENCE_TYPE = "LICENCE_TYPE"
+    APPLICATION_NAME = "APPLICATION_NAME"
+    TOLD_BY_AN_OFFICIAL = "TOLD_BY_AN_OFFICIAL"

--- a/exporter/applications/forms/common.py
+++ b/exporter/applications/forms/common.py
@@ -3,11 +3,25 @@ from django import forms
 from crispy_forms_gds.helper import FormHelper
 from crispy_forms_gds.layout import HTML, Submit
 
+from django.core.exceptions import ValidationError
 from django.urls import reverse_lazy
 
-from core.common.forms import BaseForm
+from core.common.forms import (
+    BaseForm,
+    Choice,
+    FieldsetForm,
+)
+from core.forms.layouts import (
+    ConditionalRadiosQuestion,
+    ConditionalRadios,
+    RenderTemplate,
+)
+
 from exporter.applications.forms.edit import told_by_an_official_form, reference_name_form
-from exporter.core.constants import STANDARD
+from exporter.core.constants import (
+    CaseTypes,
+    STANDARD,
+)
 from lite_content.lite_exporter_frontend import strings
 from lite_forms.components import (
     Form,
@@ -126,3 +140,112 @@ class ApplicationsListSortForm(BaseForm):
 
     def get_layout_actions(self):
         return []
+
+
+class LicenceTypeForm(FieldsetForm):
+    class Layout:
+        TITLE = "Select the type of export licence you need"
+
+    application_type = forms.ChoiceField(
+        choices=(
+            Choice(
+                CaseTypes.SIEL,
+                "Standard Individual Export Licence (SIEL)",
+                hint="Select to apply for a licence to export a set quantity and set value of products to 1 destination.",
+            ),
+            Choice(
+                CaseTypes.OGEL,
+                "Open General Export Licence (OGEL)",
+                disabled=True,
+                hint="Select to register a pre-published licence with set terms "
+                "and conditions. Being an OGEL holder can benefit your business "
+                "by saving time and money.",
+            ),
+            Choice(
+                CaseTypes.OIEL,
+                "Open Individual Export Licence (OIEL)",
+                disabled=True,
+                hint="Select to apply for a licence to export multiple shipments of specific products to specific "
+                "destinations. OIELs cover long term projects and repeat business.",
+            ),
+        ),
+        label="",
+        widget=forms.RadioSelect,
+    )
+
+    def get_layout_fields(self):
+        return (
+            RenderTemplate("applications/use-spire-application-type.html"),
+            "application_type",
+        )
+
+    def clean_application_type(self):
+        valid_choices = [
+            choice.value for choice in self.fields["application_type"].choices if not getattr(choice, "disabled", False)
+        ]
+        value = self.cleaned_data["application_type"]
+
+        if value not in valid_choices:
+            raise ValidationError(
+                self.fields["application_type"].error_messages["invalid_choice"],
+                code="invalid_choice",
+                params={"value": value},
+            )
+
+        return value
+
+
+class ApplicationNameForm(BaseForm):
+    class Layout:
+        TITLE = "Name the application"
+        TITLE_AS_LABEL_FOR = "name"
+        SUBMIT_BUTTON_TEXT = "Continue"
+
+    name = forms.CharField(
+        label="",
+        help_text="Give the application a reference name so you can refer back to it when needed",
+    )
+
+    def get_layout_fields(self):
+        return ("name",)
+
+
+class ToldByAnOfficialForm(FieldsetForm):
+    class Layout:
+        TITLE = "Have you received a letter or email from Border Force or HMRC informing you to apply for a licence?"
+        SUBMIT_BUTTON_TEXT = "Continue"
+
+    have_you_been_informed = forms.ChoiceField(
+        choices=(
+            ("yes", "Yes"),
+            ("no", "No"),
+        ),
+        label="",
+        widget=forms.RadioSelect,
+    )
+    reference_number_on_information_form = forms.CharField(
+        label="Reference number",
+        help_text="For example, CRE/2020/1234567. The reference number is on the letter or email.",
+        required=False,
+    )
+
+    def get_layout_fields(self):
+        return (
+            ConditionalRadios(
+                "have_you_been_informed",
+                ConditionalRadiosQuestion(
+                    "Yes",
+                    "reference_number_on_information_form",
+                ),
+                "No",
+            ),
+        )
+
+    def clean(self):
+        if (
+            self.cleaned_data.get("have_you_been_informed") == "no"
+            and "reference_number_on_information_form" in self.cleaned_data
+        ):
+            self.cleaned_data["reference_number_on_information_form"] = ""
+
+        return self.cleaned_data

--- a/exporter/applications/licence_type_processors.py
+++ b/exporter/applications/licence_type_processors.py
@@ -6,4 +6,4 @@ class ExportLicenceLicenceTypeProcessor:
         self.request = request
 
     def process(self):
-        return redirect("apply_for_a_licence:export_licence_questions")
+        return redirect("applications:apply")

--- a/exporter/applications/payloads.py
+++ b/exporter/applications/payloads.py
@@ -1,0 +1,26 @@
+from core.wizard.payloads import (
+    get_cleaned_data,
+    MergingPayloadBuilder,
+)
+
+from exporter.applications.constants import ExportLicenceSteps
+
+
+class ExportLicencePayloadBuilder(MergingPayloadBuilder):
+    payload_dict = {
+        ExportLicenceSteps.LICENCE_TYPE: get_cleaned_data,
+        ExportLicenceSteps.APPLICATION_NAME: get_cleaned_data,
+        ExportLicenceSteps.TOLD_BY_AN_OFFICIAL: get_cleaned_data,
+    }
+
+    def build(self, form_dict):
+        payload = super().build(form_dict)
+
+        payload.update(
+            {
+                "application_type": "siel",
+                "export_type": "permanent",
+            }
+        )
+
+        return payload

--- a/exporter/applications/urls.py
+++ b/exporter/applications/urls.py
@@ -58,6 +58,7 @@ app_name = "applications"
 urlpatterns = [
     # Common
     path("", common.ApplicationsList.as_view(), name="applications"),
+    path("apply/", common.ExportLicenceView.as_view(), name="apply"),
     path("add-serial-numbers/", goods.AddSerialNumbersList.as_view(), name="add_serial_numbers"),
     path("<uuid:pk>/delete/", common.DeleteApplication.as_view(), name="delete"),
     path("<uuid:pk>/task-list/", common.ApplicationTaskList.as_view(), name="task_list"),

--- a/exporter/apply_for_a_licence/urls.py
+++ b/exporter/apply_for_a_licence/urls.py
@@ -8,7 +8,6 @@ app_name = "apply_for_a_licence"
 
 urlpatterns = [
     path("", views.LicenceTypeView.as_view(), name="start"),
-    path("export/", views.ExportLicenceQuestions.as_view(), name="export_licence_questions"),
 ]
 
 if not settings.FEATURE_FLAG_ONLY_ALLOW_SIEL:

--- a/exporter/apply_for_a_licence/views.py
+++ b/exporter/apply_for_a_licence/views.py
@@ -6,7 +6,7 @@ from django.views.generic import (
 
 from lite_forms.views import MultiFormView
 
-from exporter.applications.services import post_applications, post_open_general_licences_applications
+from exporter.applications.services import post_applications
 from exporter.applications.licence_type_processors import ExportLicenceLicenceTypeProcessor
 from exporter.apply_for_a_licence.forms.open_general_licences import (
     open_general_licence_forms,
@@ -15,7 +15,6 @@ from exporter.apply_for_a_licence.forms.open_general_licences import (
 from exporter.apply_for_a_licence.enums import LicenceType
 from exporter.apply_for_a_licence.forms.triage_questions import (
     LicenceTypeForm,
-    export_licence_questions,
     transhipment_questions,
 )
 from exporter.apply_for_a_licence.validators import validate_open_general_licences
@@ -53,30 +52,6 @@ class LicenceTypeView(LoginRequiredMixin, FormView):
         ctx["back_link_url"] = reverse("core:home")
 
         return ctx
-
-
-class ExportLicenceQuestions(LoginRequiredMixin, MultiFormView):
-    def init(self, request, **kwargs):
-        self.forms = export_licence_questions(request, None)
-
-    def get_action(self):
-        if self.request.POST.get("application_type") == CaseTypes.OGEL:
-            return post_open_general_licences_applications
-        else:
-            return post_applications
-
-    def on_submission(self, request, **kwargs):
-        copied_req = request.POST.copy()
-        self.forms = export_licence_questions(
-            request, copied_req.get("application_type"), copied_req.get("goodstype_category")
-        )
-
-    def get_success_url(self):
-        if self.request.POST.get("application_type") == CaseTypes.OGEL:
-            return reverse_lazy("apply_for_a_licence:ogl_questions", kwargs={"ogl": CaseTypes.OGEL})
-        else:
-            pk = self.get_validated_data()["id"]
-            return reverse_lazy("applications:task_list", kwargs={"pk": pk})
 
 
 class TranshipmentQuestions(LoginRequiredMixin, MultiFormView):

--- a/exporter/templates/applications/use-spire-application-type.html
+++ b/exporter/templates/applications/use-spire-application-type.html
@@ -1,6 +1,6 @@
 {% spaceless %}
 <div class="govuk-!-margin-bottom-8 govuk-inset-text">
-    <div class="govuk-body">Use <a href="https://www.spire.trade.gov.uk">SPIRE – the online export licensing system</a>
+    <div class="govuk-body">Use <a class="govuk-link" href="https://www.spire.trade.gov.uk">SPIRE – the online export licensing system</a>
          to:</div>
     <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-2">
         <li>register for open general export licences</li>

--- a/ui_tests/exporter/pages/apply_for_a_licence_page.py
+++ b/ui_tests/exporter/pages/apply_for_a_licence_page.py
@@ -21,7 +21,7 @@ class ApplyForALicencePage(BasePage):
     OIEL_EXPORT_TYPE_RADIO_BUTTON_ID = "goodstype_category-"
 
     def enter_name_or_reference_for_application(self, name):
-        element = self.driver.find_element(by=By.ID, value=self.NAME_OR_REFERENCE_INPUT_ID)
+        element = self.driver.find_element(by=By.ID, value="id_APPLICATION_NAME-name")
         element.clear()
         element.send_keys(name)
 
@@ -38,7 +38,8 @@ class ApplyForALicencePage(BasePage):
 
     def click_export_licence(self, export_type):
         return self.driver.find_element(
-            by=By.CSS_SELECTOR, value=self.RADIOBUTTON_LICENCE_ID_PARTIAL + export_type
+            by=By.CSS_SELECTOR,
+            value=f"input[name=LICENCE_TYPE-application_type][value={export_type}]",
         ).click()
 
     def select_types_of_clearance(self):

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -2725,3 +2725,11 @@ def beautiful_soup():
         return BeautifulSoup(html, "html.parser")
 
     return _beautiful_soup
+
+
+@pytest.fixture()
+def api_url():
+    def _api_url(path):
+        return client._build_absolute_uri(path)
+
+    return _api_url

--- a/unit_tests/exporter/applications/forms/test_common.py
+++ b/unit_tests/exporter/applications/forms/test_common.py
@@ -1,0 +1,89 @@
+import pytest
+
+from exporter.applications.forms.common import (
+    ApplicationNameForm,
+    LicenceTypeForm,
+    ToldByAnOfficialForm,
+)
+
+
+@pytest.mark.parametrize(
+    "data, is_valid, cleaned_data, errors",
+    (
+        ({"application_type": "siel"}, True, {"application_type": "siel"}, {}),
+        (
+            {"application_type": "ogel"},
+            False,
+            {},
+            {"application_type": ["Select a valid choice. ogel is not one of the available choices."]},
+        ),
+        (
+            {"application_type": "oiel"},
+            False,
+            {},
+            {"application_type": ["Select a valid choice. oiel is not one of the available choices."]},
+        ),
+    ),
+)
+def test_licence_type_form(data, is_valid, cleaned_data, errors):
+    form = LicenceTypeForm(data=data)
+    assert form.is_valid() == is_valid
+    assert form.errors == errors
+    assert form.cleaned_data == cleaned_data
+
+
+@pytest.mark.parametrize(
+    "data, is_valid, cleaned_data, errors",
+    (
+        ({"name": "name of application"}, True, {"name": "name of application"}, {}),
+        ({}, False, {}, {"name": ["This field is required."]}),
+        ({"name": ""}, False, {}, {"name": ["This field is required."]}),
+    ),
+)
+def test_application_name_form(data, is_valid, cleaned_data, errors):
+    form = ApplicationNameForm(data=data)
+    assert form.is_valid() == is_valid
+    assert form.errors == errors
+    assert form.cleaned_data == cleaned_data
+
+
+@pytest.mark.parametrize(
+    "data, is_valid, cleaned_data, errors",
+    (
+        (
+            {"have_you_been_informed": "yes", "reference_number_on_information_form": "CRE/2020/1234567"},
+            True,
+            {"have_you_been_informed": "yes", "reference_number_on_information_form": "CRE/2020/1234567"},
+            {},
+        ),
+        (
+            {"have_you_been_informed": "no", "reference_number_on_information_form": "CRE/2020/1234567"},
+            True,
+            {"have_you_been_informed": "no", "reference_number_on_information_form": ""},
+            {},
+        ),
+        (
+            {"have_you_been_informed": "no"},
+            True,
+            {"have_you_been_informed": "no", "reference_number_on_information_form": ""},
+            {},
+        ),
+        (
+            {"have_you_been_informed": "yes"},
+            True,
+            {"have_you_been_informed": "yes", "reference_number_on_information_form": ""},
+            {},
+        ),
+        (
+            {},
+            False,
+            {"reference_number_on_information_form": ""},
+            {"have_you_been_informed": ["This field is required."]},
+        ),
+    ),
+)
+def test_told_by_an_official_form_reference_number_removed_if_not_informed(data, is_valid, cleaned_data, errors):
+    form = ToldByAnOfficialForm(data=data)
+    assert form.is_valid() == is_valid
+    assert form.errors == errors
+    assert form.cleaned_data == cleaned_data

--- a/unit_tests/exporter/applications/views/test_apply_for_a_licence.py
+++ b/unit_tests/exporter/applications/views/test_apply_for_a_licence.py
@@ -1,17 +1,151 @@
 import pytest
+import uuid
+
+from http import HTTPStatus
 
 from django.urls import reverse
 
+from exporter.applications.constants import ExportLicenceSteps
+from exporter.applications.forms.common import (
+    ApplicationNameForm,
+    LicenceTypeForm,
+    ToldByAnOfficialForm,
+)
+
 
 @pytest.fixture()
-def apply_for_a_licence_url():
+def apply_for_a_licence_start_url():
     return reverse("apply_for_a_licence:start")
+
+
+@pytest.fixture()
+def apply_for_an_export_licence_url():
+    return reverse("applications:apply")
+
+
+@pytest.fixture()
+def post_to_step(post_to_step_factory, apply_for_an_export_licence_url):
+    return post_to_step_factory(apply_for_an_export_licence_url)
+
+
+@pytest.fixture()
+def application_id():
+    return str(uuid.uuid4())
+
+
+@pytest.fixture()
+def mock_post_applications(requests_mock, api_url, application_id):
+    return requests_mock.post(
+        api_url("/applications/"),
+        json={"id": application_id},
+        status_code=HTTPStatus.CREATED,
+    )
+
+
+@pytest.fixture()
+def mock_post_applications_error(requests_mock, api_url, application_id):
+    return requests_mock.post(
+        api_url("/applications/"),
+        json={"id": application_id},
+        status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+    )
 
 
 def test_POST_apply_for_a_licence_redirects(
     authorized_client,
-    apply_for_a_licence_url,
+    apply_for_a_licence_start_url,
 ):
-    response = authorized_client.post(apply_for_a_licence_url, data={"licence_type": "export_licence"})
+    response = authorized_client.post(apply_for_a_licence_start_url, data={"licence_type": "export_licence"})
     assert response.status_code == 302
-    assert response.url == reverse("apply_for_a_licence:export_licence_questions")
+    assert response.url == reverse("applications:apply")
+
+
+def test_create_application_success(
+    authorized_client,
+    apply_for_an_export_licence_url,
+    post_to_step,
+    mock_post_applications,
+    application_id,
+):
+    response = authorized_client.get(apply_for_an_export_licence_url)
+    assert response.status_code == 200
+    assert isinstance(response.context["form"], LicenceTypeForm)
+
+    response = post_to_step(
+        ExportLicenceSteps.LICENCE_TYPE,
+        {
+            "application_type": "siel",
+        },
+    )
+    assert response.status_code == 200
+    assert isinstance(response.context["form"], ApplicationNameForm)
+
+    response = post_to_step(
+        ExportLicenceSteps.APPLICATION_NAME,
+        {
+            "name": "Application Name",
+        },
+    )
+    assert response.status_code == 200
+    assert isinstance(response.context["form"], ToldByAnOfficialForm)
+
+    response = post_to_step(
+        ExportLicenceSteps.TOLD_BY_AN_OFFICIAL,
+        {
+            "have_you_been_informed": "yes",
+            "reference_number_on_information_form": "CRE/2020/1234567",
+        },
+    )
+    assert response.status_code == 302
+    assert response.url == reverse("applications:task_list", kwargs={"pk": application_id})
+    assert mock_post_applications.last_request.json() == {
+        "application_type": "siel",
+        "export_type": "permanent",
+        "have_you_been_informed": "yes",
+        "name": "Application Name",
+        "reference_number_on_information_form": "CRE/2020/1234567",
+    }
+
+
+def test_create_application_failure(
+    authorized_client,
+    apply_for_an_export_licence_url,
+    post_to_step,
+    mock_post_applications,
+    application_id,
+    mock_post_applications_error,
+    beautiful_soup,
+):
+    response = authorized_client.get(apply_for_an_export_licence_url)
+    assert response.status_code == 200
+    assert isinstance(response.context["form"], LicenceTypeForm)
+
+    response = post_to_step(
+        ExportLicenceSteps.LICENCE_TYPE,
+        {
+            "application_type": "siel",
+        },
+    )
+    assert response.status_code == 200
+    assert isinstance(response.context["form"], ApplicationNameForm)
+
+    response = post_to_step(
+        ExportLicenceSteps.APPLICATION_NAME,
+        {
+            "name": "Application Name",
+        },
+    )
+    assert response.status_code == 200
+    assert isinstance(response.context["form"], ToldByAnOfficialForm)
+
+    response = post_to_step(
+        ExportLicenceSteps.TOLD_BY_AN_OFFICIAL,
+        {
+            "have_you_been_informed": "yes",
+            "reference_number_on_information_form": "CRE/2020/1234567",
+        },
+    )
+    assert response.status_code == 200
+    soup = beautiful_soup(response.content)
+    assert "Unexpected error creating application" in soup.text
+    assert not mock_post_applications.called

--- a/unit_tests/exporter/apply_for_a_licence/test_urls.py
+++ b/unit_tests/exporter/apply_for_a_licence/test_urls.py
@@ -17,7 +17,6 @@ def test_url_respects_siel_only_feature_flag_off(settings):
 
     # then SIEL and start url are found
     reverse("apply_for_a_licence:start")
-    reverse("apply_for_a_licence:export_licence_questions")
 
     # but non SIEL urls are not found
     with pytest.raises(NoReverseMatch):
@@ -35,7 +34,6 @@ def test_url_respects_siel_only_feature_flag_on(settings):
 
     # then SIEL and start url are found
     reverse("apply_for_a_licence:start")
-    reverse("apply_for_a_licence:export_licence_questions")
 
     # and non SIEL urls are found
     reverse("apply_for_a_licence:transhipment_questions")


### PR DESCRIPTION
### Aim

This moves out the logic for the SIEL application flow and puts it into the relevant SIEL application Django app.

This also switches it over to a Django form wizard from lite_forms.

[LTD-5996](https://uktrade.atlassian.net/browse/LTD-5996)


[LTD-5996]: https://uktrade.atlassian.net/browse/LTD-5996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ