### PR TITLE
LTD-6119: Add clear recommendation option on the landing page

### DIFF
--- a/caseworker/f680/recommendation/tests/test_views.py
+++ b/caseworker/f680/recommendation/tests/test_views.py
@@ -163,8 +163,12 @@ class TestF680RecommendationView:
         }
         response = authorized_client.get(url)
         assert response.status_code == 200
+
         assertTemplateUsed(response, "f680/case/recommendation/recommendation.html")
         assertTemplateUsed(response, "f680/case/recommendation/other-recommendations.html")
+        soup = BeautifulSoup(response.content, "html.parser")
+        clear_recommendation_button = soup.find(id="clear-recommendation-button")
+        assert clear_recommendation_button
 
 
 class TestF680MakeRecommendationView:

--- a/caseworker/f680/templates/f680/case/recommendation/clear_recommendation.html
+++ b/caseworker/f680/templates/f680/case/recommendation/clear_recommendation.html
@@ -5,7 +5,7 @@
 
 {% block details %}
 <div class="govuk-width-container">
-    <a href="#" class="govuk-back-link">Back</a>
+    <a href="{% url 'cases:f680:recommendation' queue_pk case.id %}" class="govuk-back-link">Back</a>
     <main class="govuk-main-wrapper">
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">

--- a/caseworker/f680/templates/f680/case/recommendation/recommendation.html
+++ b/caseworker/f680/templates/f680/case/recommendation/recommendation.html
@@ -26,6 +26,14 @@
 
         {% if user_recommendations and not pending_recommendations %}
             <h1 class="govuk-heading-xl">View recommendation</h1>
+
+            {% test_rule 'can_user_clear_f680_recommendation' request case as can_user_clear_f680_recommendation %}
+            {% if can_user_clear_f680_recommendation %}
+              <a id="clear-recommendation-button" role="button" draggable="false" class="govuk-button govuk-button--secondary" href="{% url 'cases:f680:clear_recommendation' queue_pk case.id %}">
+                  Clear recommendation
+              </a>
+            {% endif %}
+
             {% for recommendation in user_recommendations %}
                 {% include "f680/case/recommendation/recommendation_details.html" with recommendation=recommendation %}
             {% endfor %}


### PR DESCRIPTION
## Change description

Currently the option to clear recommendation is only available on ‘View my recommendation’ page. This is the page user is taken to after making a recommendation. If user navigates away then this option is not available.

[LTD-6119](https://uktrade.atlassian.net/browse/LTD-6119)


[LTD-6119]: https://uktrade.atlassian.net/browse/LTD-6119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ