### PR TITLE
[LTD-5993] Change F680 JSON contract for fields to be dict

### DIFF
--- a/caseworker/f680/templates/f680/includes/application_section_fields.html
+++ b/caseworker/f680/templates/f680/includes/application_section_fields.html
@@ -3,13 +3,15 @@
         <colgroup>
             <col span="1" class="application-questions"/>
         </colgroup>
-        {% for field in item.fields %}
-            {% if field.answer %}
-            <tr class="govuk-table__row">
-                <th scope="row" class="govuk-table__header">{{field.question}}</th>
-                <td class="govuk-table__cell">{% include "f680/includes/answer.html" with field=field %}</td>
-            </tr>
-            {% endif %}
+        {% for field_name in item.fields_sequence %}
+            {% with field=item.fields|get:field_name %}
+                {% if field.answer %}
+                <tr class="govuk-table__row">
+                    <th scope="row" class="govuk-table__header">{{field.question}}</th>
+                    <td class="govuk-table__cell">{% include "f680/includes/answer.html" with field=field %}</td>
+                </tr>
+                {% endif %}
+            {% endwith %}
         {% endfor %}
     </tbody>
 </table>

--- a/core/builtins/custom_tags.py
+++ b/core/builtins/custom_tags.py
@@ -491,11 +491,6 @@ def values(dictionary):
 
 
 @register.filter()
-def dict_get(dictionary, key):
-    return dictionary.get(key)
-
-
-@register.filter()
 def filter_advice_by_level(advice, level):
     return [advice for advice in advice if advice["level"] == level]
 

--- a/core/builtins/custom_tags.py
+++ b/core/builtins/custom_tags.py
@@ -491,6 +491,11 @@ def values(dictionary):
 
 
 @register.filter()
+def dict_get(dictionary, key):
+    return dictionary.get(key)
+
+
+@register.filter()
 def filter_advice_by_level(advice, level):
     return [advice for advice in advice if advice["level"] == level]
 

--- a/exporter/f680/application_sections/additional_information/tests/test_views.py
+++ b/exporter/f680/application_sections/additional_information/tests/test_views.py
@@ -71,15 +71,16 @@ def mock_f680_application_get_existing_data(requests_mock, data_f680_case):
             "notes_for_case_officers": {
                 "type": "single",
                 "label": "Notes for case officers",
-                "fields": [
-                    {
+                "fields": {
+                    "note": {
                         "key": "note",
                         "answer": "Some note text",
                         "datatype": "string",
                         "question": "Add note",
                         "raw_answer": "Some note text",
                     }
-                ],
+                },
+                "fields_sequence": ["note"],
             }
         }
     }
@@ -174,15 +175,16 @@ class TestAdditionalInformationView:
                 "sections": {
                     "notes_for_case_officers": {
                         "label": "Notes for case officers",
-                        "fields": [
-                            {
+                        "fields": {
+                            "note": {
                                 "key": "note",
                                 "answer": "Some information",
                                 "raw_answer": "Some information",
                                 "question": "Add note",
                                 "datatype": "string",
                             }
-                        ],
+                        },
+                        "fields_sequence": ["note"],
                         "type": "single",
                     }
                 },

--- a/exporter/f680/application_sections/approval_details/tests/test_views.py
+++ b/exporter/f680/application_sections/approval_details/tests/test_views.py
@@ -226,37 +226,43 @@ class TestApprovalDetailsView:
                 "sections": {
                     "approval_type": {
                         "label": "Approval type",
-                        "fields": [
-                            {
+                        "fields": {
+                            "approval_choices": {
                                 "key": "approval_choices",
                                 "answer": ["Training", "Supply"],
                                 "raw_answer": ["training", "supply"],
                                 "question": "Select the types of approvals you need",
                                 "datatype": "list",
                             },
-                            {
+                            "demonstration_in_uk": {
                                 "key": "demonstration_in_uk",
                                 "answer": "",
                                 "raw_answer": "",
                                 "question": "Explain what you are demonstrating and why",
                                 "datatype": "string",
                             },
-                            {
+                            "demonstration_overseas": {
                                 "key": "demonstration_overseas",
                                 "answer": "",
                                 "raw_answer": "",
                                 "question": "Explain what you are demonstrating and why",
                                 "datatype": "string",
                             },
-                            {
+                            "approval_details_text": {
                                 "key": "approval_details_text",
                                 "answer": "",
                                 "raw_answer": "",
                                 "question": "Provide details about what you're seeking approval to do",
                                 "datatype": "string",
                             },
-                        ],
+                        },
                         "type": "single",
+                        "fields_sequence": [
+                            "approval_choices",
+                            "demonstration_in_uk",
+                            "demonstration_overseas",
+                            "approval_details_text",
+                        ],
                     }
                 },
             }
@@ -708,7 +714,7 @@ class TestProductInformationViews:
                 "full_name": "a name",
                 "address": "16 Street",
                 "phone_number": "01234785785",
-                "email_address": "test@test.com",
+                "email_address": "test@test.com",  # /PS-IGNORE
             },
         )
         response = post_to_product_step(
@@ -724,219 +730,251 @@ class TestProductInformationViews:
                 "sections": {
                     "product_information": {
                         "label": "Product information",
-                        "fields": [
-                            {
+                        "fields": {
+                            "product_name": {
                                 "key": "product_name",
                                 "answer": "Test Name",
                                 "raw_answer": "Test Name",
                                 "question": "Give the item a descriptive name",
                                 "datatype": "string",
                             },
-                            {
+                            "product_description": {
                                 "key": "product_description",
                                 "answer": "Does a thing",
                                 "raw_answer": "Does a thing",
                                 "question": "Describe the item",
                                 "datatype": "string",
                             },
-                            {
+                            "has_security_classification": {
                                 "key": "has_security_classification",
                                 "answer": "Yes",
                                 "raw_answer": True,
                                 "question": "Has the product been given a security classifcation by a UK MOD authority?",
                                 "datatype": "boolean",
                             },
-                            {
+                            "prefix": {
                                 "key": "prefix",
                                 "answer": "some prefix",
                                 "raw_answer": "some prefix",
                                 "question": "Enter a prefix (optional)",
                                 "datatype": "string",
                             },
-                            {
+                            "security_classification": {
                                 "key": "security_classification",
                                 "answer": "Unclassified",
                                 "raw_answer": "unclassified",
                                 "question": "Select security classification",
                                 "datatype": "string",
                             },
-                            {
+                            "other_security_classification": {
                                 "key": "other_security_classification",
                                 "answer": "",
                                 "raw_answer": "",
                                 "question": "Enter the security classification",
                                 "datatype": "string",
                             },
-                            {
+                            "suffix": {
                                 "key": "suffix",
                                 "answer": "some suffix",
                                 "raw_answer": "some suffix",
                                 "question": "Enter a suffix (optional)",
                                 "datatype": "string",
                             },
-                            {
+                            "issuing_authority_name_address": {
                                 "key": "issuing_authority_name_address",
                                 "answer": "some address",
                                 "raw_answer": "some address",
                                 "question": "Name and address of the issuing authority",
                                 "datatype": "string",
                             },
-                            {
+                            "reference": {
                                 "key": "reference",
                                 "answer": "1234",
                                 "raw_answer": "1234",
                                 "question": "Reference",
                                 "datatype": "string",
                             },
-                            {
+                            "date_of_issue": {
                                 "key": "date_of_issue",
                                 "answer": "2025-01-01",
                                 "raw_answer": "2025-01-01",
                                 "question": "Date of issue",
                                 "datatype": "date",
                             },
-                            {
+                            "is_foreign_tech_or_information_shared": {
                                 "key": "is_foreign_tech_or_information_shared",
                                 "answer": "Yes",
                                 "raw_answer": True,
                                 "question": "Will any foreign technology or information be shared with the item?",
                                 "datatype": "boolean",
                             },
-                            {
+                            "is_controlled_under_itar": {
                                 "key": "is_controlled_under_itar",
                                 "answer": "Yes, it's controlled under  ITAR",
                                 "raw_answer": True,
                                 "question": "Is the technology or information controlled under the US International Traffic in Arms Regulations (ITAR)?",
                                 "datatype": "boolean",
                             },
-                            {
+                            "controlled_info": {
                                 "key": "controlled_info",
                                 "answer": "some info",
                                 "raw_answer": "some info",
                                 "question": "Explain how the technology or information is controlled.Include countries classification levels and reference numbers.  You can upload supporting documents later in your application",
                                 "datatype": "string",
                             },
-                            {
+                            "controlled_information": {
                                 "key": "controlled_information",
                                 "answer": "secret stuff",
                                 "raw_answer": "secret stuff",
                                 "question": "What is the ITAR controlled technology or information?",
                                 "datatype": "string",
                             },
-                            {
+                            "itar_reference_number": {
                                 "key": "itar_reference_number",
                                 "answer": "123456",
                                 "raw_answer": "123456",
                                 "question": "ITAR reference number",
                                 "datatype": "string",
                             },
-                            {
+                            "usml_categories": {
                                 "key": "usml_categories",
                                 "answer": "none",
                                 "raw_answer": "none",
                                 "question": "What are the United States Munitions List (USML) categories listed on your ITAR approval?",
                                 "datatype": "string",
                             },
-                            {
+                            "itar_approval_scope": {
                                 "key": "itar_approval_scope",
                                 "answer": "no scope",
                                 "raw_answer": "no scope",
                                 "question": "Describe the scope of your ITAR approval",
                                 "datatype": "string",
                             },
-                            {
+                            "expected_time_in_possession": {
                                 "key": "expected_time_in_possession",
                                 "answer": "10 years",
                                 "raw_answer": "10 years",
                                 "question": "How long do you expect the technology or information that is controlled under the US ITAR to be in your possession?",
                                 "datatype": "string",
                             },
-                            {
+                            "is_including_cryptography_or_security_features": {
                                 "key": "is_including_cryptography_or_security_features",
                                 "answer": "Yes",
                                 "raw_answer": True,
                                 "question": "Does the item include cryptography or other information security features?",
                                 "datatype": "boolean",
                             },
-                            {
+                            "cryptography_or_security_feature_info": {
                                 "key": "cryptography_or_security_feature_info",
                                 "answer": "some info",
                                 "raw_answer": "some info",
                                 "question": "Provide full details",
                                 "datatype": "string",
                             },
-                            {
+                            "is_item_rated_under_mctr": {
                                 "key": "is_item_rated_under_mctr",
                                 "answer": "Yes, the product is MTCR Category 1",
                                 "raw_answer": "mtcr_1",
                                 "question": "Do you believe the item is rated under the Missile Technology Control Regime (MTCR)",
                                 "datatype": "string",
                             },
-                            {
+                            "is_item_manpad": {
                                 "key": "is_item_manpad",
                                 "answer": "No, the product is not a MANPAD",
                                 "raw_answer": "no",
                                 "question": "Do you believe the item is a man-portable air defence system (MANPAD)?",
                                 "datatype": "string",
                             },
-                            {
+                            "is_mod_electronic_data_shared": {
                                 "key": "is_mod_electronic_data_shared",
                                 "answer": "No",
                                 "raw_answer": "no",
                                 "question": "Will any electronic warfare data owned by the Ministry of Defence (MOD) be shared with the item?",
                                 "datatype": "string",
                             },
-                            {
+                            "funding_source": {
                                 "key": "funding_source",
                                 "answer": "MOD",
                                 "raw_answer": "mod",
                                 "question": "Who is funding the item?",
                                 "datatype": "string",
                             },
-                            {
+                            "full_name": {
                                 "key": "full_name",
                                 "answer": "a name",
                                 "raw_answer": "a name",
                                 "question": "Full name",
                                 "datatype": "string",
                             },
-                            {
+                            "address": {
                                 "key": "address",
                                 "answer": "16 Street",
                                 "raw_answer": "16 Street",
                                 "question": "Address",
                                 "datatype": "string",
                             },
-                            {
+                            "phone_number": {
                                 "key": "phone_number",
                                 "answer": "01234785785",
                                 "raw_answer": "01234785785",
                                 "question": "Phone number",
                                 "datatype": "string",
                             },
-                            {
+                            "email_address": {
                                 "key": "email_address",
-                                "answer": "test@test.com",
-                                "raw_answer": "test@test.com",
+                                "answer": "test@test.com",  # /PS-IGNORE
+                                "raw_answer": "test@test.com",  # /PS-IGNORE
                                 "question": "Email address",
                                 "datatype": "string",
                             },
-                            {
+                            "is_used_by_uk_armed_forces": {
                                 "key": "is_used_by_uk_armed_forces",
                                 "answer": "Yes",
                                 "raw_answer": True,
                                 "question": "Will the item be used by the UK Armed Forces?",
                                 "datatype": "boolean",
                             },
-                            {
+                            "used_by_uk_armed_forces_info": {
                                 "key": "used_by_uk_armed_forces_info",
                                 "answer": "some info",
                                 "raw_answer": "some info",
                                 "question": "Explain how it will be used",
                                 "datatype": "string",
                             },
-                        ],
+                        },
                         "type": "single",
+                        "fields_sequence": [
+                            "product_name",
+                            "product_description",
+                            "has_security_classification",
+                            "prefix",
+                            "security_classification",
+                            "other_security_classification",
+                            "suffix",
+                            "issuing_authority_name_address",
+                            "reference",
+                            "date_of_issue",
+                            "is_foreign_tech_or_information_shared",
+                            "is_controlled_under_itar",
+                            "controlled_info",
+                            "controlled_information",
+                            "itar_reference_number",
+                            "usml_categories",
+                            "itar_approval_scope",
+                            "expected_time_in_possession",
+                            "is_including_cryptography_or_security_features",
+                            "cryptography_or_security_feature_info",
+                            "is_item_rated_under_mctr",
+                            "is_item_manpad",
+                            "is_mod_electronic_data_shared",
+                            "funding_source",
+                            "full_name",
+                            "address",
+                            "phone_number",
+                            "email_address",
+                            "is_used_by_uk_armed_forces",
+                            "used_by_uk_armed_forces_info",
+                        ],
                     }
                 },
             }

--- a/exporter/f680/application_sections/conftest.py
+++ b/exporter/f680/application_sections/conftest.py
@@ -204,7 +204,10 @@ def mock_f680_application_get_existing_data(requests_mock, data_f680_case):
                         "key": "controlled_info",
                         "answer": "It just is",
                         "raw_answer": "It just is",
-                        "question": "Explain how the technology or information is controlled.Include countries classification levels and reference numbers. You can upload supporting documents later in your application",
+                        "question": (
+                            "Explain how the technology or information is controlled."
+                            "Include countries classification levels and reference numbers. You can upload supporting documents later in your application"
+                        ),
                         "datatype": "string",
                     },
                     "controlled_information": {

--- a/exporter/f680/application_sections/conftest.py
+++ b/exporter/f680/application_sections/conftest.py
@@ -62,8 +62,8 @@ def mock_f680_application_get_existing_data(requests_mock, data_f680_case):
             "approval_type": {
                 "type": "single",
                 "label": "Approval type",
-                "fields": [
-                    {
+                "fields": {
+                    "approval_choices": {
                         "key": "approval_choices",
                         "answer": [
                             "Initial discussions or promoting products",
@@ -84,219 +84,250 @@ def mock_f680_application_get_existing_data(requests_mock, data_f680_case):
                             "supply",
                         ],
                     },
-                    {
+                    "demonstration_in_uk": {
                         "key": "demonstration_in_uk",
                         "answer": "some UK demonstration reason",
                         "datatype": "string",
                         "question": "Explain what you are demonstrating and why",
                         "raw_answer": "some UK demonstration reason",
                     },
-                    {
+                    "demonstration_overseas": {
                         "key": "demonstration_overseas",
                         "answer": "some overseas demonstration reason",
                         "datatype": "string",
                         "question": "Explain what you are demonstrating and why",
                         "raw_answer": "some overseas demonstration reason",
                     },
-                    {
+                    "approval_details_text": {
                         "key": "approval_details_text",
                         "answer": "some details",
                         "datatype": "string",
                         "question": "Provide details about what you're seeking approval to do",
                         "raw_answer": "some details",
                     },
+                },
+                "fields_sequence": [
+                    "approval_choices",
+                    "demonstration_in_uk",
+                    "demonstration_overseas",
+                    "approval_details_text",
                 ],
             },
             "product_information": {
                 "label": "Product information",
-                "fields": [
-                    {
+                "fields": {
+                    "product_name": {
                         "key": "product_name",
                         "answer": "Test Info",
                         "raw_answer": "Test Info",
                         "question": "Give the item a descriptive name",
                         "datatype": "string",
                     },
-                    {
+                    "product_description": {
                         "key": "product_description",
                         "answer": "It does things",
                         "raw_answer": "It does things",
                         "question": "Describe the item",
                         "datatype": "string",
                     },
-                    {
+                    "has_security_classification": {
                         "key": "has_security_classification",
                         "answer": "Yes",
                         "raw_answer": True,
                         "question": "What is the maximum security classification given?",
                         "datatype": "boolean",
                     },
-                    {
+                    "prefix": {
                         "key": "prefix",
                         "answer": "some prefix",
                         "raw_answer": "some prefix",
                         "question": "Enter a prefix (optional)",
                         "datatype": "string",
                     },
-                    {
+                    "actions_to_classify": {
                         "key": "actions_to_classify",
                         "answer": "some actions",
                         "raw_answer": "some actions",
                         "question": "Provide details on what action will have to be taken to have the product security classified",
                         "datatype": "string",
                     },
-                    {
+                    "security_classification": {
                         "key": "security_classification",
                         "answer": "unclassified",
                         "raw_answer": "unclassified",
                         "question": "Select security classification",
                         "datatype": "string",
                     },
-                    {
+                    "suffix": {
                         "key": "suffix",
                         "answer": "some suffix",
                         "raw_answer": "some suffix",
                         "question": "Enter a suffix (optional)",
                         "datatype": "string",
                     },
-                    {
+                    "issuing_authority_name_address": {
                         "key": "issuing_authority_name_address",
                         "answer": "Some address",
                         "raw_answer": "Some address",
                         "question": "Name and address of the issuing authority",
                         "datatype": "string",
                     },
-                    {
+                    "reference": {
                         "key": "reference",
                         "answer": "1234",
                         "raw_answer": "1234",
                         "question": "Reference",
                         "datatype": "string",
                     },
-                    {
+                    "date_of_issue": {
                         "key": "date_of_issue",
                         "answer": "2024-01-01",
                         "raw_answer": "2024-01-01",
                         "question": "Date of issue",
                         "datatype": "date",
                     },
-                    {
+                    "is_foreign_tech_or_information_shared": {
                         "key": "is_foreign_tech_or_information_shared",
                         "answer": "Yes",
                         "raw_answer": True,
                         "question": "Will any foreign technology or information be shared with the item?",
                         "datatype": "boolean",
                     },
-                    {
+                    "is_controlled_under_itar": {
                         "key": "is_controlled_under_itar",
                         "answer": "Yes, it's controlled under  ITAR",
                         "raw_answer": True,
                         "question": "Is the technology or information controlled under the US International Traffic in Arms Regulations (ITAR)?",
                         "datatype": "boolean",
                     },
-                    {
+                    "controlled_info": {
                         "key": "controlled_info",
                         "answer": "It just is",
                         "raw_answer": "It just is",
-                        "question": (
-                            "Explain how the technology or information is controlled.Include countries classification levels and "
-                            "reference numbers. You can upload supporting documents later in your application"
-                        ),
+                        "question": "Explain how the technology or information is controlled.Include countries classification levels and reference numbers. You can upload supporting documents later in your application",
                         "datatype": "string",
                     },
-                    {
+                    "controlled_information": {
                         "key": "controlled_information",
                         "answer": "Some info",
                         "raw_answer": "Some info",
                         "question": "What is the ITAR controlled technology or information?",
                         "datatype": "string",
                     },
-                    {
+                    "itar_reference_number": {
                         "key": "itar_reference_number",
                         "answer": "123456",
                         "raw_answer": "123456",
                         "question": "ITAR reference number",
                         "datatype": "string",
                     },
-                    {
+                    "usml_categories": {
                         "key": "usml_categories",
                         "answer": "cat 1",
                         "raw_answer": "cat 1",
                         "question": "What are the United States Munitions List (USML) categories listed on your ITAR approval?",
                         "datatype": "string",
                     },
-                    {
+                    "itar_approval_scope": {
                         "key": "itar_approval_scope",
                         "answer": "no scope",
                         "raw_answer": "no scope",
                         "question": "Describe the scope of your ITAR approval",
                         "datatype": "string",
                     },
-                    {
+                    "expected_time_in_possession": {
                         "key": "expected_time_in_possession",
                         "answer": "10 years",
                         "raw_answer": "10 years",
                         "question": "How long do you expect the technology or information that is controlled under the US ITAR to be in your possession?",
                         "datatype": "string",
                     },
-                    {
+                    "is_including_cryptography_or_security_features": {
                         "key": "is_including_cryptography_or_security_features",
                         "answer": "Yes",
                         "raw_answer": True,
                         "question": "Does the item include cryptography or other information security features?",
                         "datatype": "boolean",
                     },
-                    {
+                    "cryptography_or_security_feature_info": {
                         "key": "cryptography_or_security_feature_info",
                         "answer": "some",
                         "raw_answer": "some",
                         "question": "Provide full details",
                         "datatype": "string",
                     },
-                    {
+                    "is_item_rated_under_mctr": {
                         "key": "is_item_rated_under_mctr",
                         "answer": "Yes, the product is MTCR Category 1",
                         "raw_answer": "mtcr_1",
                         "question": "Do you believe the item is rated under the Missile Technology Control Regime (MTCR)",
                         "datatype": "string",
                     },
-                    {
+                    "is_item_manpad": {
                         "key": "is_item_manpad",
                         "answer": "No, the product is not a MANPAD",
                         "raw_answer": "no",
                         "question": "Do you believe the item is a man-portable air defence system (MANPAD)?",
                         "datatype": "string",
                     },
-                    {
+                    "is_mod_electronic_data_shared": {
                         "key": "is_mod_electronic_data_shared",
                         "answer": "No",
                         "raw_answer": "no",
                         "question": "Will any electronic warfare data owned by the Ministry of Defence (MOD) be shared with the item?",
                         "datatype": "string",
                     },
-                    {
+                    "funding_source": {
                         "key": "funding_source",
                         "answer": "MOD",
                         "raw_answer": "mod",
                         "question": "Who is funding the item?",
                         "datatype": "string",
                     },
-                    {
+                    "is_used_by_uk_armed_forces": {
                         "key": "is_used_by_uk_armed_forces",
                         "answer": "No",
                         "raw_answer": False,
                         "question": "Will the item be used by the UK Armed Forces?",
                         "datatype": "boolean",
                     },
-                    {
+                    "used_by_uk_armed_forces_info": {
                         "key": "used_by_uk_armed_forces_info",
                         "answer": "",
                         "raw_answer": "",
                         "question": "Explain how it will be used",
                         "datatype": "string",
                     },
-                ],
+                },
                 "type": "single",
+                "fields_sequence": [
+                    "product_name",
+                    "product_description",
+                    "has_security_classification",
+                    "prefix",
+                    "actions_to_classify",
+                    "security_classification",
+                    "suffix",
+                    "issuing_authority_name_address",
+                    "reference",
+                    "date_of_issue",
+                    "is_foreign_tech_or_information_shared",
+                    "is_controlled_under_itar",
+                    "controlled_info",
+                    "controlled_information",
+                    "itar_reference_number",
+                    "usml_categories",
+                    "itar_approval_scope",
+                    "expected_time_in_possession",
+                    "is_including_cryptography_or_security_features",
+                    "cryptography_or_security_feature_info",
+                    "is_item_rated_under_mctr",
+                    "is_item_manpad",
+                    "is_mod_electronic_data_shared",
+                    "funding_source",
+                    "is_used_by_uk_armed_forces",
+                    "used_by_uk_armed_forces_info",
+                ],
             },
         }
     }

--- a/exporter/f680/application_sections/general_application_details/tests/test_views.py
+++ b/exporter/f680/application_sections/general_application_details/tests/test_views.py
@@ -88,49 +88,57 @@ def mock_f680_application_get_existing_data(requests_mock, data_f680_case):
             "general_application_details": {
                 "label": "General application details",
                 "type": "single",
-                "fields": [
-                    {
+                "fields": {
+                    "name": {
                         "key": "name",
                         "answer": "my first F680",
                         "raw_answer": "my first F680",
                         "question": "What is the name of the application?",
                         "datatype": "string",
                     },
-                    {
+                    "previous_application_ecju_reference": {
                         "key": "previous_application_ecju_reference",
                         "answer": "123456",
                         "raw_answer": "123456",
                         "question": "What is the ECJU reference number?",
                         "datatype": "string",
                     },
-                    {
+                    "previous_application_details": {
                         "key": "previous_application_details",
                         "answer": "some info",
                         "raw_answer": "some info",
                         "question": "Can you provide more detail?",
                         "datatype": "string",
                     },
-                    {
+                    "is_exceptional_circumstances": {
                         "key": "is_exceptional_circumstances",
                         "answer": "Yes",
                         "raw_answer": True,
                         "question": "Are there exceptional circumstances?",
                         "datatype": "boolean",
                     },
-                    {
+                    "exceptional_circustances_date": {
                         "key": "exceptional_circumstances_date",
                         "answer": "2090-01-01",
                         "raw_answer": "2090-01-01",
                         "question": "What date do you need it?",
                         "datatype": "date",
                     },
-                    {
+                    "exceptional_circumstances_reason": {
                         "key": "exceptional_circumstances_reason",
                         "answer": "some reason",
                         "raw_answer": "some reason",
                         "question": "What makes the circumstances exceptional?",
                         "datatype": "string",
                     },
+                },
+                "fields_sequence": [
+                    "name",
+                    "previous_application_ecju_reference",
+                    "previous_application_details",
+                    "is_exceptional_circumstances",
+                    "exceptional_circumstances_date",
+                    "exceptional_circumstances_reason",
                 ],
             },
         }
@@ -338,59 +346,68 @@ class TestGeneralApplicationDetailsView:
                 "sections": {
                     "general_application_details": {
                         "label": "General application details",
-                        "fields": [
-                            {
+                        "fields": {
+                            "name": {
                                 "key": "name",
                                 "answer": "some test app",
                                 "raw_answer": "some test app",
                                 "question": "Name the application",
                                 "datatype": "string",
                             },
-                            {
+                            "has_made_previous_application": {
                                 "key": "has_made_previous_application",
                                 "answer": "Yes",
                                 "raw_answer": True,
                                 "question": "Have you made a previous application?",
                                 "datatype": "boolean",
                             },
-                            {
+                            "previous_application_ecju_reference": {
                                 "key": "previous_application_ecju_reference",
                                 "answer": "123456",
                                 "raw_answer": "123456",
                                 "question": "What is the ECJU reference number?",
                                 "datatype": "string",
                             },
-                            {
+                            "previous_application_details": {
                                 "key": "previous_application_details",
                                 "answer": "some info",
                                 "raw_answer": "some info",
                                 "question": "Can you provide more detail?",
                                 "datatype": "string",
                             },
-                            {
+                            "is_exceptional_circumstances": {
                                 "key": "is_exceptional_circumstances",
                                 "answer": "Yes",
                                 "raw_answer": True,
                                 "question": "Do you have exceptional circumstances that mean you need F680 approval in less than 30 days?",
                                 "datatype": "boolean",
                             },
-                            {
+                            "exceptional_circumstances_date": {
                                 "key": "exceptional_circumstances_date",
                                 "answer": "2026-12-01",
                                 "raw_answer": "2026-12-01",
                                 "question": "When do you need your F680 approval?",
                                 "datatype": "date",
                             },
-                            {
+                            "exceptional_circumstances_reason": {
                                 "key": "exceptional_circumstances_reason",
                                 "answer": "because",
                                 "raw_answer": "because",
                                 "question": "Why do you need approval in less than 30 days?",
                                 "datatype": "string",
                             },
-                        ],
+                        },
                         "type": "single",
-                    }
+                        "fields_sequence": [
+                            "name",
+                            "has_made_previous_application",
+                            "previous_application_ecju_reference",
+                            "previous_application_details",
+                            "is_exceptional_circumstances",
+                            "exceptional_circumstances_date",
+                            "exceptional_circumstances_reason",
+                        ],
+                    },
                 },
             }
         }

--- a/exporter/f680/application_sections/supporting_documents/tests/test_views.py
+++ b/exporter/f680/application_sections/supporting_documents/tests/test_views.py
@@ -44,7 +44,7 @@ def mock_f680_application_get(requests_mock, data_f680_case, application_id):
 def document_data(application_id):
     return [
         {
-            "id": "a66ebfb3-72c8-4a63-82f6-0519830729ce",
+            "id": "a66ebfb3-72c8-4a63-82f6-0519830729ce",  # /PS-IGNORE
             "name": "sample_doc.pdf",
             "s3_key": "sample_doc.pdf",
             "description": "my item",
@@ -234,22 +234,23 @@ class TestSupportingDocumentsAttachView:
             "items": [
                 {
                     "id": document_data[0]["id"],
-                    "fields": [
-                        {
+                    "fields": {
+                        "file": {
                             "key": "file",
                             "answer": document_data[0]["name"],
                             "raw_answer": document_data[0]["name"],
                             "question": "file",
                             "datatype": "string",
                         },
-                        {
+                        "description": {
                             "key": "description",
                             "answer": document_data[0]["description"],
                             "raw_answer": document_data[0]["description"],
                             "question": "description",
                             "datatype": "string",
                         },
-                    ],
+                    },
+                    "fields_sequence": ["file", "description"],
                 }
             ],
             "type": "multiple",

--- a/exporter/f680/application_sections/user_information/tests/test_views.py
+++ b/exporter/f680/application_sections/user_information/tests/test_views.py
@@ -60,63 +60,73 @@ def mock_f680_application_get_existing_data(requests_mock, data_f680_case, data_
             "user_information": {
                 "items": [
                     {
-                        "fields": [
-                            {
+                        "fields": {
+                            "entity_type": {
                                 "answer": "End user",
                                 "datatype": "string",
                                 "key": "entity_type",
                                 "question": "Select type of entity",
                                 "raw_answer": "end-user",
                             },
-                            {
+                            "end_user_name": {
                                 "answer": "some end user name",
                                 "datatype": "string",
                                 "key": "end_user_name",
                                 "question": "End-user name",
                                 "raw_answer": "some end user name",
                             },
-                            {
+                            "address": {
                                 "answer": "some address",
                                 "datatype": "string",
                                 "key": "address",
                                 "question": "Address",
                                 "raw_answer": "some address",
                             },
-                            {
+                            "country": {
                                 "answer": "United States",
                                 "datatype": "string",
                                 "key": "country",
                                 "question": "Country",
                                 "raw_answer": "US",
                             },
-                            {
+                            "prefix": {
                                 "answer": "some prefix",
                                 "datatype": "string",
                                 "key": "prefix",
                                 "question": "Enter a prefix (optional)",
                                 "raw_answer": "some prefix",
                             },
-                            {
+                            "security_classification": {
                                 "answer": "Official",
                                 "datatype": "string",
                                 "key": "security_classification",
                                 "question": "Select security classification",
                                 "raw_answer": "official",
                             },
-                            {
+                            "suffix": {
                                 "answer": "some suffix",
                                 "datatype": "string",
                                 "key": "suffix",
                                 "question": "Enter a suffix (optional)",
                                 "raw_answer": "some suffix",
                             },
-                            {
+                            "end_user_intended_end_use": {
                                 "answer": "some end use",
                                 "datatype": "string",
                                 "key": "end_user_intended_end_use",
                                 "question": "How does the end-user intend to use this item",
                                 "raw_answer": "some end use",
                             },
+                        },
+                        "fields_sequence": [
+                            "entity_type",
+                            "end_user_name",
+                            "address",
+                            "country",
+                            "prefix",
+                            "security_classification",
+                            "suffix",
+                            "end_user_intended_end_use",
                         ],
                         "id": data_item_id,
                     }
@@ -338,77 +348,89 @@ class TestUserInformationView:
                         "items": [
                             {
                                 "id": generated_uuid,
-                                "fields": [
-                                    {
+                                "fields": {
+                                    "entity_type": {
                                         "key": "entity_type",
                                         "answer": "Third party",
                                         "raw_answer": "third-party",
                                         "question": "Select type of entity",
                                         "datatype": "string",
                                     },
-                                    {
+                                    "third_party_role": {
                                         "key": "third_party_role",
                                         "answer": "Consultant",
                                         "raw_answer": "consultant",
                                         "question": "Select the role of the third party",
                                         "datatype": "string",
                                     },
-                                    {
+                                    "end_user_name": {
                                         "key": "end_user_name",
                                         "answer": "some end user name",
                                         "raw_answer": "some end user name",
                                         "question": "End-user name",
                                         "datatype": "string",
                                     },
-                                    {
+                                    "address": {
                                         "key": "address",
                                         "answer": "some end user address",
                                         "raw_answer": "some end user address",
                                         "question": "Address",
                                         "datatype": "string",
                                     },
-                                    {
+                                    "country": {
                                         "key": "country",
                                         "answer": "United States",
                                         "raw_answer": "US",
                                         "question": "Country",
                                         "datatype": "string",
                                     },
-                                    {
+                                    "prefix": {
                                         "key": "prefix",
                                         "answer": "some prefix",
                                         "raw_answer": "some prefix",
                                         "question": "Enter a prefix (optional)",
                                         "datatype": "string",
                                     },
-                                    {
+                                    "security_classification": {
                                         "key": "security_classification",
                                         "answer": "Secret",
                                         "raw_answer": "secret",
                                         "question": "Select security classification",
                                         "datatype": "string",
                                     },
-                                    {
+                                    "other_security_classification": {
                                         "key": "other_security_classification",
                                         "answer": "",
                                         "raw_answer": "",
                                         "question": "Enter the security classification",
                                         "datatype": "string",
                                     },
-                                    {
+                                    "suffix": {
                                         "key": "suffix",
                                         "answer": "some suffix",
                                         "raw_answer": "some suffix",
                                         "question": "Enter a suffix (optional)",
                                         "datatype": "string",
                                     },
-                                    {
+                                    "end_user_intended_end_use": {
                                         "key": "end_user_intended_end_use",
                                         "answer": "some end use",
                                         "raw_answer": "some end use",
                                         "question": "How does the end-user intend to use this item",
                                         "datatype": "string",
                                     },
+                                },
+                                "fields_sequence": [
+                                    "entity_type",
+                                    "third_party_role",
+                                    "end_user_name",
+                                    "address",
+                                    "country",
+                                    "prefix",
+                                    "security_classification",
+                                    "other_security_classification",
+                                    "suffix",
+                                    "end_user_intended_end_use",
                                 ],
                             }
                         ],
@@ -489,77 +511,89 @@ class TestUserInformationView:
         # New record also present
         assert api_patch_payload["application"]["sections"]["user_information"]["items"][1] == {
             "id": generated_uuid,
-            "fields": [
-                {
+            "fields": {
+                "entity_type": {
                     "key": "entity_type",
                     "answer": "Third party",
                     "raw_answer": "third-party",
                     "question": "Select type of entity",
                     "datatype": "string",
                 },
-                {
+                "third_party_role": {
                     "key": "third_party_role",
                     "answer": "Consultant",
                     "raw_answer": "consultant",
                     "question": "Select the role of the third party",
                     "datatype": "string",
                 },
-                {
+                "end_user_name": {
                     "key": "end_user_name",
                     "answer": "some end user name",
                     "raw_answer": "some end user name",
                     "question": "End-user name",
                     "datatype": "string",
                 },
-                {
+                "address": {
                     "key": "address",
                     "answer": "some end user address",
                     "raw_answer": "some end user address",
                     "question": "Address",
                     "datatype": "string",
                 },
-                {
+                "country": {
                     "key": "country",
                     "answer": "United States",
                     "raw_answer": "US",
                     "question": "Country",
                     "datatype": "string",
                 },
-                {
+                "prefix": {
                     "key": "prefix",
                     "answer": "some prefix",
                     "raw_answer": "some prefix",
                     "question": "Enter a prefix (optional)",
                     "datatype": "string",
                 },
-                {
+                "security_classification": {
                     "key": "security_classification",
                     "answer": "Secret",
                     "raw_answer": "secret",
                     "question": "Select security classification",
                     "datatype": "string",
                 },
-                {
+                "other_security_classification": {
                     "key": "other_security_classification",
                     "answer": "",
                     "raw_answer": "",
                     "question": "Enter the security classification",
                     "datatype": "string",
                 },
-                {
+                "suffix": {
                     "key": "suffix",
                     "answer": "some suffix",
                     "raw_answer": "some suffix",
                     "question": "Enter a suffix (optional)",
                     "datatype": "string",
                 },
-                {
+                "end_user_intended_end_use": {
                     "key": "end_user_intended_end_use",
                     "answer": "some end use",
                     "raw_answer": "some end use",
                     "question": "How does the end-user intend to use this item",
                     "datatype": "string",
                 },
+            },
+            "fields_sequence": [
+                "entity_type",
+                "third_party_role",
+                "end_user_name",
+                "address",
+                "country",
+                "prefix",
+                "security_classification",
+                "other_security_classification",
+                "suffix",
+                "end_user_intended_end_use",
             ],
         }
 

--- a/exporter/f680/application_sections/user_information/views.py
+++ b/exporter/f680/application_sections/user_information/views.py
@@ -93,7 +93,7 @@ class UserInformationSummaryView(F680FeatureRequiredMixin, TemplateView):
             return {}
         user_entities = {}
         for entity in self.application["application"]["sections"]["user_information"]["items"]:
-            answers = {field["key"]: field["answer"] for field in entity["fields"]}
+            answers = {field["key"]: field["answer"] for field in entity["fields"].values()}
             user_entities[entity["id"]] = answers
         return user_entities
 

--- a/exporter/f680/application_sections/views.py
+++ b/exporter/f680/application_sections/views.py
@@ -46,7 +46,7 @@ class F680ApplicationSectionWizard(LoginRequiredMixin, F680FeatureRequiredMixin,
 
     def deserialize_payload(self, payload):
         data = {}
-        for field in payload["fields"]:
+        for field in payload["fields"].values():
             key = field["key"]
             data[key] = self.deserialize(field["raw_answer"], field["datatype"])
         return data

--- a/exporter/f680/payloads.py
+++ b/exporter/f680/payloads.py
@@ -106,7 +106,7 @@ class F680DictPayloadBuilder(F680PatchPayloadBuilder):
                     "datatype": datatype,
                 }
                 fields_sequence.append(key)
-            item = {"id": item_id, "fields": fields}
+            item = {"id": item_id, "fields": fields, "fields_sequence": fields_sequence}
             all_items[item["id"]] = item
         section_payload = {
             "label": section_label,

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -1241,35 +1241,41 @@ def data_application_json(data_australia_release_id, data_france_release_id, dat
             "approval_type": {
                 "type": "single",
                 "label": "Approval type",
-                "fields": [
-                    {
+                "fields": {
+                    "approval_choices": {
                         "key": "approval_choices",
                         "answer": ["Demonstration overseas", "Training"],
                         "datatype": "list",
                         "question": "Select the types of approvals you need",
                         "raw_answer": ["demonstration_overseas", "training"],
                     },
-                    {
+                    "demonstration_in_uk": {
                         "key": "demonstration_in_uk",
                         "answer": "",
                         "datatype": "string",
                         "question": "Explain what you are demonstrating and why",
                         "raw_answer": "",
                     },
-                    {
+                    "demonstration_overseas": {
                         "key": "demonstration_overseas",
                         "answer": "",
                         "datatype": "string",
                         "question": "Explain what you are demonstrating and why",
                         "raw_answer": "",
                     },
-                    {
+                    "approval_details_text": {
                         "key": "approval_details_text",
                         "answer": "csda",
                         "datatype": "string",
                         "question": "Provide details about what you're seeking approval to do",
                         "raw_answer": "csda",
                     },
+                },
+                "fields_sequence": [
+                    "approval_choices",
+                    "demonstration_in_uk",
+                    "demonstration_overseas",
+                    "approval_details_text",
                 ],
             },
             "user_information": {
@@ -1277,339 +1283,391 @@ def data_application_json(data_australia_release_id, data_france_release_id, dat
                 "items": [
                     {
                         "id": data_france_release_id,
-                        "fields": [
-                            {
+                        "fields": {
+                            "entity_type": {
                                 "key": "entity_type",
                                 "answer": "Ultimate end-user",
                                 "datatype": "string",
                                 "question": "Select type of entity",
                                 "raw_answer": "ultimate-end-user",
                             },
-                            {
+                            "end_user_name": {
                                 "key": "end_user_name",
                                 "answer": "france name",
                                 "datatype": "string",
                                 "question": "End-user name",
                                 "raw_answer": "france name",
                             },
-                            {
+                            "address": {
                                 "key": "address",
                                 "answer": "france address",
                                 "datatype": "string",
                                 "question": "Address",
                                 "raw_answer": "france address",
                             },
-                            {
+                            "country": {
                                 "key": "country",
                                 "answer": "France",
                                 "datatype": "string",
                                 "question": "Country",
                                 "raw_answer": "FR",
                             },
-                            {
+                            "prefix": {
                                 "key": "prefix",
                                 "answer": "",
                                 "datatype": "string",
                                 "question": "Enter a prefix (optional)",
                                 "raw_answer": "",
                             },
-                            {
+                            "security_classification": {
                                 "key": "security_classification",
                                 "answer": "Official",
                                 "datatype": "string",
                                 "question": "Select security classification",
                                 "raw_answer": "official",
                             },
-                            {
+                            "other_security_classification": {
                                 "key": "other_security_classification",
                                 "answer": "",
                                 "datatype": "string",
                                 "question": "Enter the security classification",
                                 "raw_answer": "",
                             },
-                            {
+                            "suffix": {
                                 "key": "suffix",
                                 "answer": "",
                                 "datatype": "string",
                                 "question": "Enter a suffix (optional)",
                                 "raw_answer": "",
                             },
-                            {
+                            "issuing_authority_name_address": {
                                 "key": "issuing_authority_name_address",
                                 "answer": "cdsacsad",
                                 "datatype": "string",
                                 "question": "Name and address of the issuing authority",
                                 "raw_answer": "cdsacsad",
                             },
-                            {
+                            "reference": {
                                 "key": "reference",
                                 "answer": "ref",
                                 "datatype": "string",
                                 "question": "Reference",
                                 "raw_answer": "ref",
                             },
-                            {
+                            "date_of_issue": {
                                 "key": "date_of_issue",
                                 "answer": "2024-01-01",
                                 "datatype": "date",
                                 "question": "Date of issue",
                                 "raw_answer": "2024-01-01",
                             },
-                            {
+                            "end_user_intended_end_use": {
                                 "key": "end_user_intended_end_use",
                                 "answer": "france intended use",
                                 "datatype": "string",
                                 "question": "How does the end-user intend to use this product",
                                 "raw_answer": "france intended use",
                             },
-                            {
+                            "assemble_manufacture": {
                                 "key": "assemble_manufacture",
                                 "answer": ["No"],
                                 "datatype": "list",
                                 "question": "Does this end-user need to assemble or manufacture any of the products?",
                                 "raw_answer": ["no"],
                             },
-                            {
+                            "assemble": {
                                 "key": "assemble",
                                 "answer": "",
                                 "datatype": "string",
                                 "question": "Describe what assembly is needed.",
                                 "raw_answer": "",
                             },
-                            {
+                            "manufacture": {
                                 "key": "manufacture",
                                 "answer": "",
                                 "datatype": "string",
                                 "question": "Describe what manufacture is needed. Be sure to include the manufacturer's website if they have one.",
                                 "raw_answer": "",
                             },
+                        },
+                        "fields_sequence": [
+                            "entity_type",
+                            "end_user_name",
+                            "address",
+                            "country",
+                            "prefix",
+                            "security_classification",
+                            "other_security_classification",
+                            "suffix",
+                            "issuing_authority_name_address",
+                            "reference",
+                            "date_of_issue",
+                            "end_user_intended_end_use",
+                            "assemble_manufacture",
+                            "assemble",
+                            "manufacture",
                         ],
                     },
                     {
                         "id": data_uae_release_id,
-                        "fields": [
-                            {
+                        "fields": {
+                            "entity_type": {
                                 "key": "entity_type",
                                 "answer": "End user",
                                 "datatype": "string",
                                 "question": "Select type of entity",
                                 "raw_answer": "end-user",
                             },
-                            {
+                            "end_user_name": {
                                 "key": "end_user_name",
                                 "answer": "uae name",
                                 "datatype": "string",
                                 "question": "End-user name",
                                 "raw_answer": "uae name",
                             },
-                            {
+                            "address": {
                                 "key": "address",
                                 "answer": "uae address",
                                 "datatype": "string",
                                 "question": "Address",
                                 "raw_answer": "uae address",
                             },
-                            {
+                            "country": {
                                 "key": "country",
                                 "answer": "United Arab Emirates",
                                 "datatype": "string",
                                 "question": "Country",
                                 "raw_answer": "AE",
                             },
-                            {
+                            "prefix": {
                                 "key": "prefix",
                                 "answer": "",
                                 "datatype": "string",
                                 "question": "Enter a prefix (optional)",
                                 "raw_answer": "",
                             },
-                            {
+                            "security_classification": {
                                 "key": "security_classification",
                                 "answer": "Top-Secret",
                                 "datatype": "string",
                                 "question": "Select security classification",
                                 "raw_answer": "top-secret",
                             },
-                            {
+                            "other_security_classification": {
                                 "key": "other_security_classification",
                                 "answer": "",
                                 "datatype": "string",
                                 "question": "Enter the security classification",
                                 "raw_answer": "",
                             },
-                            {
+                            "suffix": {
                                 "key": "suffix",
                                 "answer": "",
                                 "datatype": "string",
                                 "question": "Enter a suffix (optional)",
                                 "raw_answer": "",
                             },
-                            {
+                            "issuing_authority_name_address": {
                                 "key": "issuing_authority_name_address",
                                 "answer": "casdcdsa",
                                 "datatype": "string",
                                 "question": "Name and address of the issuing authority",
                                 "raw_answer": "casdcdsa",
                             },
-                            {
+                            "reference": {
                                 "key": "reference",
                                 "answer": "csd",
                                 "datatype": "string",
                                 "question": "Reference",
                                 "raw_answer": "csd",
                             },
-                            {
+                            "date_of_issue": {
                                 "key": "date_of_issue",
                                 "answer": "2024-01-01",
                                 "datatype": "date",
                                 "question": "Date of issue",
                                 "raw_answer": "2024-01-01",
                             },
-                            {
+                            "end_user_intended_end_use": {
                                 "key": "end_user_intended_end_use",
                                 "answer": "uae intended use",
                                 "datatype": "string",
                                 "question": "How does the end-user intend to use this product",
                                 "raw_answer": "uae intended use",
                             },
-                            {
+                            "assemble_manufacture": {
                                 "key": "assemble_manufacture",
                                 "answer": ["No"],
                                 "datatype": "list",
                                 "question": "Does this end-user need to assemble or manufacture any of the products?",
                                 "raw_answer": ["no"],
                             },
-                            {
+                            "assemble": {
                                 "key": "assemble",
                                 "answer": "",
                                 "datatype": "string",
                                 "question": "Describe what assembly is needed.",
                                 "raw_answer": "",
                             },
-                            {
+                            "manufacture": {
                                 "key": "manufacture",
                                 "answer": "",
                                 "datatype": "string",
                                 "question": "Describe what manufacture is needed. Be sure to include the manufacturer's website if they have one.",
                                 "raw_answer": "",
                             },
+                        },
+                        "fields_sequence": [
+                            "entity_type",
+                            "end_user_name",
+                            "address",
+                            "country",
+                            "prefix",
+                            "security_classification",
+                            "other_security_classification",
+                            "suffix",
+                            "issuing_authority_name_address",
+                            "reference",
+                            "date_of_issue",
+                            "end_user_intended_end_use",
+                            "assemble_manufacture",
+                            "assemble",
+                            "manufacture",
                         ],
                     },
                     {
                         "id": data_australia_release_id,
-                        "fields": [
-                            {
+                        "fields": {
+                            "entity_type": {
                                 "key": "entity_type",
                                 "answer": "Third party",
                                 "datatype": "string",
                                 "question": "Select type of entity",
                                 "raw_answer": "third-party",
                             },
-                            {
+                            "third_party_role": {
                                 "key": "third_party_role",
                                 "answer": "Consultant",
                                 "datatype": "string",
                                 "question": "Select the role of the third party",
                                 "raw_answer": "consultant",
                             },
-                            {
+                            "end_user_name": {
                                 "key": "end_user_name",
                                 "answer": "australia name",
                                 "datatype": "string",
                                 "question": "End-user name",
                                 "raw_answer": "australia name",
                             },
-                            {
+                            "address": {
                                 "key": "address",
                                 "answer": "australia address",
                                 "datatype": "string",
                                 "question": "Address",
                                 "raw_answer": "australia address",
                             },
-                            {
+                            "country": {
                                 "key": "country",
                                 "answer": "Australia",
                                 "datatype": "string",
                                 "question": "Country",
                                 "raw_answer": "AU",
                             },
-                            {
+                            "prefix": {
                                 "key": "prefix",
                                 "answer": "",
                                 "datatype": "string",
                                 "question": "Enter a prefix (optional)",
                                 "raw_answer": "",
                             },
-                            {
+                            "security_classification": {
                                 "key": "security_classification",
                                 "answer": "Secret",
                                 "datatype": "string",
                                 "question": "Select security classification",
                                 "raw_answer": "secret",
                             },
-                            {
+                            "other_security_classification": {
                                 "key": "other_security_classification",
                                 "answer": "",
                                 "datatype": "string",
                                 "question": "Enter the security classification",
                                 "raw_answer": "",
                             },
-                            {
+                            "suffix": {
                                 "key": "suffix",
                                 "answer": "",
                                 "datatype": "string",
                                 "question": "Enter a suffix (optional)",
                                 "raw_answer": "",
                             },
-                            {
+                            "issuing_authority_name_address": {
                                 "key": "issuing_authority_name_address",
                                 "answer": "csdacdsa",
                                 "datatype": "string",
                                 "question": "Name and address of the issuing authority",
                                 "raw_answer": "csdacdsa",
                             },
-                            {
+                            "reference": {
                                 "key": "reference",
                                 "answer": "casdcdsa",
                                 "datatype": "string",
                                 "question": "Reference",
                                 "raw_answer": "casdcdsa",
                             },
-                            {
+                            "date_of_issue": {
                                 "key": "date_of_issue",
                                 "answer": "2024-01-01",
                                 "datatype": "date",
                                 "question": "Date of issue",
                                 "raw_answer": "2024-01-01",
                             },
-                            {
+                            "end_user_intended_end_use": {
                                 "key": "end_user_intended_end_use",
                                 "answer": "australia intended use",
                                 "datatype": "string",
                                 "question": "How does the end-user intend to use this product",
                                 "raw_answer": "australia intended use",
                             },
-                            {
+                            "assemble_manufacture": {
                                 "key": "assemble_manufacture",
                                 "answer": ["No"],
                                 "datatype": "list",
                                 "question": "Does this end-user need to assemble or manufacture any of the products?",
                                 "raw_answer": ["no"],
                             },
-                            {
+                            "assemble": {
                                 "key": "assemble",
                                 "answer": "",
                                 "datatype": "string",
                                 "question": "Describe what assembly is needed.",
                                 "raw_answer": "",
                             },
-                            {
+                            "manufacture": {
                                 "key": "manufacture",
                                 "answer": "",
                                 "datatype": "string",
                                 "question": "Describe what manufacture is needed. Be sure to include the manufacturer's website if they have one.",
                                 "raw_answer": "",
                             },
+                        },
+                        "fields_sequence": [
+                            "entity_type",
+                            "third_party_role",
+                            "end_user_name",
+                            "address",
+                            "country",
+                            "prefix",
+                            "security_classification",
+                            "other_security_classification",
+                            "suffix",
+                            "issuing_authority_name_address",
+                            "reference",
+                            "date_of_issue",
+                            "end_user_intended_end_use",
+                            "assemble_manufacture",
+                            "assemble",
+                            "manufacture",
                         ],
                     },
                 ],
@@ -1618,161 +1676,183 @@ def data_application_json(data_australia_release_id, data_france_release_id, dat
             "product_information": {
                 "type": "single",
                 "label": "Product information",
-                "fields": [
-                    {
+                "fields": {
+                    "product_name": {
                         "key": "product_name",
                         "answer": "some product name",
                         "datatype": "string",
                         "question": "Give the item a descriptive name",
                         "raw_answer": "some product name",
                     },
-                    {
+                    "product_description": {
                         "key": "product_description",
                         "answer": "some product description",
                         "datatype": "string",
                         "question": "Describe the item",
                         "raw_answer": "some product description",
                     },
-                    {
+                    "has_security_classification": {
                         "key": "has_security_classification",
                         "answer": "Yes",
                         "datatype": "boolean",
                         "question": "Has the product been given a security classifcation by a UK MOD authority?",
                         "raw_answer": True,
                     },
-                    {
+                    "prefix": {
                         "key": "prefix",
                         "answer": "",
                         "datatype": "string",
                         "question": "Enter a prefix (optional)",
                         "raw_answer": "",
                     },
-                    {
+                    "security_classification": {
                         "key": "security_classification",
                         "answer": "Official",
                         "datatype": "string",
                         "question": "Select security classification",
                         "raw_answer": "official",
                     },
-                    {
+                    "other_security_classification": {
                         "key": "other_security_classification",
                         "answer": "",
                         "datatype": "string",
                         "question": "Enter the security classification",
                         "raw_answer": "",
                     },
-                    {
+                    "suffix": {
                         "key": "suffix",
                         "answer": "",
                         "datatype": "string",
                         "question": "Enter a suffix (optional)",
                         "raw_answer": "",
                     },
-                    {
+                    "issuing_authority_name_address": {
                         "key": "issuing_authority_name_address",
                         "answer": "csadcas",
                         "datatype": "string",
                         "question": "Name and address of the issuing authority",
                         "raw_answer": "csadcas",
                     },
-                    {
+                    "reference": {
                         "key": "reference",
                         "answer": "fdfscsa",
                         "datatype": "string",
                         "question": "Reference",
                         "raw_answer": "fdfscsa",
                     },
-                    {
+                    "date_of_issue": {
                         "key": "date_of_issue",
                         "answer": "0001-01-01",
                         "datatype": "date",
                         "question": "Date of issue",
                         "raw_answer": "0001-01-01",
                     },
-                    {
+                    "is_foreign_tech_or_information_shared": {
                         "key": "is_foreign_tech_or_information_shared",
                         "answer": "No",
                         "datatype": "boolean",
                         "question": "Will any foreign technology or information be shared with the item?",
                         "raw_answer": False,
                     },
-                    {
+                    "is_including_cryptography_or_security_features": {
                         "key": "is_including_cryptography_or_security_features",
                         "answer": "No",
                         "datatype": "boolean",
                         "question": "Does the item include cryptography or other information security features?",
                         "raw_answer": False,
                     },
-                    {
+                    "cryptography_or_security_feature_info": {
                         "key": "cryptography_or_security_feature_info",
                         "answer": "",
                         "datatype": "string",
                         "question": "Provide full details",
                         "raw_answer": "",
                     },
-                    {
+                    "is_item_rated_under_mctr": {
                         "key": "is_item_rated_under_mctr",
                         "answer": "Yes, the product is MTCR Category 2",
                         "datatype": "string",
                         "question": "Do you believe the item is rated under the Missile Technology Control Regime (MTCR)",
                         "raw_answer": "mtcr_2",
                     },
-                    {
+                    "is_item_manpad": {
                         "key": "is_item_manpad",
                         "answer": "Don't know",
                         "datatype": "string",
                         "question": "Do you believe the item is a man-portable air defence system (MANPAD)?",
                         "raw_answer": "dont_know",
                     },
-                    {
+                    "is_mod_electronic_data_shared": {
                         "key": "is_mod_electronic_data_shared",
                         "answer": "No",
                         "datatype": "string",
                         "question": "Will any electronic warfare data owned by the Ministry of Defence (MOD) be shared with the item?",
                         "raw_answer": "no",
                     },
-                    {
+                    "funding_source": {
                         "key": "funding_source",
                         "answer": "MOD",
                         "datatype": "string",
                         "question": "Who is funding the item?",
                         "raw_answer": "mod",
                     },
-                    {
+                    "is_used_by_uk_armed_forces": {
                         "key": "is_used_by_uk_armed_forces",
                         "answer": "No",
                         "datatype": "boolean",
                         "question": "Will the item be used by the UK Armed Forces?",
                         "raw_answer": False,
                     },
-                    {
+                    "used_by_uk_armed_forces_info": {
                         "key": "used_by_uk_armed_forces_info",
                         "answer": "",
                         "datatype": "string",
                         "question": "Explain how it will be used",
                         "raw_answer": "",
                     },
+                },
+                "fields_sequence": [
+                    "product_name",
+                    "product_description",
+                    "has_security_classification",
+                    "prefix",
+                    "security_classification",
+                    "other_security_classification",
+                    "suffix",
+                    "issuing_authority_name_address",
+                    "reference",
+                    "date_of_issue",
+                    "is_foreign_tech_or_information_shared",
+                    "is_including_cryptography_or_security_features",
+                    "cryptography_or_security_feature_info",
+                    "is_item_rated_under_mctr",
+                    "is_item_manpad",
+                    "is_mod_electronic_data_shared",
+                    "funding_source",
+                    "is_used_by_uk_armed_forces",
+                    "used_by_uk_armed_forces_info",
                 ],
             },
             "general_application_details": {
                 "type": "single",
                 "label": "General application details",
-                "fields": [
-                    {
+                "fields": {
+                    "name": {
                         "key": "name",
                         "answer": "some name",
                         "datatype": "string",
                         "question": "Name the application",
                         "raw_answer": "some name",
                     },
-                    {
+                    "is_exceptional_circumstances": {
                         "key": "is_exceptional_circumstances",
                         "answer": "No",
                         "datatype": "boolean",
                         "question": "Do you have exceptional circumstances that mean you need F680 approval in less than 30 days?",
                         "raw_answer": False,
                     },
-                ],
+                },
+                "fields_sequence": ["name", "is_exceptional_circumstances"],
             },
         }
     }


### PR DESCRIPTION
### Aim

Change the F680 application JSON contract so that `fields` is a dictionary as opposed to an array.  This allows us to have a much easier time with DRF serializer validation and additionally makes lookups much easier.

Companion API PR: https://github.com/uktrade/lite-api/pull/2462

[LTD-5993](https://uktrade.atlassian.net/browse/LTD-5993)


[LTD-5993]: https://uktrade.atlassian.net/browse/LTD-5993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ