### PR TITLE
[LTD-6123] F680 finalise flow

### DIFF
--- a/caseworker/cases/services.py
+++ b/caseworker/cases/services.py
@@ -302,11 +302,6 @@ def post_generated_document(request, pk, json):
     return data.status_code
 
 
-def get_generated_documents(request, pk):
-    data = client.get(request, f"/cases/{pk}/generated-documents/")
-    return data.json(), data.status_code
-
-
 def get_generated_document_preview(request, pk, template, text, addressee):
     params = convert_parameters_to_query_params(locals())
     data = client.get(request, f"/cases/{pk}/generated-documents/preview/" + params)

--- a/caseworker/cases/services.py
+++ b/caseworker/cases/services.py
@@ -157,6 +157,11 @@ def grant_licence(request, case_pk, json):
     return response.json(), response.status_code
 
 
+def finalise_case(request, case_pk, json):
+    response = client.put(request, f"/cases/{case_pk}/finalise/", json)
+    return response.json(), response.status_code
+
+
 def get_licence(request, case_pk):
     data = client.get(request, f"/cases/{case_pk}/licences/")
     return data.json(), data.status_code
@@ -295,6 +300,11 @@ def get_decisions(request):
 def post_generated_document(request, pk, json):
     data = client.post(request, f"/cases/{pk}/generated-documents/", json)
     return data.status_code
+
+
+def get_generated_documents(request, pk):
+    data = client.get(request, f"/cases/{pk}/generated-documents/")
+    return data.json(), data.status_code
 
 
 def get_generated_document_preview(request, pk, template, text, addressee):

--- a/caseworker/f680/conftest.py
+++ b/caseworker/f680/conftest.py
@@ -56,6 +56,11 @@ def data_outcome_id():
 @pytest.fixture
 def data_outcomes(current_user, admin_team, data_submitted_f680_case, data_outcome_id):
     security_release_requests = data_submitted_f680_case["case"]["data"]["security_release_requests"]
+    outcome_map = {
+        security_release_requests[0]["id"]: "approve",
+        security_release_requests[1]["id"]: "refuse",
+        security_release_requests[2]["id"]: "approve",
+    }
     return [
         {
             "id": data_outcome_id,

--- a/caseworker/f680/conftest.py
+++ b/caseworker/f680/conftest.py
@@ -56,11 +56,6 @@ def data_outcome_id():
 @pytest.fixture
 def data_outcomes(current_user, admin_team, data_submitted_f680_case, data_outcome_id):
     security_release_requests = data_submitted_f680_case["case"]["data"]["security_release_requests"]
-    outcome_map = {
-        security_release_requests[0]["id"]: "approve",
-        security_release_requests[1]["id"]: "refuse",
-        security_release_requests[2]["id"]: "approve",
-    }
     return [
         {
             "id": data_outcome_id,

--- a/caseworker/f680/document/forms.py
+++ b/caseworker/f680/document/forms.py
@@ -4,20 +4,13 @@ from django import forms
 from core.common.forms import BaseForm
 
 
-class DocumentGenerationForm(BaseForm):
+class FinaliseForm(BaseForm):
 
     class Layout:
         TITLE = ""
-        SUBMIT_BUTTON_TEXT = "Save and publish to exporter"
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        SUBMIT_BUTTON_TEXT = "Finalise and publish to exporter"
 
     def get_layout_fields(self):
-        return ()
-
-    def get_layout_actions(self):
-        # Prevent the standard submit button being shown
         return []
 
 

--- a/caseworker/f680/document/tests/test_document_views.py
+++ b/caseworker/f680/document/tests/test_document_views.py
@@ -176,6 +176,7 @@ def mock_letter_template_approval_only(requests_mock, letter_templates_data):
     url = client._build_absolute_uri(f"/caseworker/letter_templates/?case_type=f680_clearance")
     return requests_mock.get(url=url, json={"results": letter_templates_data[1:]})
 
+
 @pytest.fixture
 def mock_letter_template_refusal_only(requests_mock, letter_templates_data):
     url = client._build_absolute_uri(f"/caseworker/letter_templates/?case_type=f680_clearance")
@@ -380,7 +381,7 @@ class TestAllDocumentsView:
         authorized_client,
         data_queue,
         f680_case_id,
-        mock_f680_case_under_review,
+        mock_f680_case_under_final_review,
         mock_outcomes_approve_refuse,
         mock_letter_template_filter,
         letter_templates_data,
@@ -401,7 +402,7 @@ class TestAllDocumentsView:
         authorized_client,
         data_queue,
         f680_case_id,
-        mock_f680_case_under_review,
+        mock_f680_case_under_final_review,
         mock_outcomes_approve_refuse,
         mock_letter_template_filter,
         letter_templates_data,

--- a/caseworker/f680/document/views.py
+++ b/caseworker/f680/document/views.py
@@ -75,7 +75,7 @@ class AllDocuments(LoginRequiredMixin, F680DocumentMixin, FormView):
         return super().form_valid(form)
 
     def get_success_url(self):
-        return reverse("cases:f680:detail", kwargs={"pk": self.case_id, "queue_pk": self.queue_id})
+        return reverse("cases:f680:details", kwargs={"pk": self.case_id, "queue_pk": self.queue_id})
 
 
 class F680GenerateDocument(LoginRequiredMixin, F680DocumentMixin, FormView):
@@ -142,7 +142,7 @@ class F680GenerateDocument(LoginRequiredMixin, F680DocumentMixin, FormView):
 
     def get_success_url(self, *args, **kwargs):
         # TODO: Redirect the user to the landing screen when we have a document
-        return reverse("cases:f680:details", kwargs={"queue_pk": self.queue_id, "pk": self.case_id})
+        return reverse("cases:f680:document:all", kwargs={"queue_pk": self.queue_id, "pk": self.case_id})
 
     def get_text(self, form):
         text = None

--- a/caseworker/f680/document/views.py
+++ b/caseworker/f680/document/views.py
@@ -1,14 +1,12 @@
-import rules
-
 from http import HTTPStatus
 from urllib.parse import quote
-import rules
 
 from django.contrib import messages
 from django.http import HttpResponseForbidden
 from django.urls import reverse
 from django.views.generic import FormView
 from django.http import Http404
+import rules
 
 from core.auth.views import LoginRequiredMixin
 from core.decorators import expect_status
@@ -46,6 +44,7 @@ class F680DocumentMixin(F680CaseworkerMixin):
         filters = {"case_type": self.case.case_type["sub_type"]["key"], "decision": decisions}
         f680_letter_templates, _ = self.get_letter_templates_list(filters)
         return f680_letter_templates["results"]
+
 
 class AllDocuments(LoginRequiredMixin, F680DocumentMixin, FormView):
     form_class = FinaliseForm

--- a/caseworker/f680/outcome/constants.py
+++ b/caseworker/f680/outcome/constants.py
@@ -17,3 +17,8 @@ class SecurityReleaseOutcomeDuration:
         (MONTHS_24, "24 months"),
         (MONTHS_48, "48 months"),
     ]
+
+
+class OutcomeType:
+    APPROVE = "approve"
+    REFUSE = "refuse"

--- a/caseworker/f680/rules.py
+++ b/caseworker/f680/rules.py
@@ -90,7 +90,6 @@ def releases_without_outcome_exist(request, case):
 @with_logged_in_caseworker
 def all_releases_decided(request, case):
     outcomes, _ = get_outcomes(request, case["id"])
-
     releases_without_outcome, _ = get_releases_with_no_outcome(request, outcomes, case)
     return len(releases_without_outcome) == 0
 

--- a/caseworker/f680/templates/f680/case/recommendation/recommendation.html
+++ b/caseworker/f680/templates/f680/case/recommendation/recommendation.html
@@ -22,6 +22,10 @@
         {% if outcomes %}
             <h1 class="govuk-heading-xl">Outcomes</h1>
             {% include "f680/case/outcome/includes/outcomes_table.html" with outcomes=outcomes %}
+            {% test_rule 'can_user_make_f680_outcome_letter' request case as can_user_make_f680_outcome_letter %}
+            {% if can_user_make_f680_outcome_letter %}
+                <a id="generate-outcome-letter-button" draggable="false" class="govuk-button govuk-button--primary" href="{% url 'cases:f680:document:all' queue_pk case.id %}">Generate letters</a>
+            {% endif %}
         {% endif %}
 
         {% if user_recommendations and not pending_recommendations %}

--- a/caseworker/f680/templates/f680/document/all_documents.html
+++ b/caseworker/f680/templates/f680/document/all_documents.html
@@ -13,6 +13,7 @@
                         <th scope="col" class="govuk-table__header">Actions</th>
                     </tr>
                 </thead>
+
                 <tbody class="govuk-table__body">
                     {% for letter_template in letter_templates %}
                         <tr class="govuk-table__row">

--- a/exporter/templates/f680/application_detail.html
+++ b/exporter/templates/f680/application_detail.html
@@ -88,7 +88,7 @@
     {% elif type == 'ecju-queries' %}
         {% include "includes/ecju-queries.html" with object_type="application" case_id=application.id %}
     {% elif type == 'generated-documents' %}
-        {% include "core/ecju-generated-documents.html" %}
+        {% include "core/ecju-generated-documents.html" with case_id=application.id %}
     {% elif type == 'activity' %}
         {% include "f680/includes/activity.html" %}
     {% endif %}


### PR DESCRIPTION
### Aim

This change adds a "Finalise and publish to exporter" button to the "all documents" view.  This is wired up with the finalise endpoint (adjusted in PR https://github.com/uktrade/lite-api/pull/2507)

[LTD-6123](https://uktrade.atlassian.net/browse/LTD-6123)


[LTD-6123]: https://uktrade.atlassian.net/browse/LTD-6123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ