### PR TITLE
LTD-6094: Display recommendations tab for all case statuses

### DIFF
--- a/caseworker/f680/templates/f680/case/base.html
+++ b/caseworker/f680/templates/f680/case/base.html
@@ -11,12 +11,9 @@
             <a id="application-details" href="{% url 'cases:f680:details' queue_pk case.id %}" class="lite-tabs__tab {% if current_tab == "application-details" %}lite-tabs__tab--selected{% endif %}">
                 Application Details
             </a>
-            {% test_rule 'is_user_allowed_to_make_f680_recommendation' request case as is_user_allowed_to_make_f680_recommendation %}
-            {% if is_user_allowed_to_make_f680_recommendation %}
-                <a id="recommendations" href="{% url 'cases:f680:recommendation' queue_pk case.id %}" class="lite-tabs__tab {% if current_tab == "recommendations" %}lite-tabs__tab--selected{% endif %}">
-                    Recommendations
-                </a>
-            {% endif %}
+            <a id="recommendations" href="{% url 'cases:f680:recommendation' queue_pk case.id %}" class="lite-tabs__tab {% if current_tab == "recommendations" %}lite-tabs__tab--selected{% endif %}">
+                Recommendations
+            </a>
             <a id="notes-and-timeline" href="{% url 'cases:f680:notes_and_timeline' queue_pk case.id %}" class="lite-tabs__tab {% if current_tab == "notes-and-timeline" %}lite-tabs__tab--selected{% endif %}">
                 Notes and timeline
             </a>

--- a/caseworker/f680/templates/f680/case/recommendation/includes/case_details.html
+++ b/caseworker/f680/templates/f680/case/recommendation/includes/case_details.html
@@ -1,63 +1,91 @@
-{% load static advice_tags %}
-
-    {% with product=case.data.product %}
-        <h2 class="govuk-heading-m">Case details</h2>
-        <details class="govuk-details" data-module="govuk-details">
-          <summary class="govuk-details__summary">
-              <span class="govuk-details__summary-text">Products</span>
-          </summary>
-          <div class="govuk-details__text">
+{% with product=case.data.product %}
+    <h2 class="govuk-heading-m">Case details</h2>
+    <details class="govuk-details" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">Products</span>
+        </summary>
+        <div class="govuk-details__text">
             <table id="table-nlr-products" class="govuk-table">
-              <tbody class="govuk-table__body">
-                <tr class="govuk-table__row">
-                  <td class="govuk-table__cell govuk-!-font-weight-bold">Name</td>
-                  <td class="govuk-table__cell">
-                    {{ product.name}}
-                </td>
-                </tr>
-                <tr class="govuk-table__row">
-                    <td class="govuk-table__cell govuk-!-font-weight-bold">Description</td>
-                    <td class="govuk-table__cell">
-                      {{ product.description }}
-                  </td>
-                  </tr>
+                <tbody class="govuk-table__body">
+                    <tr class="govuk-table__row">
+                        <td class="govuk-table__cell govuk-!-font-weight-bold">Name</td>
+                        <td class="govuk-table__cell">
+                            {{ product.name}}
+                        </td>
+                    </tr>
+                    <tr class="govuk-table__row">
+                        <td class="govuk-table__cell govuk-!-font-weight-bold">Description</td>
+                        <td class="govuk-table__cell">
+                            {{ product.description }}
+                        </td>
+                    </tr>
                 </tbody>
             </table>
-          </div>
-        </details>
+        </div>
+    </details>
 
-        <details class="govuk-details" data-module="govuk-details">
-          <summary class="govuk-details__summary">
+    <details class="govuk-details" data-module="govuk-details">
+        <summary class="govuk-details__summary">
             <span class="govuk-details__summary-text">Destinations</span>
-          </summary>
-          <div class="govuk-details__text">
-            <table id="table-nlr-products" class="govuk-table">
-              <thead class="govuk-table__head">
-                <tr class="govuk-table__row">
-                  <th scope="col" class="govuk-table__header">Country</th>
-                  <th scope="col" class="govuk-table__header">Type</th>
-                  <th scope="col" class="govuk-table__header">Name</th>
-                  <th scope="col" class="govuk-table__header">Security grading</th>
-                </tr>
-              </thead>
-              <tbody class="govuk-table__body">
-                {% for rr in security_release_requests %}
-                <tr class="govuk-table__row">
-                  <td class="govuk-table__cell">
-                    <strong>{{ rr.recipient.country.name }}</strong><br>
-                    <ol>
-                      {% for item in rr.approval_types %}
-                          <li>{{ item }}</li>
-                      {% endfor %}
-                    </ol>
-                  </td>
-                  <td class="govuk-table__cell">{{ rr.recipient.type.value }}</td>
-                  <td class="govuk-table__cell">{{ rr.recipient.name }}</td>
-                  <td class="govuk-table__cell">{{ rr.security_grading.value }}</td>
-                </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          </div>
-        </details>
-    {% endwith %}
+        </summary>
+        <div class="govuk-details__text">
+            {% for release_request in security_release_requests %}
+                <div class="govuk-summary-card">
+                    <div class="govuk-summary-card__title-wrapper">
+                        <h2 class="govuk-summary-card__title">
+                            {{ release_request.recipient.country.name }}
+                        </h2>
+                    </div>
+                    <div class="govuk-summary-card__content">
+                        <dl class="govuk-summary-list">
+                          <div class="govuk-summary-list__row">
+                              <dt class="govuk-summary-list__key">
+                                  Name
+                              </dt>
+                              <dd class="govuk-summary-list__value">
+                                  {{ release_request.recipient.name }}
+                              </dd>
+                          </div>
+                          <div class="govuk-summary-list__row">
+                              <dt class="govuk-summary-list__key">
+                                  Type
+                              </dt>
+                              <dd class="govuk-summary-list__value">
+                                  {{ release_request.recipient.type.value }}
+                              </dd>
+                          </div>
+                          <div class="govuk-summary-list__row">
+                              <dt class="govuk-summary-list__key">
+                                  Security grading
+                              </dt>
+                              <dd class="govuk-summary-list__value">
+                                  {{ release_request.security_grading.value }}
+                              </dd>
+                          </div>
+                          <div class="govuk-summary-list__row">
+                              <dt class="govuk-summary-list__key">
+                                  Approval types
+                              </dt>
+                              <dd class="govuk-summary-list__value">
+                                  <ol>
+                                      {% for item in release_request.approval_types %}
+                                          <li>{{ item }}</li>
+                                      {% endfor %}
+                                  </ol>
+                              </dd>
+                          </div>
+                          <div class="govuk-summary-list__row">
+                              <dt class="govuk-summary-list__key">
+                                  Intended use
+                              </dt>
+                              <dd class="govuk-summary-list__value">
+                                  {{ release_request.intended_use }}
+                              </dd>
+                          </div>
+                        </dl>
+                      </div>
+                  </div>
+            {% endfor %}
+        </div>
+    </details>
+{% endwith %}

--- a/caseworker/f680/tests/test_views.py
+++ b/caseworker/f680/tests/test_views.py
@@ -1,6 +1,5 @@
 import pytest
 
-from itertools import chain
 from requests.exceptions import HTTPError
 
 from bs4 import BeautifulSoup
@@ -104,13 +103,11 @@ class TestCaseDetailView:
         assert "some name" in table_text
 
     @pytest.mark.parametrize(
-        "case_status, expected",
+        "case_status",
         (
-            chain(
-                ((status, False) for status in recommendation_rules.INFORMATIONAL_STATUSES),
-                ((status, True) for status in recommendation_rules.RECOMMENDATION_STATUSES),
-                ((status, True) for status in recommendation_rules.OUTCOME_STATUSES),
-            )
+            recommendation_rules.INFORMATIONAL_STATUSES
+            + recommendation_rules.RECOMMENDATION_STATUSES
+            + recommendation_rules.OUTCOME_STATUSES
         ),
     )
     def test_GET_case_recommendation_tab_status(
@@ -125,7 +122,6 @@ class TestCaseDetailView:
         queue_f680_cases_to_review,
         current_user,
         case_status,
-        expected,
     ):
         data_submitted_f680_case["case"]["data"]["status"]["key"] = case_status
         data_submitted_f680_case["case"]["assigned_users"] = {queue_f680_cases_to_review["name"]: [current_user]}
@@ -135,7 +131,7 @@ class TestCaseDetailView:
 
         soup = BeautifulSoup(response.content, "html.parser")
         recommendations_tab = soup.find(id="recommendations")
-        assert bool(recommendations_tab) is expected
+        assert bool(recommendations_tab) is True
 
     def test_GET_success_transformed_submitted_by(
         self,


### PR DESCRIPTION
## Change description

It was hidden when the status is submitted as they don't really make recommendations but this behaviour is inconsistent.

Update case details in side panel to include `intended_use`


[LTD-6094](https://uktrade.atlassian.net/browse/LTD-6094)


[LTD-6094]: https://uktrade.atlassian.net/browse/LTD-6094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ