### PR TITLE
Fix displaying duplicated ultimate end users

### DIFF
--- a/caseworker/advice/templates/advice/advice_details.html
+++ b/caseworker/advice/templates/advice/advice_details.html
@@ -28,56 +28,60 @@
     <tbody class="govuk-table__body">
         {% for item in advice %}
             {% if item.consignee %}
-            {% with consignee=case.data.consignee %}
-            <tr class="govuk-table__row">
-                <td class="govuk-table__cell">{{ consignee.country.name }}</td>
-                <td class="govuk-table__cell">{{ consignee.type_display_value }}</td>
-                <td class="govuk-table__cell">{{ consignee.name }}</td>
-                <td class="govuk-table__cell">All</td>
-                {% if decision == 'refuse' %}
-                <td class="govuk-table__cell">{{ item.denial_reasons|get_denial_reason_display_values:denial_reasons_display}}</td>
-				{% endif %}
-            </tr>
-            {% endwith %}
+                {% with consignee=case.data.consignee %}
+                    <tr class="govuk-table__row">
+                        <td class="govuk-table__cell">{{ consignee.country.name }}</td>
+                        <td class="govuk-table__cell">{{ consignee.type_display_value }}</td>
+                        <td class="govuk-table__cell">{{ consignee.name }}</td>
+                        <td class="govuk-table__cell">All</td>
+                        {% if decision == 'refuse' %}
+                            <td class="govuk-table__cell">{{ item.denial_reasons|get_denial_reason_display_values:denial_reasons_display}}</td>
+                        {% endif %}
+                    </tr>
+                {% endwith %}
             {% endif %}
             {% if item.end_user %}
-            {% with end_user=case.data.end_user %}
-            <tr class="govuk-table__row">
-                <td class="govuk-table__cell">{{ end_user.country.name }}</td>
-                <td class="govuk-table__cell">{{ end_user.type_display_value }}</td>
-                <td class="govuk-table__cell">{{ end_user.name }}</td>
-                <td class="govuk-table__cell">All</td>
-                {% if decision == 'refuse' %}
-                <td class="govuk-table__cell">{{ item.denial_reasons|get_denial_reason_display_values:denial_reasons_display}}</td>
-				{% endif %}
-            </tr>
-            {% endwith %}
+                {% with end_user=case.data.end_user %}
+                    <tr class="govuk-table__row">
+                        <td class="govuk-table__cell">{{ end_user.country.name }}</td>
+                        <td class="govuk-table__cell">{{ end_user.type_display_value }}</td>
+                        <td class="govuk-table__cell">{{ end_user.name }}</td>
+                        <td class="govuk-table__cell">All</td>
+                        {% if decision == 'refuse' %}
+                            <td class="govuk-table__cell">{{ item.denial_reasons|get_denial_reason_display_values:denial_reasons_display}}</td>
+                        {% endif %}
+                    </tr>
+                {% endwith %}
             {% endif %}
             {% if item.third_party %}
-            {% for third_party in case.data.third_parties|get_third_party:item.third_party %}
-            <tr class="govuk-table__row">
-                <td class="govuk-table__cell">{{ third_party.country.name }}</td>
-                <td class="govuk-table__cell">{{ third_party.type_display_value }}</td>
-                <td class="govuk-table__cell">{{ third_party.name }}</td>
-                <td class="govuk-table__cell">All</td>
-                {% if decision == 'refuse' %}
-                <td class="govuk-table__cell">{{ item.denial_reasons|get_denial_reason_display_values:denial_reasons_display}}</td>
-                {% endif %}
-            </tr>
-            {% endfor %}
+                {% for third_party in case.data.third_parties %}
+                    {% if item.third_party == third_party.id %}
+                        <tr class="govuk-table__row">
+                            <td class="govuk-table__cell">{{ third_party.country.name }}</td>
+                            <td class="govuk-table__cell">{{ third_party.type_display_value }}</td>
+                            <td class="govuk-table__cell">{{ third_party.name }}</td>
+                            <td class="govuk-table__cell">All</td>
+                            {% if decision == 'refuse' %}
+                                <td class="govuk-table__cell">{{ item.denial_reasons|get_denial_reason_display_values:denial_reasons_display}}</td>
+                            {% endif %}
+                        </tr>
+                    {% endif %}
+                {% endfor %}
             {% endif %}
             {% if item.ultimate_end_user %}
-            {% for ultimate_end_user in case.data.ultimate_end_users %}
-            <tr class="govuk-table__row">
-                <td class="govuk-table__cell">{{ ultimate_end_user.country.name }}</td>
-                <td class="govuk-table__cell">{{ ultimate_end_user.type_display_value }}</td>
-                <td class="govuk-table__cell">{{ ultimate_end_user.name }}</td>
-                <td class="govuk-table__cell">All</td>
-                {% if decision == 'refuse' %}
-                <td class="govuk-table__cell">{{ item.denial_reasons|get_denial_reason_display_values:denial_reasons_display}}</td>
-                {% endif %}
-            </tr>
-            {% endfor %}
+                {% for ultimate_end_user in case.data.ultimate_end_users %}
+                    {% if item.ultimate_end_user == ultimate_end_user.id %}
+                        <tr class="govuk-table__row">
+                            <td class="govuk-table__cell">{{ ultimate_end_user.country.name }}</td>
+                            <td class="govuk-table__cell">{{ ultimate_end_user.type_display_value }}</td>
+                            <td class="govuk-table__cell">{{ ultimate_end_user.name }}</td>
+                            <td class="govuk-table__cell">All</td>
+                            {% if decision == 'refuse' %}
+                                <td class="govuk-table__cell">{{ item.denial_reasons|get_denial_reason_display_values:denial_reasons_display}}</td>
+                            {% endif %}
+                        </tr>
+                    {% endif %}
+                {% endfor %}
             {% endif %}
         {% endfor %}
     </tbody>

--- a/caseworker/advice/templatetags/advice_tags.py
+++ b/caseworker/advice/templatetags/advice_tags.py
@@ -113,11 +113,6 @@ def countersignatures_for_advice(case, advice):
     ]
 
 
-@register.filter
-def get_third_party(third_parties, id):
-    return [party for party in third_parties if party["id"] == id]
-
-
 @register.inclusion_tag("advice/group-advice.html", takes_context=True)
 def group_advice(context):
     grouped_advice = []

--- a/unit_tests/caseworker/advice/views/test_consolidate.py
+++ b/unit_tests/caseworker/advice/views/test_consolidate.py
@@ -19,6 +19,7 @@ from caseworker.advice.services import (
 )
 from core import client
 from unit_tests.caseworker.conftest import countersignatures_for_advice
+from unit_tests.helpers import get_rows
 
 
 @pytest.fixture
@@ -392,19 +393,10 @@ def test_view_consolidate_approve_outcome(
     table = soup.find("table", id="table-licenceable-products")
     assert [th.text for th in table.find_all("th")] == ["Country", "Type", "Name", "Approved products"]
 
-    assert [td.text for td in table.find_all("td")] == [
-        "Abu Dhabi",
-        "Consignee",
-        "Consignee",
-        "All",
-        "United Kingdom",
-        "End-user",
-        "End User",
-        "All",
-        "United Kingdom",
-        "Third party",
-        "Third party",
-        "All",
+    assert get_rows(table) == [
+        ["Abu Dhabi", "Consignee", "Consignee", "All"],
+        ["United Kingdom", "End-user", "End User", "All"],
+        ["United Kingdom", "Third party", "Third party", "All"],
     ]
 
 
@@ -429,23 +421,10 @@ def test_view_consolidate_refuse_outcome(
         "Refused products",
         "Refusal criteria",
     ]
-
-    assert [td.text for td in table.find_all("td")] == [
-        "Abu Dhabi",
-        "Consignee",
-        "Consignee",
-        "All",
-        "five a, five b",
-        "United Kingdom",
-        "End-user",
-        "End User",
-        "All",
-        "five a, five b",
-        "United Kingdom",
-        "Third party",
-        "Third party",
-        "All",
-        "five a, five b",
+    assert get_rows(table) == [
+        ["Abu Dhabi", "Consignee", "Consignee", "All", "five a, five b"],
+        ["United Kingdom", "End-user", "End User", "All", "five a, five b"],
+        ["United Kingdom", "Third party", "Third party", "All", "five a, five b"],
     ]
 
 

--- a/unit_tests/helpers.py
+++ b/unit_tests/helpers.py
@@ -29,3 +29,13 @@ def merge_summaries(summary_1, summary_2):
     summary_2_dict = get_summary_dict(summary_2)
     combined_summary = {**summary_1_dict, **summary_2_dict}
     return tuple(combined_summary.values())
+
+
+def get_rows(table):
+    rows = []
+    for table_row in table.select("tbody .govuk-table__row"):
+        cells = []
+        for row_cell in table_row.select(".govuk-table__cell"):
+            cells.append(row_cell.text)
+        rows.append(cells)
+    return rows


### PR DESCRIPTION
### Aim

This fixes an issue where parties were displayed multiple times on the countersign page for advice that was given previously.

[LTD-6060](https://uktrade.atlassian.net/browse/LTD-6060)


[LTD-6060]: https://uktrade.atlassian.net/browse/LTD-6060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ