### PR TITLE
[LTD-6164] Make validity_start_date initial value evaluate at runtime instead of module-load

### DIFF
--- a/caseworker/f680/outcome/forms.py
+++ b/caseworker/f680/outcome/forms.py
@@ -88,7 +88,7 @@ class ApproveOutcomeForm(BaseForm):
         label="Validity start date",
         help_text="For example 25 2 2025",
         require_all_fields=False,
-        initial=timezone.now().date(),
+        initial=timezone.now,
         error_messages={
             "required": "Enter the validity start date",
             "incomplete": "Enter the validity start date",


### PR DESCRIPTION
### Aim
Make validity_start_date initial value evaluate at runtime instead of module-load


[LTD-6164](https://uktrade.atlassian.net/browse/LTD-6164)


[LTD-6164]: https://uktrade.atlassian.net/browse/LTD-6164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ