### PR TITLE
[LTD-6096] F680 outcome condition grouping

### DIFF
--- a/caseworker/f680/outcome/forms.py
+++ b/caseworker/f680/outcome/forms.py
@@ -73,7 +73,7 @@ class ApproveOutcomeForm(BaseForm):
     )
     conditions = forms.CharField(
         widget=forms.Textarea(attrs={"rows": 7}),
-        label="Provisos",
+        label="Conditions",
         required=False,
     )
 

--- a/caseworker/f680/templates/f680/case/outcome/includes/security_release_request_details.html
+++ b/caseworker/f680/templates/f680/case/outcome/includes/security_release_request_details.html
@@ -1,5 +1,5 @@
 {% for security_release_request in security_release_requests %}
-    <details class="govuk-details" data-module="govuk-details" open>
+    <details class="govuk-details" data-module="govuk-details">
         <summary class="govuk-details__summary">
             <span class="govuk-details__summary-text govuk-!-font-weight-bold">
                 {{security_release_request.recipient.name}}


### PR DESCRIPTION
### Aim

This adds some simple grouping of conditions to the existing outcome flow.  Conditions are aggregated/de-duplicated by text string - so that a MOD-ECJU user selecting to give outcomes to multiple security releases will have an aggregated condition text box to edit.


[LTD-6096](https://uktrade.atlassian.net/browse/LTD-6096)


[LTD-6096]: https://uktrade.atlassian.net/browse/LTD-6096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ