### PR TITLE
[LTD-6055] Show security grading other on F680 product table

### DIFF
--- a/caseworker/f680/templates/f680/includes/product_table.html
+++ b/caseworker/f680/templates/f680/includes/product_table.html
@@ -21,8 +21,8 @@
                 {{case.data.product.security_grading.value}}
             </td>
             <td class="govuk-table__cell govuk-table__cell--max-width-400 ">
-                {% if case.product.security_grading_other %}
-                    {{case.product.security_grading_other}}
+                {% if case.data.product.security_grading_other %}
+                    {{case.data.product.security_grading_other}}
                 {% else %}
                     -
                 {% endif %}


### PR DESCRIPTION
### Aim

Show a value for `security_grading_other` in the product table on F680 summary page.

[LTD-6055](https://uktrade.atlassian.net/browse/LTD-6055)


[LTD-6055]: https://uktrade.atlassian.net/browse/LTD-6055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ