### PR TITLE
LTD-6140: Update Security outcome flow to capture validity dates

### DIFF
--- a/caseworker/f680/conftest.py
+++ b/caseworker/f680/conftest.py
@@ -71,7 +71,7 @@ def data_outcomes(current_user, admin_team, data_submitted_f680_case, data_outco
             "validity_end_date": (
                 timezone.now().date()
                 + relativedelta(
-                    months=+SecurityReleaseOutcomeDuration.DEFAULT_DURATION_MONTHS,
+                    months=+SecurityReleaseOutcomeDuration.MONTHS_24,
                 )
             ).isoformat(),
         }

--- a/caseworker/f680/conftest.py
+++ b/caseworker/f680/conftest.py
@@ -74,6 +74,7 @@ def data_outcomes(current_user, admin_team, data_submitted_f680_case, data_outco
                     months=+SecurityReleaseOutcomeDuration.MONTHS_24,
                 )
             ).isoformat(),
+            "validity_period": int(SecurityReleaseOutcomeDuration.MONTHS_24),
         }
     ]
 

--- a/caseworker/f680/conftest.py
+++ b/caseworker/f680/conftest.py
@@ -1,6 +1,10 @@
 import pytest
 
+from django.utils import timezone
+from dateutil.relativedelta import relativedelta
+
 from core import client
+from caseworker.f680.outcome.constants import SecurityReleaseOutcomeDuration
 
 
 @pytest.fixture
@@ -63,6 +67,13 @@ def data_outcomes(current_user, admin_team, data_submitted_f680_case, data_outco
             "security_release_requests": [security_release_requests[0]["id"]],
             "user": current_user,
             "team": admin_team,
+            "validity_start_date": timezone.now().date().isoformat(),
+            "validity_end_date": (
+                timezone.now().date()
+                + relativedelta(
+                    months=+SecurityReleaseOutcomeDuration.DEFAULT_DURATION_MONTHS,
+                )
+            ).isoformat(),
         }
     ]
 

--- a/caseworker/f680/outcome/constants.py
+++ b/caseworker/f680/outcome/constants.py
@@ -5,4 +5,10 @@ class OutcomeSteps:
 
 
 class SecurityReleaseOutcomeDuration:
-    DEFAULT_DURATION_MONTHS = 24
+    MONTHS_24 = 24
+    MONTHS_48 = 48
+
+    choices = [
+        (MONTHS_24, "24 months"),
+        (MONTHS_48, "48 months"),
+    ]

--- a/caseworker/f680/outcome/constants.py
+++ b/caseworker/f680/outcome/constants.py
@@ -2,3 +2,7 @@ class OutcomeSteps:
     SELECT_OUTCOME = "select_outcome"
     APPROVE = "approve"
     REFUSE = "refuse"
+
+
+class SecurityReleaseOutcomeDuration:
+    DEFAULT_DURATION_MONTHS = 24

--- a/caseworker/f680/outcome/forms.py
+++ b/caseworker/f680/outcome/forms.py
@@ -135,7 +135,7 @@ class ApproveOutcomeForm(BaseForm):
 
         if validity_start_date and validity_period:
             duration = int(validity_period)
-            validity_end_date = validity_start_date + relativedelta(months=+duration)
+            validity_end_date = validity_start_date + relativedelta(months=duration)
 
         return {
             **cleaned_data,

--- a/caseworker/f680/outcome/services.py
+++ b/caseworker/f680/outcome/services.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-from dateutil.relativedelta import relativedelta
 from json.decoder import JSONDecodeError
 
 from core import client
@@ -37,11 +35,6 @@ def get_hydrated_outcomes(request, case):
         for release_request_id in outcome["security_release_request_ids"]:
             release_requests.append(security_release_requests_by_id[release_request_id])
         outcome["security_release_requests"] = release_requests
-
-        validity_start_date = datetime.strptime(outcome["validity_start_date"], "%Y-%m-%d").date()
-        validity_end_date = datetime.strptime(outcome["validity_end_date"], "%Y-%m-%d").date()
-        diff = relativedelta(validity_end_date, validity_start_date)
-        outcome["validity_period"] = diff.years * 12 + diff.months
 
         outcomes.append(outcome)
     return outcomes, response.status_code

--- a/caseworker/f680/outcome/services.py
+++ b/caseworker/f680/outcome/services.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
 from json.decoder import JSONDecodeError
 
 from core import client
@@ -35,6 +37,12 @@ def get_hydrated_outcomes(request, case):
         for release_request_id in outcome["security_release_request_ids"]:
             release_requests.append(security_release_requests_by_id[release_request_id])
         outcome["security_release_requests"] = release_requests
+
+        validity_start_date = datetime.strptime(outcome["validity_start_date"], "%Y-%m-%d").date()
+        validity_end_date = datetime.strptime(outcome["validity_end_date"], "%Y-%m-%d").date()
+        diff = relativedelta(validity_end_date, validity_start_date)
+        outcome["validity_period"] = diff.years * 12 + diff.months
+
         outcomes.append(outcome)
     return outcomes, response.status_code
 

--- a/caseworker/f680/outcome/tests/test_forms.py
+++ b/caseworker/f680/outcome/tests/test_forms.py
@@ -5,7 +5,6 @@ from freezegun import freeze_time
 from caseworker.f680.outcome.forms import SelectOutcomeForm, ApproveOutcomeForm, RefuseOutcomeForm
 
 
-@freeze_time("2025-04-14")
 @pytest.mark.parametrize(
     "data, valid_status, errors",
     (
@@ -15,8 +14,6 @@ from caseworker.f680.outcome.forms import SelectOutcomeForm, ApproveOutcomeForm,
             {
                 "security_release_requests": ["This field is required."],
                 "outcome": ["Select if you approve or refuse"],
-                "validity_start_date": ["Enter the validity start date"],
-                "validity_end_date": ["Enter the validity end date"],
             },
         ),
         (
@@ -26,76 +23,15 @@ from caseworker.f680.outcome.forms import SelectOutcomeForm, ApproveOutcomeForm,
             False,
             {
                 "outcome": ["Select if you approve or refuse"],
-                "validity_start_date": ["Enter the validity start date"],
-                "validity_end_date": ["Enter the validity end date"],
             },
         ),
         (
             {
                 "security_release_requests": ["123465e5-4c80-4d0a-aef5-db94908b0417"],
                 "outcome": "approve",
-            },
-            False,
-            {
-                "validity_start_date": ["Enter the validity start date"],
-                "validity_end_date": ["Enter the validity end date"],
-            },
-        ),
-        (
-            {
-                "security_release_requests": ["123465e5-4c80-4d0a-aef5-db94908b0417"],
-                "outcome": "approve",
-                "validity_start_date_0": "01",
-                "validity_start_date_1": "05",
-                "validity_start_date_2": "2024",
-                "validity_end_date_0": "01",
-                "validity_end_date_1": "05",
-                "validity_end_date_2": "2026",
-            },
-            False,
-            {"validity_start_date": ["Validity start date must be from today or in the future"]},
-        ),
-        (
-            {
-                "security_release_requests": ["123465e5-4c80-4d0a-aef5-db94908b0417"],
-                "outcome": "approve",
-                "validity_start_date_0": "14",
-                "validity_start_date_1": "04",
-                "validity_start_date_2": "2025",
-                "validity_end_date_0": "14",
-                "validity_end_date_1": "04",
-                "validity_end_date_2": "2027",
             },
             True,
             {},
-        ),
-        (
-            {
-                "security_release_requests": ["123465e5-4c80-4d0a-aef5-db94908b0417"],
-                "outcome": "approve",
-                "validity_start_date_0": "14",
-                "validity_start_date_1": "04",
-                "validity_start_date_2": "2025",
-                "validity_end_date_0": "14",
-                "validity_end_date_1": "01",
-                "validity_end_date_2": "2027",
-            },
-            False,
-            {"validity_end_date": ["Outcome validity is less than 2 years"]},
-        ),
-        (
-            {
-                "security_release_requests": ["123465e5-4c80-4d0a-aef5-db94908b0417"],
-                "outcome": "approve",
-                "validity_start_date_0": "14",
-                "validity_start_date_1": "04",
-                "validity_start_date_2": "2025",
-                "validity_end_date_0": "14",
-                "validity_end_date_1": "01",
-                "validity_end_date_2": "2028",
-            },
-            False,
-            {"validity_end_date": ["Validity end date must be within 2 years"]},
         ),
     ),
 )
@@ -118,6 +54,7 @@ def test_select_outcome_form_valid(data, valid_status, errors):
         assert form.errors == errors
 
 
+@freeze_time("2025-04-15")
 @pytest.mark.parametrize(
     "data, valid_status, errors",
     (
@@ -127,6 +64,8 @@ def test_select_outcome_form_valid(data, valid_status, errors):
             {
                 "security_grading": ["Select the security release"],
                 "approval_types": ["Select approval types"],
+                "validity_start_date": ["Enter the validity start date"],
+                "validity_period": ["Select validity period"],
             },
         ),
         (
@@ -137,12 +76,87 @@ def test_select_outcome_form_valid(data, valid_status, errors):
             False,
             {
                 "approval_types": ["Select approval types"],
+                "validity_start_date": ["Enter the validity start date"],
+                "validity_period": ["Select validity period"],
             },
         ),
         (
             {
                 "security_grading": "official",
                 "approval_types": ["initial_discussion_or_promoting", "demonstration_overseas"],
+                "validity_start_date_0": "15",
+                "validity_start_date_1": "04",
+                "validity_start_date_2": "2025",
+            },
+            False,
+            {
+                "validity_period": ["Select validity period"],
+            },
+        ),
+        (
+            {
+                "security_grading": "official",
+                "approval_types": ["initial_discussion_or_promoting", "demonstration_overseas"],
+                "validity_start_date_0": "10",
+                "validity_start_date_1": "04",
+                "validity_start_date_2": "2025",
+                "validity_period": "24",
+            },
+            False,
+            {
+                "validity_start_date": ["Validity start date must be from today or in the future"],
+            },
+        ),
+        (
+            {
+                "security_grading": "official",
+                "approval_types": ["initial_discussion_or_promoting", "demonstration_overseas"],
+                "validity_start_date_0": "31",
+                "validity_start_date_1": "04",
+                "validity_start_date_2": "2025",
+                "validity_period": "24",
+            },
+            False,
+            {
+                "validity_start_date": ["Validity start date must be a real date"],
+            },
+        ),
+        (
+            {
+                "security_grading": "official",
+                "approval_types": ["initial_discussion_or_promoting", "demonstration_overseas"],
+                "validity_start_date_0": "15",
+                "validity_start_date_1": "15",
+                "validity_start_date_2": "2025",
+                "validity_period": "24",
+            },
+            False,
+            {
+                "validity_start_date": ["Validity start date must be a real date"],
+            },
+        ),
+        (
+            {
+                "security_grading": "official",
+                "approval_types": ["initial_discussion_or_promoting", "demonstration_overseas"],
+                "validity_start_date_0": "15",
+                "validity_start_date_1": "04",
+                "validity_start_date_2": "20250",
+                "validity_period": "24",
+            },
+            False,
+            {
+                "validity_start_date": ["Validity start date must be a real date"],
+            },
+        ),
+        (
+            {
+                "security_grading": "official",
+                "approval_types": ["initial_discussion_or_promoting", "demonstration_overseas"],
+                "validity_start_date_0": "15",
+                "validity_start_date_1": "04",
+                "validity_start_date_2": "2025",
+                "validity_period": "48",
             },
             True,
             {},

--- a/caseworker/f680/outcome/tests/test_forms.py
+++ b/caseworker/f680/outcome/tests/test_forms.py
@@ -1,0 +1,183 @@
+import pytest
+
+from freezegun import freeze_time
+
+from caseworker.f680.outcome.forms import SelectOutcomeForm, ApproveOutcomeForm, RefuseOutcomeForm
+
+
+@freeze_time("2025-04-14")
+@pytest.mark.parametrize(
+    "data, valid_status, errors",
+    (
+        (
+            {},
+            False,
+            {
+                "security_release_requests": ["This field is required."],
+                "outcome": ["Select if you approve or refuse"],
+                "validity_start_date": ["Enter the validity start date"],
+                "validity_end_date": ["Enter the validity end date"],
+            },
+        ),
+        (
+            {
+                "security_release_requests": ["123465e5-4c80-4d0a-aef5-db94908b0417"],
+            },
+            False,
+            {
+                "outcome": ["Select if you approve or refuse"],
+                "validity_start_date": ["Enter the validity start date"],
+                "validity_end_date": ["Enter the validity end date"],
+            },
+        ),
+        (
+            {
+                "security_release_requests": ["123465e5-4c80-4d0a-aef5-db94908b0417"],
+                "outcome": "approve",
+            },
+            False,
+            {
+                "validity_start_date": ["Enter the validity start date"],
+                "validity_end_date": ["Enter the validity end date"],
+            },
+        ),
+        (
+            {
+                "security_release_requests": ["123465e5-4c80-4d0a-aef5-db94908b0417"],
+                "outcome": "approve",
+                "validity_start_date_0": "01",
+                "validity_start_date_1": "05",
+                "validity_start_date_2": "2024",
+                "validity_end_date_0": "01",
+                "validity_end_date_1": "05",
+                "validity_end_date_2": "2026",
+            },
+            False,
+            {"validity_start_date": ["Validity start date must be from today or in the future"]},
+        ),
+        (
+            {
+                "security_release_requests": ["123465e5-4c80-4d0a-aef5-db94908b0417"],
+                "outcome": "approve",
+                "validity_start_date_0": "14",
+                "validity_start_date_1": "04",
+                "validity_start_date_2": "2025",
+                "validity_end_date_0": "14",
+                "validity_end_date_1": "04",
+                "validity_end_date_2": "2027",
+            },
+            True,
+            {},
+        ),
+        (
+            {
+                "security_release_requests": ["123465e5-4c80-4d0a-aef5-db94908b0417"],
+                "outcome": "approve",
+                "validity_start_date_0": "14",
+                "validity_start_date_1": "04",
+                "validity_start_date_2": "2025",
+                "validity_end_date_0": "14",
+                "validity_end_date_1": "01",
+                "validity_end_date_2": "2027",
+            },
+            False,
+            {"validity_end_date": ["Outcome validity is less than 2 years"]},
+        ),
+        (
+            {
+                "security_release_requests": ["123465e5-4c80-4d0a-aef5-db94908b0417"],
+                "outcome": "approve",
+                "validity_start_date_0": "14",
+                "validity_start_date_1": "04",
+                "validity_start_date_2": "2025",
+                "validity_end_date_0": "14",
+                "validity_end_date_1": "01",
+                "validity_end_date_2": "2028",
+            },
+            False,
+            {"validity_end_date": ["Validity end date must be within 2 years"]},
+        ),
+    ),
+)
+def test_select_outcome_form_valid(data, valid_status, errors):
+    release_requests = [
+        {
+            "id": "123465e5-4c80-4d0a-aef5-db94908b0417",
+            "security_grading": {"key": "official", "value": "Official"},
+            "recipient": {
+                "name": "Test entity",
+                "country": {
+                    "name": "Australia",
+                },
+            },
+        }
+    ]
+    form = SelectOutcomeForm(data=data, security_release_requests=release_requests)
+    assert form.is_valid() == valid_status
+    if not valid_status:
+        assert form.errors == errors
+
+
+@pytest.mark.parametrize(
+    "data, valid_status, errors",
+    (
+        (
+            {},
+            False,
+            {
+                "security_grading": ["Select the security release"],
+                "approval_types": ["Select approval types"],
+            },
+        ),
+        (
+            {
+                "security_grading": "official",
+                "conditions": "",
+            },
+            False,
+            {
+                "approval_types": ["Select approval types"],
+            },
+        ),
+        (
+            {
+                "security_grading": "official",
+                "approval_types": ["initial_discussion_or_promoting", "demonstration_overseas"],
+            },
+            True,
+            {},
+        ),
+    ),
+)
+def test_approve_outcome_form_valid(data, valid_status, errors):
+    all_approval_types = ["initial_discussion_or_promoting", "demonstration_overseas", "training", "supply"]
+    form = ApproveOutcomeForm(data=data, all_approval_types=all_approval_types)
+    assert form.is_valid() == valid_status
+    if not valid_status:
+        assert form.errors == errors
+
+
+@pytest.mark.parametrize(
+    "data, valid_status, errors",
+    (
+        (
+            {},
+            False,
+            {
+                "refusal_reasons": ["Enter refusal reasons"],
+            },
+        ),
+        (
+            {
+                "refusal_reasons": "Doesn't meet criteria",
+            },
+            True,
+            {},
+        ),
+    ),
+)
+def test_refuse_outcome_form_valid(data, valid_status, errors):
+    form = RefuseOutcomeForm(data=data)
+    assert form.is_valid() == valid_status
+    if not valid_status:
+        assert form.errors == errors

--- a/caseworker/f680/outcome/tests/test_views.py
+++ b/caseworker/f680/outcome/tests/test_views.py
@@ -1,12 +1,14 @@
 import pytest
 from http import HTTPStatus
 
+from dateutil.relativedelta import relativedelta
 from django.urls import reverse
+from django.utils import timezone
 
 from core import client
 from core.exceptions import ServiceError
 
-from caseworker.f680.outcome.constants import OutcomeSteps
+from caseworker.f680.outcome.constants import OutcomeSteps, SecurityReleaseOutcomeDuration
 from caseworker.f680.outcome import forms
 
 
@@ -271,11 +273,24 @@ class TestDecideOutcomeView:
     ):
         security_release_requests = data_submitted_f680_case["case"]["data"]["security_release_requests"]
         request_ids = [request["id"] for request in security_release_requests]
+        validity_start_date = timezone.now().date().isoformat()
+        validity_end_date = (
+            timezone.now().date()
+            + relativedelta(
+                months=+SecurityReleaseOutcomeDuration.DEFAULT_DURATION_MONTHS,
+            )
+        ).isoformat()
         response = post_to_step(
             OutcomeSteps.SELECT_OUTCOME,
             {
                 "outcome": outcome,
                 "security_release_requests": request_ids,
+                "validity_start_date_0": validity_start_date.split("-")[2],
+                "validity_start_date_1": validity_start_date.split("-")[1],
+                "validity_start_date_2": validity_start_date.split("-")[0],
+                "validity_end_date_0": validity_end_date.split("-")[2],
+                "validity_end_date_1": validity_end_date.split("-")[1],
+                "validity_end_date_2": validity_end_date.split("-")[0],
             },
         )
         assert response.status_code == HTTPStatus.OK
@@ -351,11 +366,24 @@ class TestDecideOutcomeView:
     ):
         security_release_requests = data_submitted_f680_case["case"]["data"]["security_release_requests"]
         request_ids = [request["id"] for request in security_release_requests]
+        validity_start_date = timezone.now().date().isoformat()
+        validity_end_date = (
+            timezone.now().date()
+            + relativedelta(
+                months=+SecurityReleaseOutcomeDuration.DEFAULT_DURATION_MONTHS,
+            )
+        ).isoformat()
         response = post_to_step(
             OutcomeSteps.SELECT_OUTCOME,
             {
                 "outcome": "approve",
                 "security_release_requests": request_ids,
+                "validity_start_date_0": validity_start_date.split("-")[2],
+                "validity_start_date_1": validity_start_date.split("-")[1],
+                "validity_start_date_2": validity_start_date.split("-")[0],
+                "validity_end_date_0": validity_end_date.split("-")[2],
+                "validity_end_date_1": validity_end_date.split("-")[1],
+                "validity_end_date_2": validity_end_date.split("-")[0],
             },
         )
         assert response.status_code == HTTPStatus.OK
@@ -385,6 +413,8 @@ class TestDecideOutcomeView:
         assert form.errors == {
             "outcome": ["Select if you approve or refuse"],
             "security_release_requests": ["This field is required."],
+            "validity_start_date": ["Enter the validity start date"],
+            "validity_end_date": ["Enter the validity end date"],
         }
 
     def test_POST_approve(
@@ -400,11 +430,24 @@ class TestDecideOutcomeView:
     ):
         security_release_requests = data_submitted_f680_case["case"]["data"]["security_release_requests"]
         request_ids = [request["id"] for request in security_release_requests]
+        validity_start_date = timezone.now().date().isoformat()
+        validity_end_date = (
+            timezone.now().date()
+            + relativedelta(
+                months=+SecurityReleaseOutcomeDuration.DEFAULT_DURATION_MONTHS,
+            )
+        ).isoformat()
         response = post_to_step(
             OutcomeSteps.SELECT_OUTCOME,
             {
                 "outcome": "approve",
                 "security_release_requests": request_ids,
+                "validity_start_date_0": validity_start_date.split("-")[2],
+                "validity_start_date_1": validity_start_date.split("-")[1],
+                "validity_start_date_2": validity_start_date.split("-")[0],
+                "validity_end_date_0": validity_end_date.split("-")[2],
+                "validity_end_date_1": validity_end_date.split("-")[1],
+                "validity_end_date_2": validity_end_date.split("-")[0],
             },
         )
         assert response.status_code == HTTPStatus.OK
@@ -434,6 +477,8 @@ class TestDecideOutcomeView:
             "approval_types": ["training"],
             "security_grading": "secret",
             "security_release_requests": request_ids,
+            "validity_start_date": validity_start_date,
+            "validity_end_date": validity_end_date,
         }
 
     def test_POST_approve_bad_request(
@@ -449,11 +494,24 @@ class TestDecideOutcomeView:
     ):
         security_release_requests = data_submitted_f680_case["case"]["data"]["security_release_requests"]
         request_ids = [request["id"] for request in security_release_requests]
+        validity_start_date = timezone.now().date().isoformat()
+        validity_end_date = (
+            timezone.now().date()
+            + relativedelta(
+                months=+SecurityReleaseOutcomeDuration.DEFAULT_DURATION_MONTHS,
+            )
+        ).isoformat()
         response = post_to_step(
             OutcomeSteps.SELECT_OUTCOME,
             {
                 "outcome": "approve",
                 "security_release_requests": request_ids,
+                "validity_start_date_0": validity_start_date.split("-")[2],
+                "validity_start_date_1": validity_start_date.split("-")[1],
+                "validity_start_date_2": validity_start_date.split("-")[0],
+                "validity_end_date_0": validity_end_date.split("-")[2],
+                "validity_end_date_1": validity_end_date.split("-")[1],
+                "validity_end_date_2": validity_end_date.split("-")[0],
             },
         )
         assert response.status_code == HTTPStatus.OK
@@ -466,7 +524,7 @@ class TestDecideOutcomeView:
         form = response.context["form"]
         assert form.errors == {
             "security_grading": ["Select the security release"],
-            "approval_types": ["This field is required."],
+            "approval_types": ["Select approval types"],
         }
 
     def test_POST_partial_approve(
@@ -483,11 +541,24 @@ class TestDecideOutcomeView:
         security_release_requests = data_submitted_f680_case["case"]["data"]["security_release_requests"]
         # Only approve for one ID
         request_ids = [security_release_requests[0]["id"]]
+        validity_start_date = timezone.now().date().isoformat()
+        validity_end_date = (
+            timezone.now().date()
+            + relativedelta(
+                months=+SecurityReleaseOutcomeDuration.DEFAULT_DURATION_MONTHS,
+            )
+        ).isoformat()
         response = post_to_step(
             OutcomeSteps.SELECT_OUTCOME,
             {
                 "outcome": "approve",
                 "security_release_requests": request_ids,
+                "validity_start_date_0": validity_start_date.split("-")[2],
+                "validity_start_date_1": validity_start_date.split("-")[1],
+                "validity_start_date_2": validity_start_date.split("-")[0],
+                "validity_end_date_0": validity_end_date.split("-")[2],
+                "validity_end_date_1": validity_end_date.split("-")[1],
+                "validity_end_date_2": validity_end_date.split("-")[0],
             },
         )
         assert response.status_code == HTTPStatus.OK
@@ -517,6 +588,8 @@ class TestDecideOutcomeView:
             "approval_types": ["training"],
             "security_grading": "secret",
             "security_release_requests": request_ids,
+            "validity_start_date": validity_start_date,
+            "validity_end_date": validity_end_date,
         }
 
     def test_POST_refuse(
@@ -531,11 +604,24 @@ class TestDecideOutcomeView:
     ):
         security_release_requests = data_submitted_f680_case["case"]["data"]["security_release_requests"]
         request_ids = [request["id"] for request in security_release_requests]
+        validity_start_date = timezone.now().date().isoformat()
+        validity_end_date = (
+            timezone.now().date()
+            + relativedelta(
+                months=+SecurityReleaseOutcomeDuration.DEFAULT_DURATION_MONTHS,
+            )
+        ).isoformat()
         response = post_to_step(
             OutcomeSteps.SELECT_OUTCOME,
             {
                 "outcome": "refuse",
                 "security_release_requests": request_ids,
+                "validity_start_date_0": validity_start_date.split("-")[2],
+                "validity_start_date_1": validity_start_date.split("-")[1],
+                "validity_start_date_2": validity_start_date.split("-")[0],
+                "validity_end_date_0": validity_end_date.split("-")[2],
+                "validity_end_date_1": validity_end_date.split("-")[1],
+                "validity_end_date_2": validity_end_date.split("-")[0],
             },
         )
         assert response.status_code == HTTPStatus.OK
@@ -553,6 +639,8 @@ class TestDecideOutcomeView:
             "outcome": "refuse",
             "refusal_reasons": "my reasons",
             "security_release_requests": request_ids,
+            "validity_start_date": validity_start_date,
+            "validity_end_date": validity_end_date,
         }
 
     def test_POST_refuse_bad_request(
@@ -567,11 +655,24 @@ class TestDecideOutcomeView:
     ):
         security_release_requests = data_submitted_f680_case["case"]["data"]["security_release_requests"]
         request_ids = [request["id"] for request in security_release_requests]
+        validity_start_date = timezone.now().date().isoformat()
+        validity_end_date = (
+            timezone.now().date()
+            + relativedelta(
+                months=+SecurityReleaseOutcomeDuration.DEFAULT_DURATION_MONTHS,
+            )
+        ).isoformat()
         response = post_to_step(
             OutcomeSteps.SELECT_OUTCOME,
             {
                 "outcome": "refuse",
                 "security_release_requests": request_ids,
+                "validity_start_date_0": validity_start_date.split("-")[2],
+                "validity_start_date_1": validity_start_date.split("-")[1],
+                "validity_start_date_2": validity_start_date.split("-")[0],
+                "validity_end_date_0": validity_end_date.split("-")[2],
+                "validity_end_date_1": validity_end_date.split("-")[1],
+                "validity_end_date_2": validity_end_date.split("-")[0],
             },
         )
         assert response.status_code == HTTPStatus.OK
@@ -583,7 +684,7 @@ class TestDecideOutcomeView:
         assert response.status_code == HTTPStatus.OK
         form = response.context["form"]
         assert form.errors == {
-            "refusal_reasons": ["This field is required."],
+            "refusal_reasons": ["Enter refusal reasons"],
         }
 
 

--- a/caseworker/f680/outcome/tests/test_views.py
+++ b/caseworker/f680/outcome/tests/test_views.py
@@ -1,4 +1,6 @@
 import pytest
+
+from freezegun import freeze_time
 from http import HTTPStatus
 
 from dateutil.relativedelta import relativedelta
@@ -273,24 +275,11 @@ class TestDecideOutcomeView:
     ):
         security_release_requests = data_submitted_f680_case["case"]["data"]["security_release_requests"]
         request_ids = [request["id"] for request in security_release_requests]
-        validity_start_date = timezone.now().date().isoformat()
-        validity_end_date = (
-            timezone.now().date()
-            + relativedelta(
-                months=+SecurityReleaseOutcomeDuration.DEFAULT_DURATION_MONTHS,
-            )
-        ).isoformat()
         response = post_to_step(
             OutcomeSteps.SELECT_OUTCOME,
             {
                 "outcome": outcome,
                 "security_release_requests": request_ids,
-                "validity_start_date_0": validity_start_date.split("-")[2],
-                "validity_start_date_1": validity_start_date.split("-")[1],
-                "validity_start_date_2": validity_start_date.split("-")[0],
-                "validity_end_date_0": validity_end_date.split("-")[2],
-                "validity_end_date_1": validity_end_date.split("-")[1],
-                "validity_end_date_2": validity_end_date.split("-")[0],
             },
         )
         assert response.status_code == HTTPStatus.OK
@@ -366,24 +355,11 @@ class TestDecideOutcomeView:
     ):
         security_release_requests = data_submitted_f680_case["case"]["data"]["security_release_requests"]
         request_ids = [request["id"] for request in security_release_requests]
-        validity_start_date = timezone.now().date().isoformat()
-        validity_end_date = (
-            timezone.now().date()
-            + relativedelta(
-                months=+SecurityReleaseOutcomeDuration.DEFAULT_DURATION_MONTHS,
-            )
-        ).isoformat()
         response = post_to_step(
             OutcomeSteps.SELECT_OUTCOME,
             {
                 "outcome": "approve",
                 "security_release_requests": request_ids,
-                "validity_start_date_0": validity_start_date.split("-")[2],
-                "validity_start_date_1": validity_start_date.split("-")[1],
-                "validity_start_date_2": validity_start_date.split("-")[0],
-                "validity_end_date_0": validity_end_date.split("-")[2],
-                "validity_end_date_1": validity_end_date.split("-")[1],
-                "validity_end_date_2": validity_end_date.split("-")[0],
             },
         )
         assert response.status_code == HTTPStatus.OK
@@ -413,10 +389,9 @@ class TestDecideOutcomeView:
         assert form.errors == {
             "outcome": ["Select if you approve or refuse"],
             "security_release_requests": ["This field is required."],
-            "validity_start_date": ["Enter the validity start date"],
-            "validity_end_date": ["Enter the validity end date"],
         }
 
+    @freeze_time("2025-04-15")
     def test_POST_approve(
         self,
         authorized_client,
@@ -434,7 +409,7 @@ class TestDecideOutcomeView:
         validity_end_date = (
             timezone.now().date()
             + relativedelta(
-                months=+SecurityReleaseOutcomeDuration.DEFAULT_DURATION_MONTHS,
+                months=+SecurityReleaseOutcomeDuration.MONTHS_48,
             )
         ).isoformat()
         response = post_to_step(
@@ -442,12 +417,6 @@ class TestDecideOutcomeView:
             {
                 "outcome": "approve",
                 "security_release_requests": request_ids,
-                "validity_start_date_0": validity_start_date.split("-")[2],
-                "validity_start_date_1": validity_start_date.split("-")[1],
-                "validity_start_date_2": validity_start_date.split("-")[0],
-                "validity_end_date_0": validity_end_date.split("-")[2],
-                "validity_end_date_1": validity_end_date.split("-")[1],
-                "validity_end_date_2": validity_end_date.split("-")[0],
             },
         )
         assert response.status_code == HTTPStatus.OK
@@ -458,6 +427,10 @@ class TestDecideOutcomeView:
                 "conditions": "my conditions",
                 "approval_types": ["training"],
                 "security_grading": "secret",
+                "validity_start_date_0": validity_start_date.split("-")[2],
+                "validity_start_date_1": validity_start_date.split("-")[1],
+                "validity_start_date_2": validity_start_date.split("-")[0],
+                "validity_period": SecurityReleaseOutcomeDuration.MONTHS_48,
             },
             follow=True,
         )
@@ -494,24 +467,11 @@ class TestDecideOutcomeView:
     ):
         security_release_requests = data_submitted_f680_case["case"]["data"]["security_release_requests"]
         request_ids = [request["id"] for request in security_release_requests]
-        validity_start_date = timezone.now().date().isoformat()
-        validity_end_date = (
-            timezone.now().date()
-            + relativedelta(
-                months=+SecurityReleaseOutcomeDuration.DEFAULT_DURATION_MONTHS,
-            )
-        ).isoformat()
         response = post_to_step(
             OutcomeSteps.SELECT_OUTCOME,
             {
                 "outcome": "approve",
                 "security_release_requests": request_ids,
-                "validity_start_date_0": validity_start_date.split("-")[2],
-                "validity_start_date_1": validity_start_date.split("-")[1],
-                "validity_start_date_2": validity_start_date.split("-")[0],
-                "validity_end_date_0": validity_end_date.split("-")[2],
-                "validity_end_date_1": validity_end_date.split("-")[1],
-                "validity_end_date_2": validity_end_date.split("-")[0],
             },
         )
         assert response.status_code == HTTPStatus.OK
@@ -525,8 +485,11 @@ class TestDecideOutcomeView:
         assert form.errors == {
             "security_grading": ["Select the security release"],
             "approval_types": ["Select approval types"],
+            "validity_start_date": ["Enter the validity start date"],
+            "validity_period": ["Select validity period"],
         }
 
+    @freeze_time("2025-04-15")
     def test_POST_partial_approve(
         self,
         authorized_client,
@@ -545,7 +508,7 @@ class TestDecideOutcomeView:
         validity_end_date = (
             timezone.now().date()
             + relativedelta(
-                months=+SecurityReleaseOutcomeDuration.DEFAULT_DURATION_MONTHS,
+                months=+SecurityReleaseOutcomeDuration.MONTHS_24,
             )
         ).isoformat()
         response = post_to_step(
@@ -553,12 +516,6 @@ class TestDecideOutcomeView:
             {
                 "outcome": "approve",
                 "security_release_requests": request_ids,
-                "validity_start_date_0": validity_start_date.split("-")[2],
-                "validity_start_date_1": validity_start_date.split("-")[1],
-                "validity_start_date_2": validity_start_date.split("-")[0],
-                "validity_end_date_0": validity_end_date.split("-")[2],
-                "validity_end_date_1": validity_end_date.split("-")[1],
-                "validity_end_date_2": validity_end_date.split("-")[0],
             },
         )
         assert response.status_code == HTTPStatus.OK
@@ -569,6 +526,10 @@ class TestDecideOutcomeView:
                 "conditions": "my conditions",
                 "approval_types": ["training"],
                 "security_grading": "secret",
+                "validity_start_date_0": validity_start_date.split("-")[2],
+                "validity_start_date_1": validity_start_date.split("-")[1],
+                "validity_start_date_2": validity_start_date.split("-")[0],
+                "validity_period": SecurityReleaseOutcomeDuration.MONTHS_24,
             },
             follow=True,
         )
@@ -604,24 +565,11 @@ class TestDecideOutcomeView:
     ):
         security_release_requests = data_submitted_f680_case["case"]["data"]["security_release_requests"]
         request_ids = [request["id"] for request in security_release_requests]
-        validity_start_date = timezone.now().date().isoformat()
-        validity_end_date = (
-            timezone.now().date()
-            + relativedelta(
-                months=+SecurityReleaseOutcomeDuration.DEFAULT_DURATION_MONTHS,
-            )
-        ).isoformat()
         response = post_to_step(
             OutcomeSteps.SELECT_OUTCOME,
             {
                 "outcome": "refuse",
                 "security_release_requests": request_ids,
-                "validity_start_date_0": validity_start_date.split("-")[2],
-                "validity_start_date_1": validity_start_date.split("-")[1],
-                "validity_start_date_2": validity_start_date.split("-")[0],
-                "validity_end_date_0": validity_end_date.split("-")[2],
-                "validity_end_date_1": validity_end_date.split("-")[1],
-                "validity_end_date_2": validity_end_date.split("-")[0],
             },
         )
         assert response.status_code == HTTPStatus.OK
@@ -639,8 +587,6 @@ class TestDecideOutcomeView:
             "outcome": "refuse",
             "refusal_reasons": "my reasons",
             "security_release_requests": request_ids,
-            "validity_start_date": validity_start_date,
-            "validity_end_date": validity_end_date,
         }
 
     def test_POST_refuse_bad_request(
@@ -655,24 +601,11 @@ class TestDecideOutcomeView:
     ):
         security_release_requests = data_submitted_f680_case["case"]["data"]["security_release_requests"]
         request_ids = [request["id"] for request in security_release_requests]
-        validity_start_date = timezone.now().date().isoformat()
-        validity_end_date = (
-            timezone.now().date()
-            + relativedelta(
-                months=+SecurityReleaseOutcomeDuration.DEFAULT_DURATION_MONTHS,
-            )
-        ).isoformat()
         response = post_to_step(
             OutcomeSteps.SELECT_OUTCOME,
             {
                 "outcome": "refuse",
                 "security_release_requests": request_ids,
-                "validity_start_date_0": validity_start_date.split("-")[2],
-                "validity_start_date_1": validity_start_date.split("-")[1],
-                "validity_start_date_2": validity_start_date.split("-")[0],
-                "validity_end_date_0": validity_end_date.split("-")[2],
-                "validity_end_date_1": validity_end_date.split("-")[1],
-                "validity_end_date_2": validity_end_date.split("-")[0],
             },
         )
         assert response.status_code == HTTPStatus.OK

--- a/caseworker/f680/templates/f680/case/outcome/includes/outcomes_table.html
+++ b/caseworker/f680/templates/f680/case/outcome/includes/outcomes_table.html
@@ -21,6 +21,8 @@
                 {% for security_release in outcome.security_release_requests %}
                     {{security_release.recipient.name}}, {{security_release.recipient.country.name}}<br/>
                 {% endfor %}
+                <br><br>
+                Valid from {{ outcome.validity_start_date|parse_date|date:"d-m-Y" }} for {{ outcome.validity_period }} months
             </td>
             <td class="govuk-table__cell govuk-table__cell--max-width-400 ">
                 {{outcome.outcome|capfirst}}

--- a/core/common/validators.py
+++ b/core/common/validators.py
@@ -1,0 +1,35 @@
+from datetime import date
+from dateutil.relativedelta import relativedelta
+
+from django.core.exceptions import ValidationError
+
+
+class FutureDateValidator:
+    def __init__(self, message, include_today=False):
+        self.message = message
+        self.include_today = include_today
+
+    def __call__(self, value):
+        if value == date.today() and self.include_today:
+            return
+        if value <= date.today():
+            raise ValidationError(self.message)
+
+
+class PastDateValidator:
+    def __init__(self, message):
+        self.message = message
+
+    def __call__(self, value):
+        if value > date.today():
+            raise ValidationError(self.message)
+
+
+class RelativeDeltaDateValidator:
+    def __init__(self, message, **kwargs):
+        self.message = message
+        self.relativedelta = relativedelta(**kwargs)
+
+    def __call__(self, value):
+        if value > (date.today() + self.relativedelta):
+            raise ValidationError(self.message)

--- a/core/common/validators.py
+++ b/core/common/validators.py
@@ -1,5 +1,4 @@
 from datetime import date
-from dateutil.relativedelta import relativedelta
 
 from django.core.exceptions import ValidationError
 

--- a/core/common/validators.py
+++ b/core/common/validators.py
@@ -14,22 +14,3 @@ class FutureDateValidator:
             return
         if value <= date.today():
             raise ValidationError(self.message)
-
-
-class PastDateValidator:
-    def __init__(self, message):
-        self.message = message
-
-    def __call__(self, value):
-        if value > date.today():
-            raise ValidationError(self.message)
-
-
-class RelativeDeltaDateValidator:
-    def __init__(self, message, **kwargs):
-        self.message = message
-        self.relativedelta = relativedelta(**kwargs)
-
-    def __call__(self, value):
-        if value > (date.today() + self.relativedelta):
-            raise ValidationError(self.message)


### PR DESCRIPTION
## Change description

Security outcomes are typically valid for 24/48 months but we are not capturing this at the moment.
Update forms to have start date and duration so user can specify a valid 24/48 month period for each outcome.

Data model changes are in this PR https://github.com/uktrade/lite-api/pull/2508

[LTD-6140](https://uktrade.atlassian.net/browse/LTD-6140)


[LTD-6140]: https://uktrade.atlassian.net/browse/LTD-6140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ