### PR TITLE
[LTD-6073] F680 outcomes success message

### DIFF
--- a/caseworker/f680/conftest.py
+++ b/caseworker/f680/conftest.py
@@ -69,6 +69,23 @@ def mock_outcomes_single_outcome(requests_mock, data_outcomes, data_submitted_f6
 
 
 @pytest.fixture
+def mock_outcomes_no_outcome(requests_mock, data_submitted_f680_case):
+    url = f"/caseworker/f680/{data_submitted_f680_case['case']['id']}/outcome/"
+    return requests_mock.get(url, json=[], status_code=200)
+
+
+@pytest.fixture
+def mock_outcomes_complete(requests_mock, data_outcomes, data_submitted_f680_case):
+    security_release_request_ids = [
+        release_request["id"]
+        for release_request in data_submitted_f680_case["case"]["data"]["security_release_requests"]
+    ]
+    data_outcomes[0]["security_release_requests"] = security_release_request_ids
+    url = f"/caseworker/f680/{data_submitted_f680_case['case']['id']}/outcome/"
+    return requests_mock.get(url, json=data_outcomes, status_code=200)
+
+
+@pytest.fixture
 def mock_f680_case_with_assigned_user(f680_case_id, requests_mock, data_submitted_f680_case, data_queue, mock_gov_user):
     data_submitted_f680_case["case"]["assigned_users"] = {data_queue["name"]: [mock_gov_user["user"]]}
     url = client._build_absolute_uri(f"/cases/{f680_case_id}/")

--- a/caseworker/f680/outcome/services.py
+++ b/caseworker/f680/outcome/services.py
@@ -26,3 +26,17 @@ def get_hydrated_outcomes(request, case):
         outcome["security_release_requests"] = release_requests
         outcomes.append(outcome)
     return outcomes, response.status_code
+
+
+def get_releases_with_no_outcome(request, existing_outcomes, case):
+    release_requests_with_outcome = set()
+    for outcome in existing_outcomes:
+        release_requests_with_outcome.update(outcome["security_release_requests"])
+    remaining_request_ids_without_outcome = set()
+    remaining_requests_without_outcome = []
+    for release_request in case.data["security_release_requests"]:
+        if release_request["id"] in release_requests_with_outcome:
+            continue
+        remaining_requests_without_outcome.append(release_request)
+        remaining_request_ids_without_outcome.add(release_request["id"])
+    return remaining_requests_without_outcome, remaining_request_ids_without_outcome

--- a/caseworker/f680/outcome/tests/test_views.py
+++ b/caseworker/f680/outcome/tests/test_views.py
@@ -394,12 +394,16 @@ class TestDecideOutcomeView:
                 "approval_types": ["training"],
                 "security_grading": "secret",
             },
+            follow=True,
         )
-        assert response.status_code == HTTPStatus.FOUND
-        assert response.url == reverse(
+        assert response.status_code == HTTPStatus.OK
+        assert response.redirect_chain[-1][0] == reverse(
             "cases:f680:recommendation",
             kwargs={"queue_pk": data_queue["id"], "pk": data_submitted_f680_case["case"]["id"]},
         )
+        messages = [str(msg) for msg in response.context["messages"]]
+        assert messages == ["Outcomes for 3 security releases saved successfully"]
+
         assert mock_POST_outcome.call_count == 1
         request = mock_POST_outcome.request_history.pop()
         assert request.json() == {
@@ -475,12 +479,15 @@ class TestDecideOutcomeView:
                 "approval_types": ["training"],
                 "security_grading": "secret",
             },
+            follow=True,
         )
-        assert response.status_code == HTTPStatus.FOUND
-        assert response.url == reverse(
+        assert response.status_code == HTTPStatus.OK
+        assert response.redirect_chain[-1][0] == reverse(
             "cases:f680:outcome:decide_outcome",
             kwargs={"queue_pk": data_queue["id"], "pk": data_submitted_f680_case["case"]["id"]},
         )
+        messages = [str(msg) for msg in response.context["messages"]]
+        assert messages == ["Outcome saved successfully"]
 
         assert mock_POST_outcome.call_count == 1
         request = mock_POST_outcome.request_history.pop()

--- a/caseworker/f680/rules.py
+++ b/caseworker/f680/rules.py
@@ -74,10 +74,6 @@ def f680_case_ready_for_move(request, case):
         if team_recommendations_exist:
             return True
 
-        # TODO: Remove this once we get stop the case going to MOD-ECJU Review and combine
-        if team["alias"] == "MOD_ECJU":
-            return True
-
     return False
 
 

--- a/caseworker/f680/tests/test_rules.py
+++ b/caseworker/f680/tests/test_rules.py
@@ -253,25 +253,6 @@ class TestCanUserMoveF680CaseForwardRule:
 
         assert rules.test_rule("can_user_move_f680_case_forward", request, case)
 
-    @mock.patch("caseworker.f680.rules.get_case_recommendations")
-    @mock.patch("caseworker.f680.rules.get_pending_recommendation_requests")
-    def test_can_user_move_f680_case_forward_recommendation_status_mod_ecju_granted(
-        self,
-        mock_get_pending_recommendations,
-        mock_case_recommendations,
-        mock_gov_user,
-        data_fake_queue,
-        data_assigned_case,
-    ):
-        mock_get_pending_recommendations.return_value = False
-        mock_case_recommendations.return_value = []
-        case = data_assigned_case
-        team = {"id": MOD_ECJU, "alias": services.MOD_ECJU_TEAM}
-        data_assigned_case.data["status"]["key"] = CaseStatusEnum.OGD_ADVICE
-        request = get_allocated_request_user(mock_gov_user, data_fake_queue, team=team)
-
-        assert rules.test_rule("can_user_move_f680_case_forward", request, case)
-
 
 class TestCanUserMakeF680OutcomeRule:
     def test_can_user_make_f680_outcome_user_not_allocated(self, mock_gov_user, data_fake_queue, data_unassigned_case):

--- a/caseworker/f680/tests/test_rules.py
+++ b/caseworker/f680/tests/test_rules.py
@@ -1,4 +1,5 @@
 import pytest
+import requests
 import rules
 
 from itertools import chain
@@ -49,6 +50,9 @@ def get_mock_request(user, queue):
     request = HttpRequest()
     request.lite_user = user
     request.queue = queue
+    # Must be added as client requests assume RequestsSessionMiddleware has run
+    request.requests_session = requests.Session()
+    request.session = {}
     return request
 
 
@@ -285,12 +289,23 @@ class TestCanUserMakeF680OutcomeRule:
 
         assert not rules.test_rule("can_user_make_f680_outcome", request, case)
 
-    def test_can_user_make_f680_outcome_permission_granted(self, mock_gov_user, data_fake_queue, data_assigned_case):
+    def test_can_user_make_f680_outcome_permission_granted(
+        self, mock_gov_user, data_fake_queue, data_assigned_case, mock_outcomes_no_outcome
+    ):
         case = data_assigned_case
         case.data["status"]["key"] = CaseStatusEnum.UNDER_FINAL_REVIEW
         request = get_allocated_request_user(mock_gov_user, data_fake_queue)
 
         assert rules.test_rule("can_user_make_f680_outcome", request, case)
+
+    def test_can_user_make_f680_outcome_existing_outcome_denied(
+        self, mock_gov_user, data_fake_queue, data_assigned_case, mock_outcomes_complete
+    ):
+        case = data_assigned_case
+        case.data["status"]["key"] = CaseStatusEnum.UNDER_FINAL_REVIEW
+        request = get_allocated_request_user(mock_gov_user, data_fake_queue)
+
+        assert not rules.test_rule("can_user_make_f680_outcome", request, case)
 
     def test_can_user_make_f680_outcome_request_missing_attributes(
         self, mock_gov_user, data_fake_queue, data_unassigned_case

--- a/caseworker/f680/tests/test_rules.py
+++ b/caseworker/f680/tests/test_rules.py
@@ -288,13 +288,21 @@ class TestCanUserMakeF680OutcomeRule:
 
         assert not rules.test_rule("can_user_make_f680_outcome", request, case)
 
-    def test_can_user_make_f680_outcome_request_missing_attributes(
+    def test_case_ready_for_outcome_request_missing_attributes(
         self, mock_gov_user, data_fake_queue, data_unassigned_case
     ):
         case = data_unassigned_case
         request = None
 
         assert not recommendation_rules.case_ready_for_outcome(request, case)
+
+    def test_releases_without_outcome_request_missing_attributes(
+        self, mock_gov_user, data_fake_queue, data_unassigned_case
+    ):
+        case = data_unassigned_case
+        request = None
+
+        assert not recommendation_rules.releases_without_outcome(request, case)
 
 
 class TestClearF680RecommendationRule:


### PR DESCRIPTION
### Aim

This change adds a success message when issuing outcomes.  The "Decide outcome" button permissions are also tightened, so that it will not show when outcomes for all security releases have been issued.

[LTD-6073](https://uktrade.atlassian.net/browse/LTD-6073)


[LTD-6073]: https://uktrade.atlassian.net/browse/LTD-6073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ