### PR TITLE
[LTD-5991] Add new F680 summary tab and display related models in tables

### DIFF
--- a/caseworker/assets/styles/styles.scss
+++ b/caseworker/assets/styles/styles.scss
@@ -13,6 +13,10 @@ $govuk-brand-colour: #31363f !default;
   @return url("../../../node_modules/govuk-frontend/govuk/assets/fonts/" + $filename);
 }
 
+h1, h2, h3 {
+    scroll-margin-top: 200px;
+}
+
 $govuk-image-url-function: "get_govuk_image_asset_url";
 $govuk-font-url-function: "get_govuk_font_asset_url";
 

--- a/caseworker/cases/helpers/tests/test_case.py
+++ b/caseworker/cases/helpers/tests/test_case.py
@@ -1,25 +1,31 @@
 import pytest
 from uuid import uuid4
 
+from django.urls import reverse
+
 from ..case import get_case_detail_url
 
 
 @pytest.mark.parametrize(
-    "case_type, expected",
+    "case_type, expected_url_name, expected_extra_kwargs",
     (
         (
             "f680_clearance",
-            "f680",
+            "cases:f680:details",
+            {},
         ),
         (
             "standard",
-            "details",
+            "cases:case",
+            {"tab": "details"},
         ),
     ),
 )
-def test_get_case_detail_url(case_type, expected):
+def test_get_case_detail_url(case_type, expected_url_name, expected_extra_kwargs):
     case_id = uuid4()
     queue_id = "00000000-0000-0000-0000-000000000001"
     result = get_case_detail_url(case_id, case_type, queue_id)
 
-    assert result == f"/queues/{queue_id}/cases/{case_id}/{expected}/"
+    expected_url = reverse(expected_url_name, kwargs={"queue_pk": queue_id, "pk": case_id, **expected_extra_kwargs})
+
+    assert result == expected_url

--- a/caseworker/f680/templates/f680/case/base.html
+++ b/caseworker/f680/templates/f680/case/base.html
@@ -4,8 +4,11 @@
 <div id="tab-bar" class="app-case-tab-bar">
 	<div class="govuk-width-container lite-tabs__container">
         <div class="lite-tabs f680-tabs">
-            <a id="details" href="{% url 'cases:f680:details' queue_pk case.id %}" class="lite-tabs__tab {% if current_tab == "details" %}lite-tabs__tab--selected{% endif %}">
-                Details
+            <a id="summary" href="{% url 'cases:f680:summary' queue_pk case.id %}" class="lite-tabs__tab {% if current_tab == "application-summary" %}lite-tabs__tab--selected{% endif %}">
+                Summary
+            </a>
+            <a id="application-details" href="{% url 'cases:f680:details' queue_pk case.id %}" class="lite-tabs__tab {% if current_tab == "application-details" %}lite-tabs__tab--selected{% endif %}">
+                Application Details
             </a>
             <a id="recommendations" href="{% url 'cases:f680:recommendation' queue_pk case.id %}" class="lite-tabs__tab {% if current_tab == "recommendations" %}lite-tabs__tab--selected{% endif %}">
                 Recommendations

--- a/caseworker/f680/templates/f680/case/detail.html
+++ b/caseworker/f680/templates/f680/case/detail.html
@@ -4,14 +4,16 @@
 
 <section class="govuk-!-margin-top-8">
     <h1 class="govuk-visually-hidden">Case Summary</h1>
-    {% include "f680/case/summary.html" %}
+    {% include "f680/includes/summary.html" %}
 </section>
 
 {% include "f680/includes/move_case_forward.html" with request=request case=case queue=queue %}
 
-{% for section_key, section in case.data.application.sections.items %}
+{% for section_key, section in application_sections.items %}
     <div class="application-section">
-    {% if section.type == "single" %}
+    {% if section_key == "user_information" %}
+        {% include "f680/includes/application_section_user_information.html" with section=section %}
+    {% elif section.type == "single" %}
         {% include "f680/includes/application_section_single.html" with section=section section_key=section_key %}
     {% else %}
         {% include "f680/includes/application_section_multiple.html" with section=section section_key=section_key %}

--- a/caseworker/f680/templates/f680/case/summary.html
+++ b/caseworker/f680/templates/f680/case/summary.html
@@ -1,1 +1,105 @@
-{% extends "case/base-case-summary.html" %}
+{% extends 'f680/case/base.html' %}
+
+{% block details %}
+
+<section class="govuk-!-margin-top-8">
+    <h1 class="govuk-visually-hidden">Case Summary</h1>
+    {% include "f680/includes/summary.html" %}
+</section>
+
+{% include "f680/includes/move_case_forward.html" with request=request case=case queue=queue %}
+
+<h2 class="govuk-heading-m">Product</h2>
+<table class="govuk-table">
+	<thead class="govuk-table__head">
+		<tr class="govuk-table__row">
+
+			<th scope="col" class="govuk-table__header">Name</th>
+			<th scope="col" class="govuk-table__header">Description</th>
+			<th scope="col" class="govuk-table__header">Security Grading</th>
+			<th scope="col" class="govuk-table__header">Security Grading Other</th>
+			<th scope="col" class="govuk-table__header">Application Details</th>
+		</tr>
+	</thead>
+	<tbody class="govuk-table__body">
+		<tr class="govuk-table__row">
+			<td class="govuk-table__cell govuk-table__cell--max-width-400 ">
+                {{case.data.product.name}}
+			</td>
+			<td class="govuk-table__cell govuk-table__cell--max-width-400 ">
+                {{case.data.product.description|linebreaksbr}}
+			</td>
+			<td class="govuk-table__cell govuk-table__cell--max-width-400 ">
+                {{case.data.product.security_grading.value}}
+			</td>
+			<td class="govuk-table__cell govuk-table__cell--max-width-400 ">
+                {% if case.product.security_grading_other %}
+                    {{case.product.security_grading_other}}
+                {% else %}
+                    -
+                {% endif %}
+			</td>
+			<td class="govuk-table__cell govuk-table__cell--max-width-400 ">
+                <a href="{% url 'cases:f680:details' queue_pk case.id %}#product_information" class="govuk-link govuk-link--no-visited-state">View full details</a>
+			</td>
+        </tr>
+	</tbody>
+</table>
+
+<h2 class="govuk-heading-m">Security Release Requests</h2>
+<table class="govuk-table">
+	<thead class="govuk-table__head">
+		<tr class="govuk-table__row">
+			<th scope="col" class="govuk-table__header">Security Grading</th>
+			<th scope="col" class="govuk-table__header">Recipient Name</th>
+			<th scope="col" class="govuk-table__header">Recipient Address</th>
+			<th scope="col" class="govuk-table__header">Recipient Country</th>
+			<th scope="col" class="govuk-table__header">Recipient Type</th>
+			<th scope="col" class="govuk-table__header">Security Grading Other</th>
+			<th scope="col" class="govuk-table__header">Approval Types</th>
+			<th scope="col" class="govuk-table__header">Intended use</th>
+			<th scope="col" class="govuk-table__header">Application Details</th>
+		</tr>
+	</thead>
+	<tbody class="govuk-table__body">
+        {% for release_request in case.data.security_release_requests %}
+		<tr class="govuk-table__row">
+			<td class="govuk-table__cell govuk-table__cell--max-width-400 ">
+                {{release_request.security_grading.value}}
+			</td>
+			<td class="govuk-table__cell govuk-table__cell--max-width-400 ">
+                {{release_request.recipient.name}}
+			</td>
+			<td class="govuk-table__cell govuk-table__cell--max-width-400">
+                {{release_request.recipient.address|linebreaksbr}}
+			</td>
+			<td class="govuk-table__cell govuk-table__cell--max-width-400 ">
+                {{release_request.recipient.country.name}}
+			</td>
+			<td class="govuk-table__cell govuk-table__cell--max-width-400 ">
+                {{release_request.recipient.type.value}}
+			</td>
+			<td class="govuk-table__cell govuk-table__cell--max-width-400 ">
+                {% if release_request.security_grading_other %}
+                    {{release_request.security_grading_other}}
+                {% else %}
+                    -
+                {% endif %}
+			</td>
+			<td class="govuk-table__cell govuk-table__cell--max-width-400 ">
+                {% for approval_type in release_request.approval_types %}
+                    {{approval_type|sentence_case}}<br/>
+                {% endfor %}
+			</td>
+			<td class="govuk-table__cell govuk-table__cell--max-width-800 ">
+                {{release_request.intended_use|linebreaksbr}}
+			</td>
+			<td class="govuk-table__cell govuk-table__cell--max-width-400 ">
+                <a href="{% url 'cases:f680:details' queue_pk case.id %}#user-information-{{release_request.id}}" class="govuk-link govuk-link--no-visited-state">View full details</a>
+			</td>
+        </tr>
+        {% endfor %}
+	</tbody>
+</table>
+
+{% endblock %}

--- a/caseworker/f680/templates/f680/case/summary.html
+++ b/caseworker/f680/templates/f680/case/summary.html
@@ -10,7 +10,8 @@
 {% include "f680/includes/move_case_forward.html" with request=request case=case queue=queue %}
 
 <h2 class="govuk-heading-m">Product</h2>
-<table class="govuk-table">
+
+<table class="govuk-table f680-product-table">
 	<thead class="govuk-table__head">
 		<tr class="govuk-table__row">
 
@@ -47,7 +48,7 @@
 </table>
 
 <h2 class="govuk-heading-m">Security Release Requests</h2>
-<table class="govuk-table">
+<table class="govuk-table f680-security-release-table">
 	<thead class="govuk-table__head">
 		<tr class="govuk-table__row">
 			<th scope="col" class="govuk-table__header">Security Grading</th>

--- a/caseworker/f680/templates/f680/includes/application_section.html
+++ b/caseworker/f680/templates/f680/includes/application_section.html
@@ -1,3 +1,3 @@
-<h2 class="govuk-heading-m">{{section.label}}</h2>
+<h2 class="govuk-heading-m" id="{{section_key}}">{{section.label}}</h2>
 
 {% include "f680/includes/application_section_fields.html" with item=section section_key=section_key %}

--- a/caseworker/f680/templates/f680/includes/application_section_multiple.html
+++ b/caseworker/f680/templates/f680/includes/application_section_multiple.html
@@ -1,4 +1,4 @@
-<h2 class="govuk-heading-m">{{section.label}}</h2>
+<h2 class="govuk-heading-m" id="{{section_key}}">{{section.label}}</h2>
 
 {% for item in section.items %}
     {% include "f680/includes/application_section_fields.html" with item=item section_key=section_key %}

--- a/caseworker/f680/templates/f680/includes/application_section_single.html
+++ b/caseworker/f680/templates/f680/includes/application_section_single.html
@@ -1,3 +1,3 @@
-<h2 class="govuk-heading-m">{{section.label}}</h2>
+<h2 class="govuk-heading-m" id="{{section_key}}">{{section.label}}</h2>
 
 {% include "f680/includes/application_section_fields.html" with item=section section_key=section_key %}

--- a/caseworker/f680/templates/f680/includes/application_section_user_information.html
+++ b/caseworker/f680/templates/f680/includes/application_section_user_information.html
@@ -1,0 +1,10 @@
+<h2 class="govuk-heading-m">{{section.label}}</h2>
+
+{% for item in section.items %}
+    {% for field in item.fields %}
+        {% if field.key == "end_user_name" %}
+        <h3 class="govuk-heading-m" id="user-information-{{item.id}}">{{field.answer}}</h3>
+        {% endif %}
+    {% endfor %}
+    {% include "f680/includes/application_section_fields.html" with item=item section_key=section_key %}
+{% endfor %}

--- a/caseworker/f680/templates/f680/includes/summary.html
+++ b/caseworker/f680/templates/f680/includes/summary.html
@@ -1,0 +1,1 @@
+{% extends "case/base-case-summary.html" %}

--- a/caseworker/f680/urls.py
+++ b/caseworker/f680/urls.py
@@ -9,6 +9,11 @@ app_name = "f680"
 urlpatterns = [
     path(
         "",
+        views.CaseSummaryView.as_view(),
+        name="summary",
+    ),
+    path(
+        "details/",
         views.CaseDetailView.as_view(),
         name="details",
     ),

--- a/caseworker/f680/views.py
+++ b/caseworker/f680/views.py
@@ -45,19 +45,36 @@ class F680CaseworkerMixin(CaseworkerMixin):
         context_data["current_tab"] = self.current_tab
         context_data["queue_pk"] = self.queue_id
         context_data["caseworker"] = self.caseworker
+        submitted_by = self.case["data"]["submitted_by"]
+        if submitted_by and "first_name" in submitted_by:
+            self.case["data"]["submitted_by"] = " ".join([submitted_by["first_name"], submitted_by["last_name"]])
         return context_data
 
 
 class CaseDetailView(LoginRequiredMixin, F680CaseworkerMixin, TemplateView):
     template_name = "f680/case/detail.html"
-    current_tab = "details"
+    current_tab = "application-details"
 
     def get_context_data(self, **kwargs):
         context_data = super().get_context_data(**kwargs)
-        submitted_by = self.case["data"]["submitted_by"]
-        if submitted_by and "first_name" in submitted_by:
-            self.case["data"]["submitted_by"] = " ".join([submitted_by["first_name"], submitted_by["last_name"]])
+        application_section_order = [
+            "general_application_details",
+            "approval_type",
+            "product_information",
+            "user_information",
+            "supporting_documents",
+            "notes_for_case_officers",
+        ]
+        application_sections = {
+            key: self.case["data"]["application"]["sections"].get(key, None) for key in application_section_order
+        }
+        context_data["application_sections"] = application_sections
         return context_data
+
+
+class CaseSummaryView(LoginRequiredMixin, F680CaseworkerMixin, TemplateView):
+    template_name = "f680/case/summary.html"
+    current_tab = "application-summary"
 
 
 class MoveCaseForward(LoginRequiredMixin, View):

--- a/unit_tests/caseworker/cases/views/test_case_assignments.py
+++ b/unit_tests/caseworker/cases/views/test_case_assignments.py
@@ -101,9 +101,8 @@ def test_f680_case_assignments_POST_remove_user_success(
     url = reverse("cases:remove-case-assignment", kwargs={"queue_pk": data_queue["id"], "pk": case["case"]["id"]})
     response = authorized_client.post(url, data={"assignment_id": str(data_f680_assignment["id"])}, follow=True)
     assert response.status_code == 200
-    assert (
-        response.redirect_chain[-1][0]
-        == f"/queues/{data_queue['id']}/cases/{data_submitted_f680_case['case']['id']}/f680/"
+    assert response.redirect_chain[-1][0] == reverse(
+        "cases:f680:details", kwargs={"queue_pk": data_queue["id"], "pk": data_submitted_f680_case["case"]["id"]}
     )
     messages = [str(msg) for msg in response.context["messages"]]
     expected_message = "some user was successfully removed as case adviser"
@@ -345,7 +344,7 @@ def test_case_assign_me(
     assert response.status_code == 200
     assert (
         response.wsgi_request.path
-        == "/queues/00000000-0000-0000-0000-000000000001/cases/8fb76bed-fd45-4293-95b8-eda9468aa254/"
+        == "/queues/00000000-0000-0000-0000-000000000001/cases/8fb76bed-fd45-4293-95b8-eda9468aa254/"  # /PS-IGNORE
     )
 
     html = BeautifulSoup(response.content, "html.parser")
@@ -377,9 +376,9 @@ def test_f680_case_assign_me(
     response = authorized_client.post(url, data=data, follow=True)
 
     assert response.status_code == 200
-    assert (
-        response.wsgi_request.path
-        == "/queues/00000000-0000-0000-0000-000000000001/cases/67271217-7e55-4345-9db4-31de1bfe4067/f680/"
+    assert response.wsgi_request.path == reverse(
+        "cases:f680:details",
+        kwargs={"queue_pk": "00000000-0000-0000-0000-000000000001", "pk": data_submitted_f680_case["case"]["id"]},
     )
 
     html = BeautifulSoup(response.content, "html.parser")

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -1218,8 +1218,572 @@ def data_standard_case_with_all_trigger_list_products_assessed(data_standard_cas
 
 
 @pytest.fixture
-def data_submitted_f680_case():
+def data_australia_release_id():
+    return "2ad8273e-a15d-4bb3-b7ec-af78b5574615"
+
+
+@pytest.fixture
+def data_france_release_id():
+    return "695c65e5-4c80-4d0a-aef5-db94908b0417"
+
+
+@pytest.fixture
+def data_uae_release_id():
+    return "ba8c4b61-51e3-4be3-9208-f7eff2923c91"
+
+
+# TODO: There is overlap here between a fixture in lite-api, however we are currently
+#   missing a mechanism to share fixtures between the two
+@pytest.fixture
+def data_application_json(data_australia_release_id, data_france_release_id, data_uae_release_id):
+    return {
+        "sections": {
+            "approval_type": {
+                "type": "single",
+                "label": "Approval type",
+                "fields": [
+                    {
+                        "key": "approval_choices",
+                        "answer": ["Demonstration overseas", "Training"],
+                        "datatype": "list",
+                        "question": "Select the types of approvals you need",
+                        "raw_answer": ["demonstration_overseas", "training"],
+                    },
+                    {
+                        "key": "demonstration_in_uk",
+                        "answer": "",
+                        "datatype": "string",
+                        "question": "Explain what you are demonstrating and why",
+                        "raw_answer": "",
+                    },
+                    {
+                        "key": "demonstration_overseas",
+                        "answer": "",
+                        "datatype": "string",
+                        "question": "Explain what you are demonstrating and why",
+                        "raw_answer": "",
+                    },
+                    {
+                        "key": "approval_details_text",
+                        "answer": "csda",
+                        "datatype": "string",
+                        "question": "Provide details about what you're seeking approval to do",
+                        "raw_answer": "csda",
+                    },
+                ],
+            },
+            "user_information": {
+                "type": "multiple",
+                "items": [
+                    {
+                        "id": data_france_release_id,
+                        "fields": [
+                            {
+                                "key": "entity_type",
+                                "answer": "Ultimate end-user",
+                                "datatype": "string",
+                                "question": "Select type of entity",
+                                "raw_answer": "ultimate-end-user",
+                            },
+                            {
+                                "key": "end_user_name",
+                                "answer": "france name",
+                                "datatype": "string",
+                                "question": "End-user name",
+                                "raw_answer": "france name",
+                            },
+                            {
+                                "key": "address",
+                                "answer": "france address",
+                                "datatype": "string",
+                                "question": "Address",
+                                "raw_answer": "france address",
+                            },
+                            {
+                                "key": "country",
+                                "answer": "France",
+                                "datatype": "string",
+                                "question": "Country",
+                                "raw_answer": "FR",
+                            },
+                            {
+                                "key": "prefix",
+                                "answer": "",
+                                "datatype": "string",
+                                "question": "Enter a prefix (optional)",
+                                "raw_answer": "",
+                            },
+                            {
+                                "key": "security_classification",
+                                "answer": "Official",
+                                "datatype": "string",
+                                "question": "Select security classification",
+                                "raw_answer": "official",
+                            },
+                            {
+                                "key": "other_security_classification",
+                                "answer": "",
+                                "datatype": "string",
+                                "question": "Enter the security classification",
+                                "raw_answer": "",
+                            },
+                            {
+                                "key": "suffix",
+                                "answer": "",
+                                "datatype": "string",
+                                "question": "Enter a suffix (optional)",
+                                "raw_answer": "",
+                            },
+                            {
+                                "key": "issuing_authority_name_address",
+                                "answer": "cdsacsad",
+                                "datatype": "string",
+                                "question": "Name and address of the issuing authority",
+                                "raw_answer": "cdsacsad",
+                            },
+                            {
+                                "key": "reference",
+                                "answer": "ref",
+                                "datatype": "string",
+                                "question": "Reference",
+                                "raw_answer": "ref",
+                            },
+                            {
+                                "key": "date_of_issue",
+                                "answer": "2024-01-01",
+                                "datatype": "date",
+                                "question": "Date of issue",
+                                "raw_answer": "2024-01-01",
+                            },
+                            {
+                                "key": "end_user_intended_end_use",
+                                "answer": "france intended use",
+                                "datatype": "string",
+                                "question": "How does the end-user intend to use this product",
+                                "raw_answer": "france intended use",
+                            },
+                            {
+                                "key": "assemble_manufacture",
+                                "answer": ["No"],
+                                "datatype": "list",
+                                "question": "Does this end-user need to assemble or manufacture any of the products?",
+                                "raw_answer": ["no"],
+                            },
+                            {
+                                "key": "assemble",
+                                "answer": "",
+                                "datatype": "string",
+                                "question": "Describe what assembly is needed.",
+                                "raw_answer": "",
+                            },
+                            {
+                                "key": "manufacture",
+                                "answer": "",
+                                "datatype": "string",
+                                "question": "Describe what manufacture is needed. Be sure to include the manufacturer's website if they have one.",
+                                "raw_answer": "",
+                            },
+                        ],
+                    },
+                    {
+                        "id": data_uae_release_id,
+                        "fields": [
+                            {
+                                "key": "entity_type",
+                                "answer": "End user",
+                                "datatype": "string",
+                                "question": "Select type of entity",
+                                "raw_answer": "end-user",
+                            },
+                            {
+                                "key": "end_user_name",
+                                "answer": "uae name",
+                                "datatype": "string",
+                                "question": "End-user name",
+                                "raw_answer": "uae name",
+                            },
+                            {
+                                "key": "address",
+                                "answer": "uae address",
+                                "datatype": "string",
+                                "question": "Address",
+                                "raw_answer": "uae address",
+                            },
+                            {
+                                "key": "country",
+                                "answer": "United Arab Emirates",
+                                "datatype": "string",
+                                "question": "Country",
+                                "raw_answer": "AE",
+                            },
+                            {
+                                "key": "prefix",
+                                "answer": "",
+                                "datatype": "string",
+                                "question": "Enter a prefix (optional)",
+                                "raw_answer": "",
+                            },
+                            {
+                                "key": "security_classification",
+                                "answer": "Top-Secret",
+                                "datatype": "string",
+                                "question": "Select security classification",
+                                "raw_answer": "top-secret",
+                            },
+                            {
+                                "key": "other_security_classification",
+                                "answer": "",
+                                "datatype": "string",
+                                "question": "Enter the security classification",
+                                "raw_answer": "",
+                            },
+                            {
+                                "key": "suffix",
+                                "answer": "",
+                                "datatype": "string",
+                                "question": "Enter a suffix (optional)",
+                                "raw_answer": "",
+                            },
+                            {
+                                "key": "issuing_authority_name_address",
+                                "answer": "casdcdsa",
+                                "datatype": "string",
+                                "question": "Name and address of the issuing authority",
+                                "raw_answer": "casdcdsa",
+                            },
+                            {
+                                "key": "reference",
+                                "answer": "csd",
+                                "datatype": "string",
+                                "question": "Reference",
+                                "raw_answer": "csd",
+                            },
+                            {
+                                "key": "date_of_issue",
+                                "answer": "2024-01-01",
+                                "datatype": "date",
+                                "question": "Date of issue",
+                                "raw_answer": "2024-01-01",
+                            },
+                            {
+                                "key": "end_user_intended_end_use",
+                                "answer": "uae intended use",
+                                "datatype": "string",
+                                "question": "How does the end-user intend to use this product",
+                                "raw_answer": "uae intended use",
+                            },
+                            {
+                                "key": "assemble_manufacture",
+                                "answer": ["No"],
+                                "datatype": "list",
+                                "question": "Does this end-user need to assemble or manufacture any of the products?",
+                                "raw_answer": ["no"],
+                            },
+                            {
+                                "key": "assemble",
+                                "answer": "",
+                                "datatype": "string",
+                                "question": "Describe what assembly is needed.",
+                                "raw_answer": "",
+                            },
+                            {
+                                "key": "manufacture",
+                                "answer": "",
+                                "datatype": "string",
+                                "question": "Describe what manufacture is needed. Be sure to include the manufacturer's website if they have one.",
+                                "raw_answer": "",
+                            },
+                        ],
+                    },
+                    {
+                        "id": data_australia_release_id,
+                        "fields": [
+                            {
+                                "key": "entity_type",
+                                "answer": "Third party",
+                                "datatype": "string",
+                                "question": "Select type of entity",
+                                "raw_answer": "third-party",
+                            },
+                            {
+                                "key": "third_party_role",
+                                "answer": "Consultant",
+                                "datatype": "string",
+                                "question": "Select the role of the third party",
+                                "raw_answer": "consultant",
+                            },
+                            {
+                                "key": "end_user_name",
+                                "answer": "australia name",
+                                "datatype": "string",
+                                "question": "End-user name",
+                                "raw_answer": "australia name",
+                            },
+                            {
+                                "key": "address",
+                                "answer": "australia address",
+                                "datatype": "string",
+                                "question": "Address",
+                                "raw_answer": "australia address",
+                            },
+                            {
+                                "key": "country",
+                                "answer": "Australia",
+                                "datatype": "string",
+                                "question": "Country",
+                                "raw_answer": "AU",
+                            },
+                            {
+                                "key": "prefix",
+                                "answer": "",
+                                "datatype": "string",
+                                "question": "Enter a prefix (optional)",
+                                "raw_answer": "",
+                            },
+                            {
+                                "key": "security_classification",
+                                "answer": "Secret",
+                                "datatype": "string",
+                                "question": "Select security classification",
+                                "raw_answer": "secret",
+                            },
+                            {
+                                "key": "other_security_classification",
+                                "answer": "",
+                                "datatype": "string",
+                                "question": "Enter the security classification",
+                                "raw_answer": "",
+                            },
+                            {
+                                "key": "suffix",
+                                "answer": "",
+                                "datatype": "string",
+                                "question": "Enter a suffix (optional)",
+                                "raw_answer": "",
+                            },
+                            {
+                                "key": "issuing_authority_name_address",
+                                "answer": "csdacdsa",
+                                "datatype": "string",
+                                "question": "Name and address of the issuing authority",
+                                "raw_answer": "csdacdsa",
+                            },
+                            {
+                                "key": "reference",
+                                "answer": "casdcdsa",
+                                "datatype": "string",
+                                "question": "Reference",
+                                "raw_answer": "casdcdsa",
+                            },
+                            {
+                                "key": "date_of_issue",
+                                "answer": "2024-01-01",
+                                "datatype": "date",
+                                "question": "Date of issue",
+                                "raw_answer": "2024-01-01",
+                            },
+                            {
+                                "key": "end_user_intended_end_use",
+                                "answer": "australia intended use",
+                                "datatype": "string",
+                                "question": "How does the end-user intend to use this product",
+                                "raw_answer": "australia intended use",
+                            },
+                            {
+                                "key": "assemble_manufacture",
+                                "answer": ["No"],
+                                "datatype": "list",
+                                "question": "Does this end-user need to assemble or manufacture any of the products?",
+                                "raw_answer": ["no"],
+                            },
+                            {
+                                "key": "assemble",
+                                "answer": "",
+                                "datatype": "string",
+                                "question": "Describe what assembly is needed.",
+                                "raw_answer": "",
+                            },
+                            {
+                                "key": "manufacture",
+                                "answer": "",
+                                "datatype": "string",
+                                "question": "Describe what manufacture is needed. Be sure to include the manufacturer's website if they have one.",
+                                "raw_answer": "",
+                            },
+                        ],
+                    },
+                ],
+                "label": "User Information",
+            },
+            "product_information": {
+                "type": "single",
+                "label": "Product information",
+                "fields": [
+                    {
+                        "key": "product_name",
+                        "answer": "some product name",
+                        "datatype": "string",
+                        "question": "Give the item a descriptive name",
+                        "raw_answer": "some product name",
+                    },
+                    {
+                        "key": "product_description",
+                        "answer": "some product description",
+                        "datatype": "string",
+                        "question": "Describe the item",
+                        "raw_answer": "some product description",
+                    },
+                    {
+                        "key": "has_security_classification",
+                        "answer": "Yes",
+                        "datatype": "boolean",
+                        "question": "Has the product been given a security classifcation by a UK MOD authority?",
+                        "raw_answer": True,
+                    },
+                    {
+                        "key": "prefix",
+                        "answer": "",
+                        "datatype": "string",
+                        "question": "Enter a prefix (optional)",
+                        "raw_answer": "",
+                    },
+                    {
+                        "key": "security_classification",
+                        "answer": "Official",
+                        "datatype": "string",
+                        "question": "Select security classification",
+                        "raw_answer": "official",
+                    },
+                    {
+                        "key": "other_security_classification",
+                        "answer": "",
+                        "datatype": "string",
+                        "question": "Enter the security classification",
+                        "raw_answer": "",
+                    },
+                    {
+                        "key": "suffix",
+                        "answer": "",
+                        "datatype": "string",
+                        "question": "Enter a suffix (optional)",
+                        "raw_answer": "",
+                    },
+                    {
+                        "key": "issuing_authority_name_address",
+                        "answer": "csadcas",
+                        "datatype": "string",
+                        "question": "Name and address of the issuing authority",
+                        "raw_answer": "csadcas",
+                    },
+                    {
+                        "key": "reference",
+                        "answer": "fdfscsa",
+                        "datatype": "string",
+                        "question": "Reference",
+                        "raw_answer": "fdfscsa",
+                    },
+                    {
+                        "key": "date_of_issue",
+                        "answer": "0001-01-01",
+                        "datatype": "date",
+                        "question": "Date of issue",
+                        "raw_answer": "0001-01-01",
+                    },
+                    {
+                        "key": "is_foreign_tech_or_information_shared",
+                        "answer": "No",
+                        "datatype": "boolean",
+                        "question": "Will any foreign technology or information be shared with the item?",
+                        "raw_answer": False,
+                    },
+                    {
+                        "key": "is_including_cryptography_or_security_features",
+                        "answer": "No",
+                        "datatype": "boolean",
+                        "question": "Does the item include cryptography or other information security features?",
+                        "raw_answer": False,
+                    },
+                    {
+                        "key": "cryptography_or_security_feature_info",
+                        "answer": "",
+                        "datatype": "string",
+                        "question": "Provide full details",
+                        "raw_answer": "",
+                    },
+                    {
+                        "key": "is_item_rated_under_mctr",
+                        "answer": "Yes, the product is MTCR Category 2",
+                        "datatype": "string",
+                        "question": "Do you believe the item is rated under the Missile Technology Control Regime (MTCR)",
+                        "raw_answer": "mtcr_2",
+                    },
+                    {
+                        "key": "is_item_manpad",
+                        "answer": "Don't know",
+                        "datatype": "string",
+                        "question": "Do you believe the item is a man-portable air defence system (MANPAD)?",
+                        "raw_answer": "dont_know",
+                    },
+                    {
+                        "key": "is_mod_electronic_data_shared",
+                        "answer": "No",
+                        "datatype": "string",
+                        "question": "Will any electronic warfare data owned by the Ministry of Defence (MOD) be shared with the item?",
+                        "raw_answer": "no",
+                    },
+                    {
+                        "key": "funding_source",
+                        "answer": "MOD",
+                        "datatype": "string",
+                        "question": "Who is funding the item?",
+                        "raw_answer": "mod",
+                    },
+                    {
+                        "key": "is_used_by_uk_armed_forces",
+                        "answer": "No",
+                        "datatype": "boolean",
+                        "question": "Will the item be used by the UK Armed Forces?",
+                        "raw_answer": False,
+                    },
+                    {
+                        "key": "used_by_uk_armed_forces_info",
+                        "answer": "",
+                        "datatype": "string",
+                        "question": "Explain how it will be used",
+                        "raw_answer": "",
+                    },
+                ],
+            },
+            "general_application_details": {
+                "type": "single",
+                "label": "General application details",
+                "fields": [
+                    {
+                        "key": "name",
+                        "answer": "some name",
+                        "datatype": "string",
+                        "question": "Name the application",
+                        "raw_answer": "some name",
+                    },
+                    {
+                        "key": "is_exceptional_circumstances",
+                        "answer": "No",
+                        "datatype": "boolean",
+                        "question": "Do you have exceptional circumstances that mean you need F680 approval in less than 30 days?",
+                        "raw_answer": False,
+                    },
+                ],
+            },
+        }
+    }
+
+
+@pytest.fixture
+def data_submitted_f680_case(
+    data_application_json, data_australia_release_id, data_france_release_id, data_uae_release_id
+):
     submitted_at = timezone.now() - timedelta(days=7)
+    product_id = "67271217-7e55-4345-9db4-31de1bfe4066"
     return {
         "case": {
             "advice": [],
@@ -1236,30 +1800,7 @@ def data_submitted_f680_case():
             "copy_of": None,
             "countersign_advice": [],
             "data": {
-                "application": {
-                    "sections": {
-                        "general_application_details": {
-                            "label": "General application details",
-                            "type": "single",
-                            "fields": [
-                                {
-                                    "key": "name",
-                                    "answer": "some name",
-                                    "datatype": "string",
-                                    "question": "Name the application",
-                                    "raw_answer": "casdc",
-                                },
-                                {
-                                    "key": "is_exceptional_circumstances",
-                                    "answer": "No",
-                                    "datatype": "boolean",
-                                    "question": "Do you have exceptional circumstances that mean you need F680 approval in less than 30 days?",
-                                    "raw_answer": False,
-                                },
-                            ],
-                        },
-                    }
-                },
+                "application": data_application_json,
                 "id": "67271217-7e55-4345-9db4-31de1bfe4067",
                 "organisation": {
                     "id": "1363b104-9669-4c53-8602-8fc3717b07cd",  # /PS-IGNORE
@@ -1271,6 +1812,84 @@ def data_submitted_f680_case():
                 "status": {"id": "00000000-0000-0000-0000-000000000001", "key": "submitted", "value": "Submitted"},
                 "submitted_at": submitted_at.isoformat(),
                 "submitted_by": None,
+                "product": {
+                    "id": product_id,
+                    "name": "some product name",
+                    "description": "some product description",
+                    "security_grading": {"key": "official", "value": "Official"},
+                    "security_grading_other": None,
+                },
+                "security_release_requests": [
+                    {
+                        "id": data_australia_release_id,
+                        "recipient": {
+                            "id": "8d6236bf-1d94-450d-98f9-97e7b428dea6",
+                            "name": "australia name",
+                            "address": "australia address",
+                            "country": {
+                                "id": "AU",
+                                "name": "Australia",
+                                "type": "gov.uk Country",
+                                "is_eu": False,
+                                "report_name": "",
+                            },
+                            "type": {"key": "third-party", "value": "Third party"},
+                            "role": {"key": "consultant", "value": "Consultant"},
+                            "role_other": None,
+                        },
+                        "security_grading": {"key": "secret", "value": "Secret"},
+                        "security_grading_other": "",
+                        "approval_types": ["demonstration_overseas", "training"],
+                        "intended_use": "australia intended use",
+                        "product_id": product_id,
+                    },
+                    {
+                        "id": data_france_release_id,
+                        "recipient": {
+                            "id": "8d6236bf-1d94-450d-98f9-97e7b428dea7",
+                            "name": "france name",
+                            "address": "france address",
+                            "country": {
+                                "id": "FR",
+                                "name": "France",
+                                "type": "gov.uk Country",
+                                "is_eu": True,
+                                "report_name": "",
+                            },
+                            "type": {"key": "ultimate-end-user", "value": "Ultimate end-user"},
+                            "role": None,
+                            "role_other": None,
+                        },
+                        "security_grading": {"key": "official", "value": "Official"},
+                        "security_grading_other": "",
+                        "approval_types": ["demonstration_overseas", "training"],
+                        "intended_use": "france intended use",
+                        "product_id": product_id,
+                    },
+                    {
+                        "id": data_uae_release_id,
+                        "recipient": {
+                            "id": "8d6236bf-1d94-450d-98f9-97e7b428dea8",
+                            "name": "uae name",
+                            "address": "uae address",
+                            "country": {
+                                "id": "AE",
+                                "name": "UAE",
+                                "type": "gov.uk Country",
+                                "is_eu": False,
+                                "report_name": "",
+                            },
+                            "type": {"key": "end-user", "value": "End-user"},
+                            "role": None,
+                            "role_other": None,
+                        },
+                        "security_grading": {"key": "top-secret", "value": "Top-secret"},
+                        "security_grading_other": "",
+                        "approval_types": ["demonstration_overseas", "training"],
+                        "intended_use": "uae intended use",
+                        "product_id": product_id,
+                    },
+                ],
             },
             "flags": [],
             "has_advice": {"final": False, "my_team": False, "my_user": False, "team": False, "user": False},


### PR DESCRIPTION
### Aim

Depends on API PR: https://github.com/uktrade/lite-api/pull/2460

This change displays F680 security release requests and products on a new F680 summary tab on the caseworker application.

[LTD-5991](https://uktrade.atlassian.net/browse/LTD-5991)


[LTD-5991]: https://uktrade.atlassian.net/browse/LTD-5991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ