### PR TITLE
LTD-6181: Retrieve F680 specific provisos when making recommendation

### DIFF
--- a/caseworker/f680/document/tests/test_document_views.py
+++ b/caseworker/f680/document/tests/test_document_views.py
@@ -15,7 +15,7 @@ def setup(
     mock_case,
     settings,
     mock_f680_case_with_assigned_user,
-    mock_proviso,
+    mock_f680_proviso,
     mock_denial_reasons,
     mock_get_case_recommendations,
 ):

--- a/caseworker/f680/outcome/tests/test_views.py
+++ b/caseworker/f680/outcome/tests/test_views.py
@@ -23,7 +23,7 @@ def setup(
     mock_approval_reason,
     mock_denial_reasons,
     mock_footnote_details,
-    mock_proviso,
+    mock_f680_proviso,
     mock_get_case_recommendations,
     settings,
 ):

--- a/caseworker/f680/recommendation/tests/test_views.py
+++ b/caseworker/f680/recommendation/tests/test_views.py
@@ -31,7 +31,7 @@ def setup(
     mock_approval_reason,
     mock_denial_reasons,
     mock_footnote_details,
-    mock_proviso,
+    mock_f680_proviso,
     mock_get_case_recommendations,
     settings,
 ):
@@ -304,7 +304,7 @@ class TestF680MakeRecommendationView:
         f680_case_id,
         data_submitted_f680_case,
         mock_f680_case,
-        mock_no_provisos,
+        mock_no_f680_provisos,
         mock_post_recommendation,
         post_to_step,
         view_recommendation_url,

--- a/caseworker/f680/tests/test_views.py
+++ b/caseworker/f680/tests/test_views.py
@@ -22,7 +22,7 @@ def setup(
     mock_case,
     mock_approval_reason,
     mock_denial_reasons,
-    mock_proviso,
+    mock_f680_proviso,
     mock_footnote_details,
     mock_get_case_recommendations,
     settings,

--- a/caseworker/f680/views.py
+++ b/caseworker/f680/views.py
@@ -57,7 +57,7 @@ class F680CaseworkerMixin(UserPassesTestMixin, CaseworkerMixin):
         for rr in self.case["data"]["security_release_requests"]:
             self.security_release_requests[rr["id"]] = rr
 
-        self.conditions = get_picklists_list(request, type="proviso", disable_pagination=True, show_deactivated=False)
+        self.conditions = get_picklists_list(request, type="f680_proviso", disable_pagination=True, show_deactivated=False)
         self.refusal_reasons = get_denial_reasons(request)
         self.denial_reasons_choices = group_denial_reasons(self.refusal_reasons)
         self.pending_recommendations = get_pending_recommendation_requests(self.request, self.case, self.caseworker)

--- a/caseworker/f680/views.py
+++ b/caseworker/f680/views.py
@@ -57,7 +57,9 @@ class F680CaseworkerMixin(UserPassesTestMixin, CaseworkerMixin):
         for rr in self.case["data"]["security_release_requests"]:
             self.security_release_requests[rr["id"]] = rr
 
-        self.conditions = get_picklists_list(request, type="f680_proviso", disable_pagination=True, show_deactivated=False)
+        self.conditions = get_picklists_list(
+            request, type="f680_proviso", disable_pagination=True, show_deactivated=False
+        )
         self.refusal_reasons = get_denial_reasons(request)
         self.denial_reasons_choices = group_denial_reasons(self.refusal_reasons)
         self.pending_recommendations = get_pending_recommendation_requests(self.request, self.case, self.caseworker)

--- a/caseworker/picklists/enums.py
+++ b/caseworker/picklists/enums.py
@@ -15,6 +15,7 @@ class PicklistCategories:
     report_summary = Picklist(PicklistCategory.REPORT_SUMMARIES, "report_summary")
     standard_advice = Picklist(PicklistCategory.STANDARD_ADVICE, "standard_advice")
     footnotes = Picklist(PicklistCategory.FOOTNOTES, "footnotes")
+    f680_proviso = Picklist(PicklistCategory.F680_PROVISO, "f680_proviso")
 
     @classmethod
     def all(cls):
@@ -27,4 +28,5 @@ class PicklistCategories:
             cls.report_summary,
             cls.standard_advice,
             cls.footnotes,
+            cls.f680_proviso,
         ]

--- a/lite_content/lite_internal_frontend/picklists.py
+++ b/lite_content/lite_internal_frontend/picklists.py
@@ -21,6 +21,7 @@ class NewPicklistForm:
     FOOTNOTES = "Create a reporting footnote"
     LETTER_PARAGRAPH = "Create a letter paragraph"
     PROVISO = "Create a licence condition"
+    F680_PROVISO = "Create a F680 proviso"
     REPORT_SUMMARY = "Create a report summary"
     STANDARD_ADVICE = "Create an approval reason"
     BACK_LINK = "Back to templates"
@@ -67,3 +68,4 @@ class PicklistCategory:
     REPORT_SUMMARIES = "Report summaries"
     STANDARD_ADVICE = "Standard Advice"
     FOOTNOTES = "Reporting footnotes"
+    F680_PROVISO = "F680 provisos"

--- a/unit_tests/caseworker/cases/views/test_case_assignments.py
+++ b/unit_tests/caseworker/cases/views/test_case_assignments.py
@@ -96,7 +96,7 @@ def test_f680_case_assignments_POST_remove_user_success(
     mock_f680_case,
     data_f680_assignment,
     mock_f680_case_with_assignments,
-    mock_proviso,
+    mock_f680_proviso,
     mock_denial_reasons,
     mock_remove_f680_assignment,
     mock_queue,
@@ -337,7 +337,7 @@ def test_case_assign_me(
     mock_standard_case_activity_filters,
     mock_queue,
     mock_standard_case_assigned_queues,
-    mock_proviso,
+    mock_f680_proviso,
 ):
     case = data_standard_case
     url = reverse("queues:case_assignment_assign_to_me", kwargs={"pk": data_queue["id"]})
@@ -372,7 +372,7 @@ def test_f680_case_assign_me(
     mock_add_assignment,
     mock_f680_case,
     mock_queue,
-    mock_proviso,
+    mock_f680_proviso,
     mock_denial_reasons,
     settings,
 ):

--- a/unit_tests/caseworker/conftest.py
+++ b/unit_tests/caseworker/conftest.py
@@ -1006,6 +1006,29 @@ def mock_no_provisos(requests_mock):
 
 
 @pytest.fixture
+def mock_f680_proviso(requests_mock):
+    url = client._build_absolute_uri(
+        "/picklist/?type=f680_proviso&page=1&disable_pagination=True&show_deactivated=False"
+    )
+    data = {
+        "results": [
+            {"name": "firearm serial numbers", "text": "Firearm serial numbers text"},
+            {"name": "no release", "text": "No release of capability details"},
+            {"name": "no specifications", "text": "No release of specifications"},
+        ]
+    }
+    return requests_mock.get(url=url, json=data)
+
+
+@pytest.fixture
+def mock_no_f680_provisos(requests_mock):
+    url = client._build_absolute_uri(
+        "/picklist/?type=f680_proviso&page=1&disable_pagination=True&show_deactivated=False"
+    )
+    return requests_mock.get(url=url, json={"results": []})
+
+
+@pytest.fixture
 def mock_footnote_details(requests_mock):
     url = client._build_absolute_uri("/picklist/?type=footnotes&page=1&disable_pagination=True&show_deactivated=False")
     data = {


### PR DESCRIPTION
## Change description

Users first need to create them to be able to select from the forms. If they don't create they will see a text box to enter the conditions manually.

Relevant API PR is https://github.com/uktrade/lite-api/pull/2560

[LTD-6181](https://uktrade.atlassian.net/browse/LTD-6181)


[LTD-6181]: https://uktrade.atlassian.net/browse/LTD-6181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ