### PR TITLE
LTD: Hide recommendations tab if the case status is not appropriate

### DIFF
--- a/caseworker/f680/conftest.py
+++ b/caseworker/f680/conftest.py
@@ -20,6 +20,25 @@ def queue_f680_cases_to_review():
 
 
 @pytest.fixture
+def recommendations(current_user, admin_team, data_submitted_f680_case):
+    security_release_requests = data_submitted_f680_case["case"]["data"]["security_release_requests"]
+    return [
+        {
+            "created_at": "2021-10-16T23:48:39.486679+01:00",
+            "id": "429c5596-fe8b-4540-988b-c37805cd08de",  # /PS-IGNORE
+            "type": {"key": "approve", "value": "Approve"},
+            "conditions": "No concerns",
+            "refusal_reasons": "",
+            "security_grading": {"key": "official", "value": "Official"},
+            "security_grading_other": "",
+            "security_release_request": security_release_requests[0]["id"],
+            "user": current_user,
+            "team": admin_team,
+        }
+    ]
+
+
+@pytest.fixture
 def mock_f680_case_with_assigned_user(f680_case_id, requests_mock, data_submitted_f680_case, data_queue, mock_gov_user):
     data_submitted_f680_case["case"]["assigned_users"] = {data_queue["name"]: [mock_gov_user["user"]]}
     url = client._build_absolute_uri(f"/cases/{f680_case_id}/")
@@ -41,6 +60,18 @@ def mock_f680_case(f680_case_id, requests_mock, data_submitted_f680_case):
 def mock_post_recommendation(requests_mock, data_submitted_f680_case):
     url = f"/caseworker/f680/{data_submitted_f680_case['case']['id']}/recommendation/"
     return requests_mock.post(url, json={}, status_code=201)
+
+
+@pytest.fixture
+def mock_get_case_recommendations(requests_mock, data_submitted_f680_case, recommendations):
+    url = f"/caseworker/f680/{data_submitted_f680_case['case']['id']}/recommendation/"
+    return requests_mock.get(url, json=recommendations, status_code=200)
+
+
+@pytest.fixture
+def mock_get_case_no_recommendations(requests_mock, data_submitted_f680_case, recommendations):
+    url = f"/caseworker/f680/{data_submitted_f680_case['case']['id']}/recommendation/"
+    return requests_mock.get(url, json=[], status_code=200)
 
 
 @pytest.fixture

--- a/caseworker/f680/recommendation/tests/test_views.py
+++ b/caseworker/f680/recommendation/tests/test_views.py
@@ -57,37 +57,6 @@ def mock_current_gov_user(requests_mock, current_user, f680_case_id):
 
 
 @pytest.fixture
-def recommendations(current_user, admin_team, data_submitted_f680_case):
-    security_release_requests = data_submitted_f680_case["case"]["data"]["security_release_requests"]
-    return [
-        {
-            "created_at": "2021-10-16T23:48:39.486679+01:00",
-            "id": "429c5596-fe8b-4540-988b-c37805cd08de",  # /PS-IGNORE
-            "type": {"key": "approve", "value": "Approve"},
-            "conditions": "No concerns",
-            "refusal_reasons": "",
-            "security_grading": {"key": "official", "value": "Official"},
-            "security_grading_other": "",
-            "security_release_request": security_release_requests[0]["id"],
-            "user": current_user,
-            "team": admin_team,
-        }
-    ]
-
-
-@pytest.fixture
-def mock_get_case_recommendations(requests_mock, data_submitted_f680_case, recommendations):
-    url = f"/caseworker/f680/{data_submitted_f680_case['case']['id']}/recommendation/"
-    return requests_mock.get(url, json=recommendations, status_code=200)
-
-
-@pytest.fixture
-def mock_get_case_no_recommendations(requests_mock, data_submitted_f680_case, recommendations):
-    url = f"/caseworker/f680/{data_submitted_f680_case['case']['id']}/recommendation/"
-    return requests_mock.get(url, json=[], status_code=200)
-
-
-@pytest.fixture
 def mock_clear_recommendations(requests_mock, data_submitted_f680_case):
     url = f"/caseworker/f680/{data_submitted_f680_case['case']['id']}/recommendation/"
     return requests_mock.delete(url, status_code=204)

--- a/caseworker/f680/rules.py
+++ b/caseworker/f680/rules.py
@@ -16,6 +16,15 @@ INFORMATIONAL_STATUSES = [CaseStatusEnum.SUBMITTED]
 
 
 @rules.predicate
+def is_user_allowed_to_make_f680_recommendation(request, case):
+    user = get_logged_in_caseworker(request)
+    if not user:
+        return False
+
+    return case["data"]["status"]["key"] in RECOMMENDATION_STATUSES + OUTCOME_STATUSES
+
+
+@rules.predicate
 def can_user_make_f680_recommendation(request, case):
     # TODO: change this snippet in to a decorator? We seem to use it for every rule
     user = get_logged_in_caseworker(request)
@@ -71,6 +80,9 @@ def case_ready_for_outcome(request, case):
     return case["data"]["status"]["key"] in OUTCOME_STATUSES
 
 
+rules.add_rule(
+    "is_user_allowed_to_make_f680_recommendation", is_user_allocated & is_user_allowed_to_make_f680_recommendation
+)
 rules.add_rule("can_user_make_f680_recommendation", is_user_allocated & can_user_make_f680_recommendation)
 rules.add_rule("can_user_clear_f680_recommendation", is_user_allocated & can_user_clear_f680_recommendation)
 rules.add_rule("can_user_make_f680_outcome", is_user_allocated & case_ready_for_outcome)

--- a/caseworker/f680/templates/f680/case/base.html
+++ b/caseworker/f680/templates/f680/case/base.html
@@ -1,4 +1,5 @@
 {% extends 'layouts/case.html' %}
+{% load rules %}
 
 {% block header_tabs %}
 <div id="tab-bar" class="app-case-tab-bar">
@@ -10,9 +11,12 @@
             <a id="application-details" href="{% url 'cases:f680:details' queue_pk case.id %}" class="lite-tabs__tab {% if current_tab == "application-details" %}lite-tabs__tab--selected{% endif %}">
                 Application Details
             </a>
-            <a id="recommendations" href="{% url 'cases:f680:recommendation' queue_pk case.id %}" class="lite-tabs__tab {% if current_tab == "recommendations" %}lite-tabs__tab--selected{% endif %}">
-                Recommendations
-            </a>
+            {% test_rule 'is_user_allowed_to_make_f680_recommendation' request case as is_user_allowed_to_make_f680_recommendation %}
+            {% if is_user_allowed_to_make_f680_recommendation %}
+                <a id="recommendations" href="{% url 'cases:f680:recommendation' queue_pk case.id %}" class="lite-tabs__tab {% if current_tab == "recommendations" %}lite-tabs__tab--selected{% endif %}">
+                    Recommendations
+                </a>
+            {% endif %}
         </div>
     </div>
 </div>

--- a/caseworker/f680/tests/test_rules.py
+++ b/caseworker/f680/tests/test_rules.py
@@ -87,161 +87,159 @@ class TestIsUserAllowedToMakeRecommendationRule:
         assert rules.test_rule("is_user_allowed_to_make_f680_recommendation", request, data_assigned_case) is expected
 
 
-def test_can_user_make_f680_recommendation_request_missing_attributes(
-    mock_gov_user, data_fake_queue, data_unassigned_case
-):
-    case = data_unassigned_case
-    request = None
+class TestCanUserMakeF680RecommendationRule:
 
-    assert not recommendation_rules.can_user_make_f680_recommendation(request, case)
+    def test_can_user_make_f680_recommendation_request_missing_attributes(
+        self, mock_gov_user, data_fake_queue, data_unassigned_case
+    ):
+        case = data_unassigned_case
+        request = None
 
+        assert not recommendation_rules.can_user_make_f680_recommendation(request, case)
 
-def test_can_user_make_f680_recommendation_user_not_allocated(mock_gov_user, data_fake_queue, data_unassigned_case):
-    case = data_unassigned_case
-    request = get_mock_request(mock_gov_user["user"], data_fake_queue)
+    def test_can_user_make_f680_recommendation_user_not_allocated(
+        self, mock_gov_user, data_fake_queue, data_unassigned_case
+    ):
+        case = data_unassigned_case
+        request = get_mock_request(mock_gov_user["user"], data_fake_queue)
 
-    assert not rules.test_rule("can_user_make_f680_recommendation", request, case)
+        assert not rules.test_rule("can_user_make_f680_recommendation", request, case)
 
+    @mock.patch("caseworker.f680.rules.recommendations_by_current_user")
+    def test_can_user_make_f680_recommendation_user_allocated_existing_recommendation(
+        self, mock_get_my_recommendation, mock_gov_user, data_fake_queue, data_assigned_case
+    ):
+        mock_get_my_recommendation.return_value = True
+        request = get_mock_request(mock_gov_user["user"], data_fake_queue)
+        assert not rules.test_rule("can_user_make_f680_recommendation", request, data_assigned_case)
 
-@mock.patch("caseworker.f680.rules.recommendations_by_current_user")
-def test_can_user_make_f680_recommendation_user_allocated_existing_recommendation(
-    mock_get_my_recommendation, mock_gov_user, data_fake_queue, data_assigned_case
-):
-    mock_get_my_recommendation.return_value = True
-    request = get_mock_request(mock_gov_user["user"], data_fake_queue)
-    assert not rules.test_rule("can_user_make_f680_recommendation", request, data_assigned_case)
+    @mock.patch("caseworker.f680.rules.recommendations_by_current_user")
+    def test_can_user_make_f680_recommendation_user_allocated_incorrect_case_status(
+        self, mock_get_my_recommendation, mock_gov_user, data_fake_queue, data_assigned_case
+    ):
+        mock_get_my_recommendation.return_value = True
+        request = get_allocated_request_user(mock_gov_user, data_fake_queue)
+        assert not rules.test_rule("can_user_make_f680_recommendation", request, data_assigned_case)
 
+    @mock.patch("caseworker.f680.rules.recommendations_by_current_user")
+    def test_can_user_make_f680_recommendation_user_allocated(
+        self, mock_get_my_recommendation, mock_gov_user, data_fake_queue, data_assigned_case
+    ):
+        mock_get_my_recommendation.return_value = False
+        data_assigned_case.data["status"]["key"] = CaseStatusEnum.OGD_ADVICE
 
-@mock.patch("caseworker.f680.rules.recommendations_by_current_user")
-def test_can_user_make_f680_recommendation_user_allocated_incorrect_case_status(
-    mock_get_my_recommendation, mock_gov_user, data_fake_queue, data_assigned_case
-):
-    mock_get_my_recommendation.return_value = True
-    request = get_allocated_request_user(mock_gov_user, data_fake_queue)
-    assert not rules.test_rule("can_user_make_f680_recommendation", request, data_assigned_case)
-
-
-@mock.patch("caseworker.f680.rules.recommendations_by_current_user")
-def test_can_user_make_f680_recommendation_user_allocated(
-    mock_get_my_recommendation, mock_gov_user, data_fake_queue, data_assigned_case
-):
-    mock_get_my_recommendation.return_value = False
-    data_assigned_case.data["status"]["key"] = CaseStatusEnum.OGD_ADVICE
-
-    request = get_allocated_request_user(mock_gov_user, data_fake_queue)
-    assert rules.test_rule("can_user_make_f680_recommendation", request, data_assigned_case)
-
-
-def test_can_user_move_f680_case_forward_request_missing_attributes(
-    mock_gov_user, data_fake_queue, data_unassigned_case
-):
-    case = data_unassigned_case
-    request = None
-
-    assert not recommendation_rules.f680_case_ready_for_move(request, case)
+        request = get_allocated_request_user(mock_gov_user, data_fake_queue)
+        assert rules.test_rule("can_user_make_f680_recommendation", request, data_assigned_case)
 
 
-def test_can_user_move_f680_case_forward_user_not_allocated_denied(
-    mock_gov_user, data_fake_queue, data_unassigned_case
-):
-    case = data_unassigned_case
-    request = get_mock_request(mock_gov_user["user"], data_fake_queue)
+class TestCanUserMoveF680CaseForwardRule:
 
-    assert not rules.test_rule("can_user_move_f680_case_forward", request, case)
+    def test_can_user_move_f680_case_forward_request_missing_attributes(
+        self, mock_gov_user, data_fake_queue, data_unassigned_case
+    ):
+        case = data_unassigned_case
+        request = None
 
+        assert not recommendation_rules.f680_case_ready_for_move(request, case)
 
-def test_can_user_move_f680_case_forward_user_allocated_wrong_status_denied(
-    mock_gov_user, data_fake_queue, data_assigned_case
-):
-    case = data_assigned_case
-    request = get_allocated_request_user(mock_gov_user, data_fake_queue)
-    case.data["status"]["key"] = CaseStatusEnum.UNDER_FINAL_REVIEW
+    def test_can_user_move_f680_case_forward_user_not_allocated_denied(
+        self, mock_gov_user, data_fake_queue, data_unassigned_case
+    ):
+        case = data_unassigned_case
+        request = get_mock_request(mock_gov_user["user"], data_fake_queue)
 
-    assert not rules.test_rule("can_user_move_f680_case_forward", request, case)
+        assert not rules.test_rule("can_user_move_f680_case_forward", request, case)
 
+    def test_can_user_move_f680_case_forward_user_allocated_wrong_status_denied(
+        self, mock_gov_user, data_fake_queue, data_assigned_case
+    ):
+        case = data_assigned_case
+        request = get_allocated_request_user(mock_gov_user, data_fake_queue)
+        case.data["status"]["key"] = CaseStatusEnum.UNDER_FINAL_REVIEW
 
-def test_can_user_move_f680_case_forward_informational_status_granted(
-    mock_gov_user, data_fake_queue, data_assigned_case
-):
-    case = data_assigned_case
-    case.data["status"]["key"] = CaseStatusEnum.SUBMITTED
-    request = get_allocated_request_user(mock_gov_user, data_fake_queue)
+        assert not rules.test_rule("can_user_move_f680_case_forward", request, case)
 
-    assert rules.test_rule("can_user_move_f680_case_forward", request, case)
+    def test_can_user_move_f680_case_forward_informational_status_granted(
+        self, mock_gov_user, data_fake_queue, data_assigned_case
+    ):
+        case = data_assigned_case
+        case.data["status"]["key"] = CaseStatusEnum.SUBMITTED
+        request = get_allocated_request_user(mock_gov_user, data_fake_queue)
 
+        assert rules.test_rule("can_user_move_f680_case_forward", request, case)
 
-@mock.patch("caseworker.f680.rules.get_case_recommendations")
-def test_can_user_move_f680_case_forward_recommendation_status_no_recommendation_denied(
-    mock_case_recommendations, mock_gov_user, data_fake_queue, data_assigned_case
-):
-    mock_case_recommendations.return_value = []
-    case = data_assigned_case
-    data_assigned_case.data["status"]["key"] = CaseStatusEnum.OGD_ADVICE
-    request = get_allocated_request_user(mock_gov_user, data_fake_queue)
+    @mock.patch("caseworker.f680.rules.get_case_recommendations")
+    def test_can_user_move_f680_case_forward_recommendation_status_no_recommendation_denied(
+        self, mock_case_recommendations, mock_gov_user, data_fake_queue, data_assigned_case
+    ):
+        mock_case_recommendations.return_value = []
+        case = data_assigned_case
+        data_assigned_case.data["status"]["key"] = CaseStatusEnum.OGD_ADVICE
+        request = get_allocated_request_user(mock_gov_user, data_fake_queue)
 
-    assert not rules.test_rule("can_user_move_f680_case_forward", request, case)
+        assert not rules.test_rule("can_user_move_f680_case_forward", request, case)
 
+    @pytest.mark.parametrize(
+        "team",
+        (
+            {"id": MOD_CAPPROT_TEAM, "alias": services.MOD_CAPPROT_TEAM},
+            {"id": MOD_DSR_TEAM, "alias": services.MOD_DSR_TEAM},
+        ),
+    )
+    @mock.patch("caseworker.f680.rules.get_case_recommendations")
+    def test_can_user_move_f680_case_forward_recommendation_status_granted(
+        self, mock_case_recommendations, team, mock_gov_user, data_fake_queue, data_assigned_case
+    ):
+        mock_case_recommendations.return_value = [{"type": "approve", "team": team}]
+        case = data_assigned_case
+        data_assigned_case.data["status"]["key"] = CaseStatusEnum.OGD_ADVICE
+        request = get_allocated_request_user(mock_gov_user, data_fake_queue, team=team)
 
-@pytest.mark.parametrize(
-    "team",
-    (
-        {"id": MOD_CAPPROT_TEAM, "alias": services.MOD_CAPPROT_TEAM},
-        {"id": MOD_DSR_TEAM, "alias": services.MOD_DSR_TEAM},
-    ),
-)
-@mock.patch("caseworker.f680.rules.get_case_recommendations")
-def test_can_user_move_f680_case_forward_recommendation_status_granted(
-    mock_case_recommendations, team, mock_gov_user, data_fake_queue, data_assigned_case
-):
-    mock_case_recommendations.return_value = [{"type": "approve", "team": team}]
-    case = data_assigned_case
-    data_assigned_case.data["status"]["key"] = CaseStatusEnum.OGD_ADVICE
-    request = get_allocated_request_user(mock_gov_user, data_fake_queue, team=team)
+        assert rules.test_rule("can_user_move_f680_case_forward", request, case)
 
-    assert rules.test_rule("can_user_move_f680_case_forward", request, case)
+    @mock.patch("caseworker.f680.rules.get_case_recommendations")
+    def test_can_user_move_f680_case_forward_recommendation_status_mod_ecju_granted(
+        self, mock_case_recommendations, mock_gov_user, data_fake_queue, data_assigned_case
+    ):
+        mock_case_recommendations.return_value = []
+        case = data_assigned_case
+        team = {"id": MOD_ECJU, "alias": services.MOD_ECJU_TEAM}
+        data_assigned_case.data["status"]["key"] = CaseStatusEnum.OGD_ADVICE
+        request = get_allocated_request_user(mock_gov_user, data_fake_queue, team=team)
 
-
-@mock.patch("caseworker.f680.rules.get_case_recommendations")
-def test_can_user_move_f680_case_forward_recommendation_status_mod_ecju_granted(
-    mock_case_recommendations, mock_gov_user, data_fake_queue, data_assigned_case
-):
-    mock_case_recommendations.return_value = []
-    case = data_assigned_case
-    team = {"id": MOD_ECJU, "alias": services.MOD_ECJU_TEAM}
-    data_assigned_case.data["status"]["key"] = CaseStatusEnum.OGD_ADVICE
-    request = get_allocated_request_user(mock_gov_user, data_fake_queue, team=team)
-
-    assert rules.test_rule("can_user_move_f680_case_forward", request, case)
-
-
-def test_can_user_make_f680_outcome_user_not_allocated(mock_gov_user, data_fake_queue, data_unassigned_case):
-    case = data_unassigned_case
-    request = get_mock_request(mock_gov_user["user"], data_fake_queue)
-
-    assert not rules.test_rule("can_user_make_f680_outcome", request, case)
+        assert rules.test_rule("can_user_move_f680_case_forward", request, case)
 
 
-def test_can_user_make_f680_outcome_user_allocated_wrong_status(mock_gov_user, data_fake_queue, data_assigned_case):
-    case = data_assigned_case
-    case.data["status"]["key"] = CaseStatusEnum.SUBMITTED
-    request = get_allocated_request_user(mock_gov_user, data_fake_queue)
+class TestCanUserMakeF680OutcomeRule:
+    def test_can_user_make_f680_outcome_user_not_allocated(self, mock_gov_user, data_fake_queue, data_unassigned_case):
+        case = data_unassigned_case
+        request = get_mock_request(mock_gov_user["user"], data_fake_queue)
 
-    assert not rules.test_rule("can_user_make_f680_outcome", request, case)
+        assert not rules.test_rule("can_user_make_f680_outcome", request, case)
 
+    def test_can_user_make_f680_outcome_user_allocated_wrong_status(
+        self, mock_gov_user, data_fake_queue, data_assigned_case
+    ):
+        case = data_assigned_case
+        case.data["status"]["key"] = CaseStatusEnum.SUBMITTED
+        request = get_allocated_request_user(mock_gov_user, data_fake_queue)
 
-def test_can_user_make_f680_outcome_permission_granted(mock_gov_user, data_fake_queue, data_assigned_case):
-    case = data_assigned_case
-    case.data["status"]["key"] = CaseStatusEnum.UNDER_FINAL_REVIEW
-    request = get_allocated_request_user(mock_gov_user, data_fake_queue)
+        assert not rules.test_rule("can_user_make_f680_outcome", request, case)
 
-    assert rules.test_rule("can_user_make_f680_outcome", request, case)
+    def test_can_user_make_f680_outcome_permission_granted(self, mock_gov_user, data_fake_queue, data_assigned_case):
+        case = data_assigned_case
+        case.data["status"]["key"] = CaseStatusEnum.UNDER_FINAL_REVIEW
+        request = get_allocated_request_user(mock_gov_user, data_fake_queue)
 
+        assert rules.test_rule("can_user_make_f680_outcome", request, case)
 
-def test_can_user_make_f680_outcome_request_missing_attributes(mock_gov_user, data_fake_queue, data_unassigned_case):
-    case = data_unassigned_case
-    request = None
+    def test_can_user_make_f680_outcome_request_missing_attributes(
+        self, mock_gov_user, data_fake_queue, data_unassigned_case
+    ):
+        case = data_unassigned_case
+        request = None
 
-    assert not recommendation_rules.case_ready_for_outcome(request, case)
+        assert not recommendation_rules.case_ready_for_outcome(request, case)
 
 
 class TestClearF680RecommendationRule:

--- a/caseworker/f680/tests/test_views.py
+++ b/caseworker/f680/tests/test_views.py
@@ -37,6 +37,8 @@ def mock_put_assigned_queues(f680_case_id, requests_mock, data_queue):
     return requests_mock.put(
         client._build_absolute_uri(f"/cases/{f680_case_id}/assigned-queues/"), json={"queues": [queue_pk]}
     )
+
+
 @pytest.fixture
 def mock_case_sub_statuses(requests_mock, data_submitted_f680_case):
     url = f"/applications/{data_submitted_f680_case['case']['id']}/sub-statuses/"
@@ -93,9 +95,7 @@ class TestCaseDetailView:
         expected,
     ):
         data_submitted_f680_case["case"]["data"]["status"]["key"] = case_status
-        data_submitted_f680_case["case"]["assigned_users"] = {
-            queue_f680_cases_to_review["name"]: [current_user]
-        }
+        data_submitted_f680_case["case"]["assigned_users"] = {queue_f680_cases_to_review["name"]: [current_user]}
         url = reverse("cases:f680:details", kwargs={"queue_pk": data_queue["id"], "pk": f680_case_id})
         response = authorized_client.get(url)
         assert response.status_code == 200


### PR DESCRIPTION
## Change description

Users are only allowed to make recommendations if the case is in the correct status otherwise switching to this tab raises an exception.

Recommendation tab is hidden if it is not applicable for the given case status. Add unit tests for this.
Group rules unit tests under different classes.

[LTD-](https://uktrade.atlassian.net/browse/LTD-)
