### PR TITLE
Handle additional edge cases for address formatting

### DIFF
--- a/core/builtins/custom_tags.py
+++ b/core/builtins/custom_tags.py
@@ -232,37 +232,49 @@ def get_address(data):
     from {'address': {'address_line_1': '10 Downing St', ...}
     or {'address': '10 Downing St ...', 'country': {'name': United Kingdom'}}
     """
-    if data and "address" in data:
-        address = data["address"]
-        country = data.get("country")
+    if not data:
+        return ""
 
-        if "country" in address:
-            country = address.get("country")
+    if not isinstance(data, dict):
+        return ""
 
-        if isinstance(address, str):
-            if country:
-                return address + ", " + country["name"]
-            else:
-                return address
+    if "address" not in data:
+        return ""
 
-        if "address_line_1" in address:
-            address = [
-                address["address_line_1"],
-                address["address_line_2"],
-                address["city"],
-                address["region"],
-                address["postcode"],
-            ]
-        else:
-            address = [
-                address["address"],
-            ]
+    country = data.get("country")
+    address = data["address"]
 
-        if country:
-            address.append(country["name"])
+    if isinstance(address, str) and not country:
+        return address
 
-        return ", ".join([x for x in address if x])
-    return ""
+    if isinstance(address, str) and country:
+        return f"{address}, {country['name']}"
+
+    if not isinstance(address, dict):
+        return ""
+
+    if not address:
+        return ""
+
+    if "country" in address:
+        country = address["country"]
+
+    if "address" in address:
+        address_parts_keys = ["address"]
+    else:
+        address_parts_keys = [
+            "address_line_1",
+            "address_line_2",
+            "city",
+            "region",
+            "postcode",
+        ]
+
+    address_parts = [address[k] for k in address_parts_keys]
+    if country:
+        address_parts.append(country["name"])
+
+    return ", ".join(address_part for address_part in address_parts if address_part)
 
 
 @register.filter()

--- a/unit_tests/core/builtins/test_custom_tags.py
+++ b/unit_tests/core/builtins/test_custom_tags.py
@@ -230,6 +230,14 @@ def test_subtract(num1, num2, expected):
 @pytest.mark.parametrize(
     "data,expected",
     [
+        ({}, ""),
+        (12345, ""),
+        ([], ""),
+        ({"no_address_key": "not an address"}, ""),
+        ("not a dict", ""),
+        ("not a dict with the word address in it", ""),
+        ({"address": []}, ""),
+        ({"address": {}}, ""),
         (
             {
                 "address": {
@@ -244,6 +252,17 @@ def test_subtract(num1, num2, expected):
             "42, Bakers street, San Jose, California, 42551, US",
         ),
         (
+            {"address": {"address": "42, Bakers street, San Jose, California, 42551, US"}},
+            "42, Bakers street, San Jose, California, 42551, US",
+        ),
+        (
+            {
+                "address": {"address": "42, Bakers street, San Jose, California, 42551"},
+                "country": {"name": "United States"},
+            },
+            "42, Bakers street, San Jose, California, 42551, United States",
+        ),
+        (
             {"address": "54, Bakers street, San Diego, California, 42551", "country": {"name": "United States"}},
             "54, Bakers street, San Diego, California, 42551, United States",
         ),
@@ -252,6 +271,12 @@ def test_subtract(num1, num2, expected):
                 "address": "54, Bakers street, San Diego, California, 42551",
             },
             "54, Bakers street, San Diego, California, 42551",
+        ),
+        (
+            {
+                "address": "this address has the word country in it",
+            },
+            "this address has the word country in it",
         ),
     ],
 )


### PR DESCRIPTION
### Aim

Stop errors when someone has put the word "country" in the address field itself.

This was failing as there was an `in` lookup that assumed that the variable was always a dict but could have just been a string with the word "country" in it.

This resolves this and any other edge cases I could think of.

Ideally we should have a single format for addresses that everything adheres to instead of having a function that tries to handle a multitude of cases, but for this specific fix I chose just to fix it in this particular template tag.

[LTD-6082](https://uktrade.atlassian.net/browse/LTD-6082)


[LTD-6082]: https://uktrade.atlassian.net/browse/LTD-6082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ