### PR TITLE
[LTD-6070] Add ability to clear F680 outcome records

### DIFF
--- a/caseworker/f680/conftest.py
+++ b/caseworker/f680/conftest.py
@@ -44,11 +44,16 @@ def mock_outcomes_no_outcomes(requests_mock, data_submitted_f680_case):
 
 
 @pytest.fixture
-def data_outcomes(current_user, admin_team, data_submitted_f680_case):
+def data_outcome_id():
+    return "429c5596-fe8b-4540-988b-c37805cd08de"  # /PS-IGNORE
+
+
+@pytest.fixture
+def data_outcomes(current_user, admin_team, data_submitted_f680_case, data_outcome_id):
     security_release_requests = data_submitted_f680_case["case"]["data"]["security_release_requests"]
     return [
         {
-            "id": "429c5596-fe8b-4540-988b-c37805cd08de",  # /PS-IGNORE
+            "id": data_outcome_id,
             "created_at": "2021-10-16T23:48:39.486679+01:00",
             "outcome": "approve",
             "conditions": "No concerns",

--- a/caseworker/f680/outcome/forms.py
+++ b/caseworker/f680/outcome/forms.py
@@ -54,8 +54,8 @@ class ApproveOutcomeForm(BaseForm):
     security_grading = forms.ChoiceField(
         choices=security_grading_choices,
         widget=forms.RadioSelect,
-        label="Select security grading",
-        error_messages={"required": "Select the security grading"},
+        label="Select security release",
+        error_messages={"required": "Select the security release"},
     )
     approval_types = forms.MultipleChoiceField(
         label="Approval types",

--- a/caseworker/f680/outcome/services.py
+++ b/caseworker/f680/outcome/services.py
@@ -1,3 +1,5 @@
+from json.decoder import JSONDecodeError
+
 from core import client
 
 
@@ -9,6 +11,15 @@ def post_outcome(request, case_id, data):
 def get_outcomes(request, case_id):
     response = client.get(request, f"/caseworker/f680/{case_id}/outcome/")
     return response.json(), response.status_code
+
+
+def delete_outcome(request, case_id, outcome_id):
+    response = client.delete(request, f"/caseworker/f680/{case_id}/outcome/{outcome_id}/")
+    try:
+        body = response.json()
+    except JSONDecodeError:
+        body = None
+    return body, response.status_code
 
 
 def get_hydrated_outcomes(request, case):

--- a/caseworker/f680/outcome/tests/test_views.py
+++ b/caseworker/f680/outcome/tests/test_views.py
@@ -465,7 +465,7 @@ class TestDecideOutcomeView:
         assert response.status_code == HTTPStatus.OK
         form = response.context["form"]
         assert form.errors == {
-            "security_grading": ["Select the security grading"],
+            "security_grading": ["Select the security release"],
             "approval_types": ["This field is required."],
         }
 

--- a/caseworker/f680/outcome/tests/test_views.py
+++ b/caseworker/f680/outcome/tests/test_views.py
@@ -3,9 +3,11 @@ from http import HTTPStatus
 
 from django.urls import reverse
 
+from core import client
+from core.exceptions import ServiceError
+
 from caseworker.f680.outcome.constants import OutcomeSteps
 from caseworker.f680.outcome import forms
-from core import client
 
 
 @pytest.fixture(autouse=True)
@@ -31,6 +33,14 @@ def decide_outcome_url(data_queue, f680_case_id):
 
 
 @pytest.fixture
+def clear_outcome_url(data_queue, f680_case_id, data_outcome_id):
+    return reverse(
+        "cases:f680:outcome:clear_outcome",
+        kwargs={"queue_pk": data_queue["id"], "pk": f680_case_id, "outcome_id": data_outcome_id},
+    )
+
+
+@pytest.fixture
 def post_to_step(post_to_step_factory, decide_outcome_url):
     return post_to_step_factory(decide_outcome_url)
 
@@ -53,6 +63,24 @@ def mock_outcomes_no_outcomes(requests_mock, data_submitted_f680_case):
 def mock_POST_outcome(requests_mock, data_submitted_f680_case):
     url = f"/caseworker/f680/{data_submitted_f680_case['case']['id']}/outcome/"
     return requests_mock.post(url, json={}, status_code=HTTPStatus.CREATED)
+
+
+@pytest.fixture
+def mock_DELETE_outcome(requests_mock, data_submitted_f680_case, data_outcome_id):
+    url = f"/caseworker/f680/{data_submitted_f680_case['case']['id']}/outcome/{data_outcome_id}/"
+    return requests_mock.delete(url, status_code=HTTPStatus.NO_CONTENT)
+
+
+@pytest.fixture
+def mock_DELETE_outcome_outcome_missing(requests_mock, data_submitted_f680_case, data_outcome_id):
+    url = f"/caseworker/f680/{data_submitted_f680_case['case']['id']}/outcome/{data_outcome_id}/"
+    return requests_mock.delete(url, status_code=HTTPStatus.NOT_FOUND)
+
+
+@pytest.fixture
+def mock_DELETE_outcome_server_error(requests_mock, data_submitted_f680_case, data_outcome_id):
+    url = f"/caseworker/f680/{data_submitted_f680_case['case']['id']}/outcome/{data_outcome_id}/"
+    return requests_mock.delete(url, json={"error": "error"}, status_code=HTTPStatus.INTERNAL_SERVER_ERROR)
 
 
 @pytest.fixture
@@ -109,7 +137,6 @@ class TestDecideOutcomeView:
     def test_GET_select_outcome(
         self,
         authorized_client,
-        requests_mock,
         f680_case_id,
         data_submitted_f680_case,
         mock_f680_case,
@@ -196,7 +223,6 @@ class TestDecideOutcomeView:
     def test_GET_select_outcome_existing_outcome(
         self,
         authorized_client,
-        requests_mock,
         f680_case_id,
         data_submitted_f680_case,
         mock_f680_case,
@@ -234,7 +260,6 @@ class TestDecideOutcomeView:
     def test_POST_select_outcome(
         self,
         authorized_client,
-        requests_mock,
         f680_case_id,
         data_submitted_f680_case,
         mock_f680_case,
@@ -317,7 +342,6 @@ class TestDecideOutcomeView:
     def test_POST_select_approve_outcome_conditions_aggregated(
         self,
         authorized_client,
-        requests_mock,
         f680_case_id,
         data_submitted_f680_case,
         mock_f680_case,
@@ -343,7 +367,6 @@ class TestDecideOutcomeView:
     def test_POST_select_outcome_bad_request(
         self,
         authorized_client,
-        requests_mock,
         f680_case_id,
         data_submitted_f680_case,
         mock_f680_case,
@@ -367,7 +390,6 @@ class TestDecideOutcomeView:
     def test_POST_approve(
         self,
         authorized_client,
-        requests_mock,
         f680_case_id,
         data_submitted_f680_case,
         data_queue,
@@ -417,7 +439,6 @@ class TestDecideOutcomeView:
     def test_POST_approve_bad_request(
         self,
         authorized_client,
-        requests_mock,
         f680_case_id,
         data_submitted_f680_case,
         data_queue,
@@ -451,7 +472,6 @@ class TestDecideOutcomeView:
     def test_POST_partial_approve(
         self,
         authorized_client,
-        requests_mock,
         f680_case_id,
         data_submitted_f680_case,
         data_queue,
@@ -502,7 +522,6 @@ class TestDecideOutcomeView:
     def test_POST_refuse(
         self,
         authorized_client,
-        requests_mock,
         f680_case_id,
         data_submitted_f680_case,
         mock_f680_case,
@@ -539,7 +558,6 @@ class TestDecideOutcomeView:
     def test_POST_refuse_bad_request(
         self,
         authorized_client,
-        requests_mock,
         f680_case_id,
         data_submitted_f680_case,
         mock_f680_case,
@@ -567,3 +585,55 @@ class TestDecideOutcomeView:
         assert form.errors == {
             "refusal_reasons": ["This field is required."],
         }
+
+
+class TestClearOutcome:
+
+    def test_POST_outcome_missing(
+        self,
+        authorized_client,
+        data_queue,
+        data_submitted_f680_case,
+        mock_f680_case,
+        mock_outcomes_single_outcome,
+        clear_outcome_url,
+        data_outcome_id,
+        mock_DELETE_outcome_outcome_missing,
+    ):
+        with pytest.raises(ServiceError):
+            response = authorized_client.post(clear_outcome_url)
+        assert mock_DELETE_outcome_outcome_missing.call_count == 1
+
+    def test_POST_api_error(
+        self,
+        authorized_client,
+        data_queue,
+        data_submitted_f680_case,
+        mock_f680_case,
+        mock_outcomes_single_outcome,
+        clear_outcome_url,
+        data_outcome_id,
+        mock_DELETE_outcome_server_error,
+    ):
+        with pytest.raises(ServiceError):
+            response = authorized_client.post(clear_outcome_url)
+        assert mock_DELETE_outcome_server_error.call_count == 1
+
+    def test_POST_success(
+        self,
+        authorized_client,
+        data_queue,
+        data_submitted_f680_case,
+        mock_f680_case,
+        mock_outcomes_single_outcome,
+        clear_outcome_url,
+        data_outcome_id,
+        mock_DELETE_outcome,
+    ):
+        response = authorized_client.post(clear_outcome_url)
+        assert response.status_code == HTTPStatus.FOUND
+        assert response.url == reverse(
+            "cases:f680:recommendation",
+            kwargs={"queue_pk": data_queue["id"], "pk": data_submitted_f680_case["case"]["id"]},
+        )
+        assert mock_DELETE_outcome.call_count == 1

--- a/caseworker/f680/outcome/urls.py
+++ b/caseworker/f680/outcome/urls.py
@@ -11,4 +11,9 @@ urlpatterns = [
         views.DecideOutcome.as_view(),
         name="decide_outcome",
     ),
+    path(
+        "clear-outcome/<uuid:outcome_id>/",
+        views.ClearOutcome.as_view(),
+        name="clear_outcome",
+    ),
 ]

--- a/caseworker/f680/outcome/views.py
+++ b/caseworker/f680/outcome/views.py
@@ -177,7 +177,7 @@ class ClearOutcome(LoginRequiredMixin, F680CaseworkerMixin, View):
     def post(self, request, **kwargs):
         self.delete_outcome(self.kwargs["outcome_id"])
         success_message = "Outcome cleared successfully"
-        messages.success(self.request, success_message, extra_tags="safe")
+        messages.success(self.request, success_message)
         outcome_url = reverse(
             "cases:f680:recommendation", kwargs={"queue_pk": self.kwargs["queue_pk"], "pk": self.kwargs["pk"]}
         )

--- a/caseworker/f680/rules.py
+++ b/caseworker/f680/rules.py
@@ -102,4 +102,5 @@ rules.add_rule(
 rules.add_rule("can_user_make_f680_recommendation", is_user_allocated & can_user_make_f680_recommendation)
 rules.add_rule("can_user_clear_f680_recommendation", is_user_allocated & can_user_clear_f680_recommendation)
 rules.add_rule("can_user_make_f680_outcome", is_user_allocated & case_ready_for_outcome & releases_without_outcome)
+rules.add_rule("can_user_clear_f680_outcome", is_user_allocated & case_ready_for_outcome)
 rules.add_rule("can_user_move_f680_case_forward", is_user_allocated & f680_case_ready_for_move)

--- a/caseworker/f680/templates/f680/case/outcome/includes/outcomes_table.html
+++ b/caseworker/f680/templates/f680/case/outcome/includes/outcomes_table.html
@@ -1,3 +1,5 @@
+{% load rules %}
+
 <table class="govuk-table f680-outcome-table">
     <thead class="govuk-table__head">
         <tr class="govuk-table__row">
@@ -8,8 +10,10 @@
             <th scope="col" class="govuk-table__header">Approval types</th>
             <th scope="col" class="govuk-table__header">Conditions</th>
             <th scope="col" class="govuk-table__header">Refusal reasons</th>
+            <th scope="col" class="govuk-table__header">Actions</th>
         </tr>
     </thead>
+    {% test_rule 'can_user_clear_f680_outcome' request case as can_user_clear_f680_outcome %}
     <tbody class="govuk-table__body">
         {% for outcome in outcomes %}
         <tr class="govuk-table__row">
@@ -49,6 +53,14 @@
                     {{outcome.refusal_reasons|linebreaksbr}}
                 {% else %}
                     -
+                {% endif %}
+            </td>
+            <td class="govuk-table__cell govuk-table__cell--max-width-400 ">
+                {% if can_user_clear_f680_outcome %}
+                <form action="{% url 'cases:f680:outcome:clear_outcome' queue.id case.id outcome.id %}" method="POST">
+                    {% csrf_token %}
+                    <input class="govuk-button govuk-button--warning" type="submit" value="Clear">
+                </form>
                 {% endif %}
             </td>
         </tr>


### PR DESCRIPTION
### Aim

This change adds a "Clear" button to each row of the outcome table - so that MOD-ECJU are able to clear an outcome grouping after they have created it.

[LTD-6070](https://uktrade.atlassian.net/browse/LTD-6070)


[LTD-6070]: https://uktrade.atlassian.net/browse/LTD-6070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ