### PR TITLE
LTD-6199 - Remove the ability to manually set an F680 to finalised

### DIFF
--- a/caseworker/core/services.py
+++ b/caseworker/core/services.py
@@ -2,7 +2,7 @@ from cacheops import cached
 from collections import defaultdict
 from django.conf import settings
 
-from caseworker.advice.constants import LICENSING_UNIT_TEAM, MOD_ECJU
+from caseworker.advice.constants import LICENSING_UNIT_TEAM
 from caseworker.cases.constants import CaseType
 from caseworker.core.constants import CONTROL_LIST_ENTRIES_CACHE_TIMEOUT
 from caseworker.users.services import get_gov_user
@@ -95,8 +95,6 @@ def get_permissible_statuses(request, case):
             CaseStatusEnum.WITHDRAWN,
             CaseStatusEnum.REOPENED_FOR_CHANGES,
         ]
-        if user_team_alias == MOD_ECJU:
-            permissible_statuses.append(CaseStatusEnum.FINALISED)
 
     elif case.type == CaseType.APPLICATION.value:
         statuses, _ = get_statuses(request)

--- a/unit_tests/caseworker/core/test_services.py
+++ b/unit_tests/caseworker/core/test_services.py
@@ -6,7 +6,7 @@ from caseworker.cases.objects import Case
 from caseworker.cases.constants import CaseType
 from core.constants import CaseStatusEnum
 from core import client
-from caseworker.advice.constants import LICENSING_UNIT_TEAM, MOD_ECJU
+from caseworker.advice.constants import LICENSING_UNIT_TEAM
 
 
 def test_group_denial_reasons():
@@ -161,32 +161,5 @@ def test_get_permissible_statuses_for_f680(mock_request, mock_gov_user, data_sta
         CaseStatusEnum.OGD_ADVICE,
         CaseStatusEnum.UNDER_FINAL_REVIEW,
         CaseStatusEnum.WITHDRAWN,
-        CaseStatusEnum.REOPENED_FOR_CHANGES,
-    }
-
-
-def test_get_permissible_statuses_for_f680_mod_ecju_team(
-    mock_request, data_standard_case, requests_mock, gov_uk_user_id, mock_case_statuses
-):
-    data_standard_case["case"]["case_type"]["type"]["key"] = CaseType.SECURITY_CLEARANCE.value
-    data = {
-        "user": {
-            "role": {"statuses": mock_case_statuses["statuses"]},
-            "team": {"id": MOD_ECJU},
-        }
-    }
-    url = client._build_absolute_uri("/gov-users/")
-    requests_mock.get(url=f"{url}me/", json=data)
-    requests_mock.get(url=re.compile(f"{url}{gov_uk_user_id}/"), json=data)
-
-    statuses = get_permissible_statuses(mock_request, Case(data_standard_case["case"]))
-    assert len(statuses) == 6
-    status_keys = [status_dict["key"] for status_dict in statuses]
-    assert set(status_keys) == {
-        CaseStatusEnum.SUBMITTED,
-        CaseStatusEnum.OGD_ADVICE,
-        CaseStatusEnum.UNDER_FINAL_REVIEW,
-        CaseStatusEnum.WITHDRAWN,
-        CaseStatusEnum.FINALISED,
         CaseStatusEnum.REOPENED_FOR_CHANGES,
     }


### PR DESCRIPTION
### Aim

After a better understanding of how the manual override for SIELs is used it seemed better to omit this option from f680s rather than supporting it from the outset.

[LTD-6199](https://uktrade.atlassian.net/browse/LTD-6199)


[LTD-6199]: https://uktrade.atlassian.net/browse/LTD-6199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ