### PR TITLE
Make the internal case details page work for Export Licence types

### DIFF
--- a/caseworker/activities/views.py
+++ b/caseworker/activities/views.py
@@ -41,6 +41,6 @@ class NotesAndTimeline(LoginRequiredMixin, CaseTabsMixin, CaseworkerMixin, Notes
             **context,
             "case": self.case,
             "queue": self.queue,
-            "tabs": self.get_standard_application_tabs(),
+            "tabs": self.get_tabs(),
             "current_tab": "cases:activities:notes-and-timeline",
         }

--- a/caseworker/advice/views/views.py
+++ b/caseworker/advice/views/views.py
@@ -150,7 +150,7 @@ class AdviceDetailView(LoginRequiredMixin, CaseTabsMixin, CaseContextMixin, DESN
             "nlr_products": nlr_products,
             "advice_completed": advice_completed,
             "denial_reasons_display": self.denial_reasons_display,
-            "tabs": self.get_standard_application_tabs(),
+            "tabs": self.get_tabs(),
             "current_tab": "cases:view_my_advice",
             "security_approvals_classified_display": self.security_approvals_classified_display,
             "assessed_trigger_list_goods": self.assessed_trigger_list_goods,
@@ -298,7 +298,7 @@ class AdviceView(LoginRequiredMixin, CaseTabsMixin, CaseContextMixin, DESNZNucle
             "security_approvals_classified_display": self.security_approvals_classified_display,
             "assessed_trigger_list_goods": self.assessed_trigger_list_goods,
             "unassessed_trigger_list_goods": self.unassessed_trigger_list_goods,
-            "tabs": self.get_standard_application_tabs(),
+            "tabs": self.get_tabs(),
             "current_tab": "cases:advice_view",
             **services.get_advice_tab_context(
                 self.case,

--- a/caseworker/cases/helpers/case.py
+++ b/caseworker/cases/helpers/case.py
@@ -254,10 +254,8 @@ class CaseView(CaseworkerMixin, TemplateView):
 
         self._transform_data()
 
-        if hasattr(self, "get_" + self.case.sub_type + "_" + self.case.type):
-            getattr(self, "get_" + self.case.sub_type + "_" + self.case.type)()
-        else:
-            getattr(self, "get_" + self.case.sub_type)()
+        self.get_standard_application()
+
         return render(request, "case/case.html", self.get_context())
 
 

--- a/caseworker/cases/helpers/case.py
+++ b/caseworker/cases/helpers/case.py
@@ -254,6 +254,7 @@ class CaseView(CaseworkerMixin, TemplateView):
 
         self._transform_data()
 
+        self.tabs = self.get_tabs()
         self.get_standard_application()
 
         return render(request, "case/case.html", self.get_context())

--- a/caseworker/cases/helpers/case.py
+++ b/caseworker/cases/helpers/case.py
@@ -1,34 +1,12 @@
-import rules
-from dateutil.parser import parse
-from decimal import Decimal
-
-from django.shortcuts import render
 from django.urls import reverse
-from django.utils import timezone
 from django.utils.functional import cached_property
-from django.views.generic import TemplateView
 
-from caseworker.cases.helpers.licence import get_latest_licence_status
-from caseworker.queues.forms import CaseAssignmentsAllocateToMeForm
-from core.constants import CaseStatusEnum, SecurityClassifiedApprovalsType
-
-from caseworker.cases.forms.queries import CloseQueryForm
-from caseworker.cases.helpers.ecju_queries import get_ecju_queries
-from caseworker.cases.objects import Slice, Case
-from caseworker.cases.services import (
-    get_case,
-    get_user_case_queues,
-    get_case_documents,
-    get_case_additional_contacts,
-    get_activity_filters,
-)
-from caseworker.core.constants import GENERATED_DOCUMENT
-from caseworker.core.helpers import generate_activity_filters
-from caseworker.core.objects import Tab
-from caseworker.core.services import get_user_permissions, get_status_properties, get_permissible_statuses
 from lite_content.lite_internal_frontend import cases
-from lite_content.lite_internal_frontend.cases import CasePage, ApplicationPage
-from caseworker.queues.services import get_queue
+from lite_content.lite_internal_frontend.cases import CasePage
+
+from caseworker.cases.objects import Slice
+from caseworker.core.objects import Tab
+from caseworker.queues.forms import CaseAssignmentsAllocateToMeForm
 from caseworker.users.services import get_gov_user
 
 
@@ -126,138 +104,6 @@ class CaseworkerMixin:
             "allocate_to_me_form": allocate_to_me_form,
             "allocate_and_approve_form": allocate_and_approve_form,
         }
-
-
-class CaseView(CaseworkerMixin, TemplateView):
-    case_id = None
-    case: Case = None
-    queue_id = None
-    queue = None
-    permissions = None
-    tabs = None
-    slices = None
-    additional_context = {}
-
-    def is_only_on_post_circ_queue(self):
-        queue_alias = tuple(queue.get("alias") for queue in self.case.queue_details)
-        return self.is_lu_user() and queue_alias == (LU_POST_CIRC_FINALISE_QUEUE_ALIAS,)
-
-    def get_goods_summary(self):
-        goods_summary = {
-            "names": list(),
-            "cles": set(),
-            "regimes": set(),
-            "report_summaries": set(),
-            "total_value": 0,
-        }
-        for good in self.case.goods:
-            goods_summary["cles"].update(list(cle["rating"] for cle in good["control_list_entries"]))
-            goods_summary["regimes"].update(list(regime["name"] for regime in good["regime_entries"]))
-            goods_summary["names"].append(good["good"]["name"])
-            if "report_summary_subject" in good and good["report_summary_subject"]:
-                report_summary = good["report_summary_subject"]["name"]
-                if "report_summary_prefix" in good and good["report_summary_prefix"]:
-                    report_summary = f"{good['report_summary_prefix']['name']} {report_summary}"
-                goods_summary["report_summaries"].add(report_summary)
-            # support legacy report_summary field until it is removed
-            elif good.get("report_summary"):
-                goods_summary["report_summaries"].add(good["report_summary"])
-
-            goods_summary["total_value"] += Decimal(good["value"])
-        return goods_summary
-
-    def get_destination_countries(self):
-        destination_countries = set()
-        all_parties = self.case.data.get("ultimate_end_users", []) + self.case.data.get("third_parties", [])
-        if self.case.data.get("end_user"):
-            all_parties.append(self.case.data["end_user"])
-        if self.case.data.get("consignee"):
-            all_parties.append(self.case.data["consignee"])
-        for party in all_parties:
-            destination_countries.add(party["country"]["name"])
-        return destination_countries
-
-    def get_open_ecju_queries_with_forms(self, open_ecju_queries):
-        open_ecju_queries_with_forms = []
-        for open_query in open_ecju_queries:
-            open_ecju_queries_with_forms.append((open_query, CloseQueryForm(prefix=str(open_query["id"]))))
-        return open_ecju_queries_with_forms
-
-    def get_context(self):
-        if not self.tabs:
-            self.tabs = []
-        if not self.slices:
-            self.slices = []
-        open_ecju_queries, closed_ecju_queries = get_ecju_queries(self.request, self.case_id)
-        open_ecju_queries_with_forms = self.get_open_ecju_queries_with_forms(open_ecju_queries)
-        user_assigned_queues = get_user_case_queues(self.request, self.case_id)[0]
-        status_props, _ = get_status_properties(self.request, self.case.data["status"]["key"])
-        can_set_done = (
-            status_props["is_terminal"]
-            and self.case.data["status"]["key"] != CaseStatusEnum.APPLICANT_EDITING
-            and not self.is_tau_user()
-        )
-
-        context = super().get_context_data()
-        default_tab = "quick-summary"
-        current_tab = default_tab if self.kwargs["tab"] == "default" else self.kwargs["tab"]
-        show_actions_column = False
-        for licence in self.case.licences:
-            if rules.test_rule("can_licence_status_be_changed", self.request, licence):
-                show_actions_column = True
-                break
-
-        return {
-            **context,
-            "tabs": self.tabs if self.tabs else self.get_tabs(),
-            "current_tab": current_tab,
-            "slices": [Slices.SUMMARY, *self.slices],
-            "case": self.case,
-            "queue": self.queue,
-            "is_system_queue": self.queue["is_system_queue"],
-            "goods_summary": self.get_goods_summary(),
-            "destination_countries": self.get_destination_countries(),
-            "user_assigned_queues": user_assigned_queues,
-            "case_documents": get_case_documents(self.request, self.case_id)[0]["documents"],
-            "open_queries": open_ecju_queries_with_forms,
-            "closed_queries": closed_ecju_queries,
-            "additional_contacts": get_case_additional_contacts(self.request, self.case_id),
-            "permissions": self.permissions,
-            "is_tau_user": self.is_tau_user(),
-            "hide_im_done": self.is_tau_user() or self.is_only_on_post_circ_queue(),
-            "can_set_done": can_set_done
-            and (self.queue["is_system_queue"] and user_assigned_queues)
-            or not self.queue["is_system_queue"],
-            "generated_document_key": GENERATED_DOCUMENT,
-            "permissible_statuses": get_permissible_statuses(self.request, self.case),
-            "filters": generate_activity_filters(get_activity_filters(self.request, self.case_id), ApplicationPage),
-            "is_terminal": status_props["is_terminal"],
-            "security_classified_approvals_types": SecurityClassifiedApprovalsType,
-            "user": self.caseworker,
-            "show_actions_column": show_actions_column,
-            "licence_status": get_latest_licence_status(self.case),
-            **self.additional_context,
-        }
-
-    def _transform_data(self):
-        self.case.total_days_elapsed = (timezone.now() - parse(self.case.submitted_at)).days
-        if self.case.queue_details:
-            for queue_detail in self.case.queue_details:
-                queue_detail["days_on_queue_elapsed"] = (timezone.now() - parse(queue_detail["joined_queue_at"])).days
-
-    def get(self, request, *args, **kwargs):
-        self.case_id = str(kwargs["pk"])
-        self.case = get_case(request, self.case_id)
-        self.queue_id = kwargs["queue_pk"]
-        self.queue = get_queue(request, self.queue_id)
-        self.permissions = get_user_permissions(self.request)
-
-        self._transform_data()
-
-        self.tabs = self.get_tabs()
-        self.get_standard_application()
-
-        return render(request, "case/case.html", self.get_context())
 
 
 def get_case_detail_url(case_id, case_type, queue_id):

--- a/caseworker/cases/views/main.py
+++ b/caseworker/cases/views/main.py
@@ -10,7 +10,6 @@ from django.contrib.messages.views import SuccessMessageMixin
 from django.http import Http404
 from django.shortcuts import (
     redirect,
-    render,
 )
 from django.urls import reverse, reverse_lazy
 from django.utils import timezone
@@ -166,6 +165,8 @@ class CaseTabsMixin:
 
 
 class CaseDetail(CaseTabsMixin, CaseworkerMixin, TemplateView):
+    template_name = "case/case.html"
+
     def get_advice_additional_context(self):
         status_props, _ = get_status_properties(self.request, self.case.data["status"]["key"])
         current_advice_level = ["user"]
@@ -281,7 +282,7 @@ class CaseDetail(CaseTabsMixin, CaseworkerMixin, TemplateView):
             open_ecju_queries_with_forms.append((open_query, CloseQueryForm(prefix=str(open_query["id"]))))
         return open_ecju_queries_with_forms
 
-    def get_context_data(self):
+    def get_context_data(self, *args, **kwargs):
         open_ecju_queries, closed_ecju_queries = get_ecju_queries(self.request, self.case_id)
         open_ecju_queries_with_forms = self.get_open_ecju_queries_with_forms(open_ecju_queries)
         user_assigned_queues = get_user_case_queues(self.request, self.case_id)[0]
@@ -292,7 +293,7 @@ class CaseDetail(CaseTabsMixin, CaseworkerMixin, TemplateView):
             and not self.is_tau_user()
         )
 
-        context = super().get_context_data()
+        context = super().get_context_data(*args, **kwargs)
         default_tab = "quick-summary"
         current_tab = default_tab if self.kwargs["tab"] == "default" else self.kwargs["tab"]
         show_actions_column = False
@@ -368,7 +369,7 @@ class CaseDetail(CaseTabsMixin, CaseworkerMixin, TemplateView):
         self.slices = self.get_slices()
         self.additional_context = self.get_advice_additional_context()
 
-        return render(request, "case/case.html", self.get_context_data())
+        return super().get(request, *args, **kwargs)
 
 
 class CaseNotes(TemplateView):

--- a/caseworker/cases/views/main.py
+++ b/caseworker/cases/views/main.py
@@ -171,8 +171,6 @@ class CaseDetail(CaseTabsMixin, CaseworkerMixin, TemplateView):
     queue_id = None
     queue = None
     permissions = None
-    tabs = None
-    slices = None
     additional_context = {}
 
     def get_advice_additional_context(self):
@@ -291,10 +289,6 @@ class CaseDetail(CaseTabsMixin, CaseworkerMixin, TemplateView):
         return open_ecju_queries_with_forms
 
     def get_context(self):
-        if not self.tabs:
-            self.tabs = []
-        if not self.slices:
-            self.slices = []
         open_ecju_queries, closed_ecju_queries = get_ecju_queries(self.request, self.case_id)
         open_ecju_queries_with_forms = self.get_open_ecju_queries_with_forms(open_ecju_queries)
         user_assigned_queues = get_user_case_queues(self.request, self.case_id)[0]

--- a/caseworker/cases/views/main.py
+++ b/caseworker/cases/views/main.py
@@ -281,7 +281,7 @@ class CaseDetail(CaseTabsMixin, CaseworkerMixin, TemplateView):
             open_ecju_queries_with_forms.append((open_query, CloseQueryForm(prefix=str(open_query["id"]))))
         return open_ecju_queries_with_forms
 
-    def get_context(self):
+    def get_context_data(self):
         open_ecju_queries, closed_ecju_queries = get_ecju_queries(self.request, self.case_id)
         open_ecju_queries_with_forms = self.get_open_ecju_queries_with_forms(open_ecju_queries)
         user_assigned_queues = get_user_case_queues(self.request, self.case_id)[0]
@@ -368,7 +368,7 @@ class CaseDetail(CaseTabsMixin, CaseworkerMixin, TemplateView):
         self.slices = self.get_slices()
         self.additional_context = self.get_advice_additional_context()
 
-        return render(request, "case/case.html", self.get_context())
+        return render(request, "case/case.html", self.get_context_data())
 
 
 class CaseNotes(TemplateView):

--- a/caseworker/cases/views/main.py
+++ b/caseworker/cases/views/main.py
@@ -245,9 +245,6 @@ class CaseDetail(CaseTabsMixin, CaseworkerMixin, TemplateView):
             "blocking_flags": blocking_flags,
         }
 
-    def get_standard_application(self):
-        self.additional_context = self.get_advice_additional_context()
-
     def is_only_on_post_circ_queue(self):
         queue_alias = tuple(queue.get("alias") for queue in self.case.queue_details)
         return self.is_lu_user() and queue_alias == (LU_POST_CIRC_FINALISE_QUEUE_ALIAS,)
@@ -382,7 +379,7 @@ class CaseDetail(CaseTabsMixin, CaseworkerMixin, TemplateView):
 
         self.tabs = self.get_tabs()
         self.slices = self.get_slices()
-        self.get_standard_application()
+        self.additional_context = self.get_advice_additional_context()
 
         return render(request, "case/case.html", self.get_context())
 

--- a/caseworker/cases/views/main.py
+++ b/caseworker/cases/views/main.py
@@ -356,7 +356,9 @@ class CaseDetail(CaseTabsMixin, CaseworkerMixin, TemplateView):
             conditional(self.case.data["appeal"], Slices.APPEAL_DETAILS),
         ]
 
-    def get(self, request, *args, **kwargs):
+    def setup(self, request, *args, **kwargs):
+        super().setup(request, *args, **kwargs)
+
         self.case_id = str(kwargs["pk"])
         self.case = get_case(request, self.case_id)
         self.queue_id = kwargs["queue_pk"]
@@ -368,8 +370,6 @@ class CaseDetail(CaseTabsMixin, CaseworkerMixin, TemplateView):
         self.tabs = self.get_tabs()
         self.slices = self.get_slices()
         self.additional_context = self.get_advice_additional_context()
-
-        return super().get(request, *args, **kwargs)
 
 
 class CaseNotes(TemplateView):

--- a/caseworker/cases/views/main.py
+++ b/caseworker/cases/views/main.py
@@ -1,15 +1,19 @@
-from core.constants import LicenceStatusEnum
 import rules
 
+from dateutil.parser import parse
+from decimal import Decimal
 from logging import getLogger
-
 from http import HTTPStatus
 
 from django.conf import settings
 from django.contrib.messages.views import SuccessMessageMixin
 from django.http import Http404
-from django.shortcuts import redirect
+from django.shortcuts import (
+    redirect,
+    render,
+)
 from django.urls import reverse, reverse_lazy
+from django.utils import timezone
 from django.utils.functional import cached_property
 from django.views.generic import (
     FormView,
@@ -21,6 +25,11 @@ from requests.exceptions import HTTPError
 
 from core.auth.views import LoginRequiredMixin
 from core.builtins.custom_tags import filter_advice_by_level
+from core.constants import (
+    CaseStatusEnum,
+    LicenceStatusEnum,
+    SecurityClassifiedApprovalsType,
+)
 from core.decorators import expect_status
 from core.exceptions import APIError
 from core.helpers import (
@@ -30,6 +39,7 @@ from core.helpers import (
 from core.services import stream_document
 from lite_content.lite_internal_frontend import cases
 from lite_content.lite_internal_frontend.cases import (
+    ApplicationPage,
     CasePage,
     DoneWithCaseOnQueueForm,
     Manage,
@@ -43,13 +53,24 @@ from caseworker.advice.services import get_advice_tab_context
 from caseworker.cases.forms.attach_documents import attach_documents_form
 from caseworker.cases.forms.change_status import ChangeStatusForm
 from caseworker.cases.forms.change_sub_status import ChangeSubStatusForm
-from caseworker.cases.forms.change_licence_status import ChangeLicenceStatusConfirmationForm, ChangeLicenceStatusForm
+from caseworker.cases.forms.change_licence_status import (
+    ChangeLicenceStatusConfirmationForm,
+    ChangeLicenceStatusForm,
+)
 from caseworker.cases.forms.done_with_case import done_with_case_form
 from caseworker.cases.forms.move_case import move_case_form
+from caseworker.cases.forms.queries import CloseQueryForm
 from caseworker.cases.forms.reissue_ogl_form import reissue_ogl_confirmation_form
 from caseworker.cases.forms.rerun_routing_rules import rerun_routing_rules_confirmation_form
 import caseworker.cases.helpers.advice as advice_helpers
-from caseworker.cases.helpers.case import CaseView, Tabs, Slices
+from caseworker.cases.helpers.case import (
+    CaseworkerMixin,
+    LU_POST_CIRC_FINALISE_QUEUE_ALIAS,
+    Slices,
+    Tabs,
+)
+from caseworker.cases.helpers.ecju_queries import get_ecju_queries
+from caseworker.cases.helpers.licence import get_latest_licence_status
 from caseworker.cases.services import (
     get_case,
     post_case_notes,
@@ -64,10 +85,20 @@ from caseworker.cases.services import (
     put_case_sub_status,
     get_licence_details,
     update_licence_details,
+    get_case_documents,
+    get_case_additional_contacts,
+    get_activity_filters,
+    get_case_basic_details,
+    get_user_case_queues,
 )
-from caseworker.cases.services import get_case_basic_details
+from caseworker.core.constants import GENERATED_DOCUMENT
+from caseworker.core.helpers import generate_activity_filters
 from caseworker.core.objects import Tab
-from caseworker.core.services import get_status_properties, get_permissible_statuses
+from caseworker.core.services import (
+    get_permissible_statuses,
+    get_status_properties,
+    get_user_permissions,
+)
 from caseworker.core.constants import Permission
 from caseworker.queues.services import get_queue
 from caseworker.tau.utils import get_tau_tab_url_name
@@ -134,7 +165,16 @@ class CaseTabsMixin:
         )
 
 
-class CaseDetail(CaseTabsMixin, CaseView):
+class CaseDetail(CaseTabsMixin, CaseworkerMixin, TemplateView):
+    case_id = None
+    case = None
+    queue_id = None
+    queue = None
+    permissions = None
+    tabs = None
+    slices = None
+    additional_context = {}
+
     def get_advice_additional_context(self):
         status_props, _ = get_status_properties(self.request, self.case.data["status"]["key"])
         current_advice_level = ["user"]
@@ -221,6 +261,127 @@ class CaseDetail(CaseTabsMixin, CaseView):
             conditional(self.case.data["appeal"], Slices.APPEAL_DETAILS),
         ]
         self.additional_context = self.get_advice_additional_context()
+
+    def is_only_on_post_circ_queue(self):
+        queue_alias = tuple(queue.get("alias") for queue in self.case.queue_details)
+        return self.is_lu_user() and queue_alias == (LU_POST_CIRC_FINALISE_QUEUE_ALIAS,)
+
+    def get_goods_summary(self):
+        goods_summary = {
+            "names": list(),
+            "cles": set(),
+            "regimes": set(),
+            "report_summaries": set(),
+            "total_value": 0,
+        }
+        for good in self.case.goods:
+            goods_summary["cles"].update(list(cle["rating"] for cle in good["control_list_entries"]))
+            goods_summary["regimes"].update(list(regime["name"] for regime in good["regime_entries"]))
+            goods_summary["names"].append(good["good"]["name"])
+            if "report_summary_subject" in good and good["report_summary_subject"]:
+                report_summary = good["report_summary_subject"]["name"]
+                if "report_summary_prefix" in good and good["report_summary_prefix"]:
+                    report_summary = f"{good['report_summary_prefix']['name']} {report_summary}"
+                goods_summary["report_summaries"].add(report_summary)
+            # support legacy report_summary field until it is removed
+            elif good.get("report_summary"):
+                goods_summary["report_summaries"].add(good["report_summary"])
+
+            goods_summary["total_value"] += Decimal(good["value"])
+        return goods_summary
+
+    def get_destination_countries(self):
+        destination_countries = set()
+        all_parties = self.case.data.get("ultimate_end_users", []) + self.case.data.get("third_parties", [])
+        if self.case.data.get("end_user"):
+            all_parties.append(self.case.data["end_user"])
+        if self.case.data.get("consignee"):
+            all_parties.append(self.case.data["consignee"])
+        for party in all_parties:
+            destination_countries.add(party["country"]["name"])
+        return destination_countries
+
+    def get_open_ecju_queries_with_forms(self, open_ecju_queries):
+        open_ecju_queries_with_forms = []
+        for open_query in open_ecju_queries:
+            open_ecju_queries_with_forms.append((open_query, CloseQueryForm(prefix=str(open_query["id"]))))
+        return open_ecju_queries_with_forms
+
+    def get_context(self):
+        if not self.tabs:
+            self.tabs = []
+        if not self.slices:
+            self.slices = []
+        open_ecju_queries, closed_ecju_queries = get_ecju_queries(self.request, self.case_id)
+        open_ecju_queries_with_forms = self.get_open_ecju_queries_with_forms(open_ecju_queries)
+        user_assigned_queues = get_user_case_queues(self.request, self.case_id)[0]
+        status_props, _ = get_status_properties(self.request, self.case.data["status"]["key"])
+        can_set_done = (
+            status_props["is_terminal"]
+            and self.case.data["status"]["key"] != CaseStatusEnum.APPLICANT_EDITING
+            and not self.is_tau_user()
+        )
+
+        context = super().get_context_data()
+        default_tab = "quick-summary"
+        current_tab = default_tab if self.kwargs["tab"] == "default" else self.kwargs["tab"]
+        show_actions_column = False
+        for licence in self.case.licences:
+            if rules.test_rule("can_licence_status_be_changed", self.request, licence):
+                show_actions_column = True
+                break
+
+        return {
+            **context,
+            "tabs": self.tabs if self.tabs else self.get_tabs(),
+            "current_tab": current_tab,
+            "slices": [Slices.SUMMARY, *self.slices],
+            "case": self.case,
+            "queue": self.queue,
+            "is_system_queue": self.queue["is_system_queue"],
+            "goods_summary": self.get_goods_summary(),
+            "destination_countries": self.get_destination_countries(),
+            "user_assigned_queues": user_assigned_queues,
+            "case_documents": get_case_documents(self.request, self.case_id)[0]["documents"],
+            "open_queries": open_ecju_queries_with_forms,
+            "closed_queries": closed_ecju_queries,
+            "additional_contacts": get_case_additional_contacts(self.request, self.case_id),
+            "permissions": self.permissions,
+            "is_tau_user": self.is_tau_user(),
+            "hide_im_done": self.is_tau_user() or self.is_only_on_post_circ_queue(),
+            "can_set_done": can_set_done
+            and (self.queue["is_system_queue"] and user_assigned_queues)
+            or not self.queue["is_system_queue"],
+            "generated_document_key": GENERATED_DOCUMENT,
+            "permissible_statuses": get_permissible_statuses(self.request, self.case),
+            "filters": generate_activity_filters(get_activity_filters(self.request, self.case_id), ApplicationPage),
+            "is_terminal": status_props["is_terminal"],
+            "security_classified_approvals_types": SecurityClassifiedApprovalsType,
+            "user": self.caseworker,
+            "show_actions_column": show_actions_column,
+            "licence_status": get_latest_licence_status(self.case),
+            **self.additional_context,
+        }
+
+    def _transform_data(self):
+        self.case.total_days_elapsed = (timezone.now() - parse(self.case.submitted_at)).days
+        if self.case.queue_details:
+            for queue_detail in self.case.queue_details:
+                queue_detail["days_on_queue_elapsed"] = (timezone.now() - parse(queue_detail["joined_queue_at"])).days
+
+    def get(self, request, *args, **kwargs):
+        self.case_id = str(kwargs["pk"])
+        self.case = get_case(request, self.case_id)
+        self.queue_id = kwargs["queue_pk"]
+        self.queue = get_queue(request, self.queue_id)
+        self.permissions = get_user_permissions(self.request)
+
+        self._transform_data()
+
+        self.tabs = self.get_tabs()
+        self.get_standard_application()
+
+        return render(request, "case/case.html", self.get_context())
 
 
 class CaseNotes(TemplateView):

--- a/caseworker/cases/views/main.py
+++ b/caseworker/cases/views/main.py
@@ -166,13 +166,6 @@ class CaseTabsMixin:
 
 
 class CaseDetail(CaseTabsMixin, CaseworkerMixin, TemplateView):
-    case_id = None
-    case = None
-    queue_id = None
-    queue = None
-    permissions = None
-    additional_context = {}
-
     def get_advice_additional_context(self):
         status_props, _ = get_status_properties(self.request, self.case.data["status"]["key"])
         current_advice_level = ["user"]

--- a/caseworker/cases/views/main.py
+++ b/caseworker/cases/views/main.py
@@ -246,20 +246,6 @@ class CaseDetail(CaseTabsMixin, CaseworkerMixin, TemplateView):
         }
 
     def get_standard_application(self):
-        self.slices = [
-            Slices.GOODS,
-            Slices.DESTINATIONS,
-            conditional(self.case.data["denial_matches"], Slices.DENIAL_MATCHES),
-            conditional(self.case.data["sanction_matches"], Slices.SANCTION_MATCHES),
-            conditional(self.case.data["end_user"], Slices.END_USER_DOCUMENTS),
-            conditional(self.case.data["inactive_parties"], Slices.DELETED_ENTITIES),
-            Slices.LOCATIONS,
-            Slices.SECURITY_APPROVALS,
-            Slices.END_USE_DETAILS,
-            Slices.SUPPORTING_DOCUMENTS,
-            Slices.FREEDOM_OF_INFORMATION,
-            conditional(self.case.data["appeal"], Slices.APPEAL_DETAILS),
-        ]
         self.additional_context = self.get_advice_additional_context()
 
     def is_only_on_post_circ_queue(self):
@@ -369,6 +355,22 @@ class CaseDetail(CaseTabsMixin, CaseworkerMixin, TemplateView):
             for queue_detail in self.case.queue_details:
                 queue_detail["days_on_queue_elapsed"] = (timezone.now() - parse(queue_detail["joined_queue_at"])).days
 
+    def get_slices(self):
+        return [
+            Slices.GOODS,
+            Slices.DESTINATIONS,
+            conditional(self.case.data["denial_matches"], Slices.DENIAL_MATCHES),
+            conditional(self.case.data["sanction_matches"], Slices.SANCTION_MATCHES),
+            conditional(self.case.data["end_user"], Slices.END_USER_DOCUMENTS),
+            conditional(self.case.data["inactive_parties"], Slices.DELETED_ENTITIES),
+            Slices.LOCATIONS,
+            Slices.SECURITY_APPROVALS,
+            Slices.END_USE_DETAILS,
+            Slices.SUPPORTING_DOCUMENTS,
+            Slices.FREEDOM_OF_INFORMATION,
+            conditional(self.case.data["appeal"], Slices.APPEAL_DETAILS),
+        ]
+
     def get(self, request, *args, **kwargs):
         self.case_id = str(kwargs["pk"])
         self.case = get_case(request, self.case_id)
@@ -379,6 +381,7 @@ class CaseDetail(CaseTabsMixin, CaseworkerMixin, TemplateView):
         self._transform_data()
 
         self.tabs = self.get_tabs()
+        self.slices = self.get_slices()
         self.get_standard_application()
 
         return render(request, "case/case.html", self.get_context())

--- a/caseworker/tau/views.py
+++ b/caseworker/tau/views.py
@@ -186,7 +186,7 @@ class TAUMixin(CaseTabsMixin):
 
         context.update(
             {
-                "tabs": self.get_standard_application_tabs(),
+                "tabs": self.get_tabs(),
                 "current_tab": get_tau_tab_url_name(),
             }
         )


### PR DESCRIPTION
### Aim

Make the internal case details page work for Export Licence types.

I've additionally removed code that didn't pertain to Export Licences and SIELs for this view as we'll be implementing the F680s pattern moving forward.

There's also a bit of general refactoring of this view to tidy it up.

[LTD-6198](https://uktrade.atlassian.net/browse/LTD-6198)


[LTD-6198]: https://uktrade.atlassian.net/browse/LTD-6198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ