### PR TITLE
LTD-6043 add backlinks to first wizard step

### DIFF
--- a/exporter/f680/application_sections/additional_information/tests/test_views.py
+++ b/exporter/f680/application_sections/additional_information/tests/test_views.py
@@ -122,9 +122,11 @@ class TestAdditionalInformationView:
         authorized_client,
         mock_f680_application_get,
         f680_application_wizard_url,
+        data_f680_case,
     ):
         response = authorized_client.get(f680_application_wizard_url)
         assert response.status_code == 200
+        assert response.context["back_link_url"] == reverse("f680:summary", kwargs={"pk": data_f680_case["id"]})
         assert isinstance(response.context["form"], NotesForCaseOfficerForm)
 
     def test_GET_success_with_organisation_set(

--- a/exporter/f680/application_sections/approval_details/tests/test_views.py
+++ b/exporter/f680/application_sections/approval_details/tests/test_views.py
@@ -169,9 +169,11 @@ class TestApprovalDetailsView:
         authorized_client,
         mock_f680_application_get,
         f680_approval_type_wizard_url,
+        data_f680_case,
     ):
         response = authorized_client.get(f680_approval_type_wizard_url)
         assert response.status_code == 200
+        assert response.context["back_link_url"] == reverse("f680:summary", kwargs={"pk": data_f680_case["id"]})
         assert isinstance(response.context["form"], forms.ApprovalTypeForm)
 
     def test_GET_success_with_organisation_set(
@@ -320,9 +322,11 @@ class TestProductInformationViews:
         authorized_client,
         mock_f680_application_get,
         f680_product_wizard_url,
+        data_f680_case,
     ):
         response = authorized_client.get(f680_product_wizard_url)
         assert response.status_code == 200
+        assert response.context["back_link_url"] == reverse("f680:summary", kwargs={"pk": data_f680_case["id"]})
         assert isinstance(response.context["form"], forms.ProductNameForm)
 
     def test_GET_success_with_organisation_set(

--- a/exporter/f680/application_sections/general_application_details/tests/test_views.py
+++ b/exporter/f680/application_sections/general_application_details/tests/test_views.py
@@ -174,9 +174,11 @@ class TestGeneralApplicationDetailsView:
         authorized_client,
         mock_f680_application_get,
         f680_application_wizard_url,
+        data_f680_case,
     ):
         response = authorized_client.get(f680_application_wizard_url)
         assert response.status_code == 200
+        assert response.context["back_link_url"] == reverse("f680:summary", kwargs={"pk": data_f680_case["id"]})
         assert isinstance(response.context["form"], ApplicationNameForm)
 
     def test_GET_success_organisation_set(

--- a/exporter/f680/application_sections/user_information/tests/test_views.py
+++ b/exporter/f680/application_sections/user_information/tests/test_views.py
@@ -172,6 +172,7 @@ class TestUserInformationView:
         authorized_client,
         mock_f680_application_get,
         f680_user_information_wizard_url,
+        data_f680_case,
     ):
         response = authorized_client.get(f680_user_information_wizard_url)
         assert response.status_code == 200

--- a/exporter/f680/application_sections/user_information/tests/test_views.py
+++ b/exporter/f680/application_sections/user_information/tests/test_views.py
@@ -176,6 +176,7 @@ class TestUserInformationView:
     ):
         response = authorized_client.get(f680_user_information_wizard_url)
         assert response.status_code == 200
+        assert response.context["back_link_url"] == reverse("f680:summary", kwargs={"pk": data_f680_case["id"]})
         assert isinstance(response.context["form"], forms.EntityTypeForm)
 
     def test_GET_no_feature_flag_forbidden(

--- a/exporter/f680/application_sections/user_information/views.py
+++ b/exporter/f680/application_sections/user_information/views.py
@@ -51,7 +51,7 @@ class UserInformationView(F680MultipleItemApplicationSectionWizard):
         return {}
 
     def get_back_link_url(self):
-        return reverse("applications:applications")
+        return reverse("f680:summary", kwargs={"pk": self.application["id"]})
 
     def get_success_url(self, application_id):
         return reverse(

--- a/exporter/f680/application_sections/user_information/views.py
+++ b/exporter/f680/application_sections/user_information/views.py
@@ -50,6 +50,9 @@ class UserInformationView(F680MultipleItemApplicationSectionWizard):
             return {"countries": countries}
         return {}
 
+    def get_back_link_url(self):
+        return reverse("applications:applications")
+
     def get_success_url(self, application_id):
         return reverse(
             "f680:user_information:summary",

--- a/exporter/f680/application_sections/views.py
+++ b/exporter/f680/application_sections/views.py
@@ -65,6 +65,14 @@ class F680ApplicationSectionWizard(LoginRequiredMixin, F680FeatureRequiredMixin,
             },
         )
 
+    def get_back_link_url(self):
+        return self.get_success_url(self.application["id"])
+
+    def get_context_data(self, **kwargs):
+        context_data = super().get_context_data(**kwargs)
+        context_data["back_link_url"] = self.get_back_link_url()
+        return context_data
+
     def get_payload(self, form_dict):
         current_application = self.application.get("application", {})
         return F680PatchPayloadBuilder().build(self.section, self.section_label, current_application, form_dict)

--- a/exporter/templates/f680/summary.html
+++ b/exporter/templates/f680/summary.html
@@ -2,6 +2,8 @@
 
 {% load crispy_forms_tags %}
 
+{% block back_link_url %}{% url "applications:applications" %}{% endblock %}
+
 {% block title %}Apply for an F680 Application{% endblock%}
 
 {% block body %}


### PR DESCRIPTION
### Aim

There are currently no back links on the first step of each of sections in the F680 exporter journey.  This PR looks to address this adding these links.  The backlink on the F680 draft application summary page has also been repaired so that it returns to the application list page (this follows the same convention set in SIEL application)

[LTD-6043](https://uktrade.atlassian.net/browse/LTD-6043)


[LTD-6043]: https://uktrade.atlassian.net/browse/LTD-6043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ